### PR TITLE
allow adding QMAKE FLAGS from env for subdir projects

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -1,3 +1,7 @@
+QMAKE_CFLAGS   *= $$(QMAKE_CFLAGS)
+QMAKE_CXXFLAGS *= $$(QMAKE_CXXFLAGS)
+QMAKE_LFLAGS   *= $$(QMAKE_LFLAGS)
+
 QT += core quick network quickcontrols2 svg
 CONFIG += c++11
 

--- a/h264bitstream/h264bitstream.pro
+++ b/h264bitstream/h264bitstream.pro
@@ -4,6 +4,9 @@
 #
 #-------------------------------------------------
 
+QMAKE_CFLAGS   *= $$(QMAKE_CFLAGS)
+QMAKE_CXXFLAGS *= $$(QMAKE_CXXFLAGS)
+QMAKE_LFLAGS   *= $$(QMAKE_LFLAGS)
 
 QT       -= core gui
 

--- a/moonlight-common-c/moonlight-common-c.pro
+++ b/moonlight-common-c/moonlight-common-c.pro
@@ -4,6 +4,10 @@
 #
 #-------------------------------------------------
 
+QMAKE_CFLAGS   *= $$(QMAKE_CFLAGS)
+QMAKE_CXXFLAGS *= $$(QMAKE_CXXFLAGS)
+QMAKE_LFLAGS   *= $$(QMAKE_LFLAGS)
+
 QT -= core gui
 
 TARGET = moonlight-common-c

--- a/qmdnsengine/qmdnsengine.pro
+++ b/qmdnsengine/qmdnsengine.pro
@@ -1,3 +1,7 @@
+QMAKE_CFLAGS   *= $$(QMAKE_CFLAGS)
+QMAKE_CXXFLAGS *= $$(QMAKE_CXXFLAGS)
+QMAKE_LFLAGS   *= $$(QMAKE_LFLAGS)
+
 QT -= gui
 QT += network
 


### PR DESCRIPTION
I'm doing packaging for debian these days, and I find there are missing flags when compiling:
https://salsa.debian.org/amazingfate/moonlight-qt/-/jobs/7624590

I'm using qmake6 as buildsystem supported by debhelper. There are very few qt6 projects that is using qmake6, but there is a package doesn't have this issue: https://codeberg.org/ltworf/explosive-c4/src/branch/master/debian/rules.

Now I find that it is sub dir not supporting QMAKE FLAGS passed from parent project.

debhelper is using the following qmake command:
```
qmake6 -makefile "QMAKE_CFLAGS_RELEASE=-g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=$PWD=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2" "QMAKE_CFLAGS_DEBUG=-g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=$PWD=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2" "QMAKE_CXXFLAGS_RELEASE=-g -O2 -ffile-prefix-map=$PWD=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2" "QMAKE_CXXFLAGS_DEBUG=-g -O2 -ffile-prefix-map=$PWD=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2" "QMAKE_LFLAGS_RELEASE=-Wl,-z,relro -Wl,-z,now" "QMAKE_LFLAGS_DEBUG=-Wl,-z,relro -Wl,-z,now" QMAKE_STRIP=: PREFIX=/usr
```

But at subdir qmake is not setting flags like QMAKE_CFLAGS_RELEASE with debian's default hardening flags like `fstack-protector-strong`. So I allow accepting QMAKE FLAGS from env so that all subdir projects can receive the flags set by debhelper.