### PR TITLE
Make the bitrate slider text show MB/s aswell as Mbit/s.

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -683,7 +683,7 @@ Flickable {
                     width: Math.min(bitrateDesc.implicitWidth, parent.width)
 
                     onValueChanged: {
-                        bitrateTitle.text = qsTr("Video bitrate: %1 Mbps").arg(value / 1000.0)
+                        bitrateTitle.text = qsTr("Video bitrate: %1 Mbps (%2 MB/s)").arg(value / 1000.0).arg((value / 1000.0)*0.125)
                         StreamingPreferences.bitrateKbps = value
                     }
 


### PR DESCRIPTION
I'm sure this would help some people. My bad if my code is wrong; I have never used or wrote in QML before, and am just going off [what the Qt docs say](https://doc.qt.io/qt-5/qtquick-internationalization.html#4-use-op-op-x-to-insert-parameters-into-a-string).
Should I change Mbps to MBit/s too or no?