### PR TITLE
Fix: Improve stream window resizing logic for pixel-perfect display

### DIFF
--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1347,26 +1347,23 @@ void Session::getWindowDimensions(int& x, int& y,
 
     SDL_Rect usableBounds;
     if (SDL_GetDisplayUsableBounds(displayIndex, &usableBounds) == 0) {
-        // Don't use more than 80% of the display to leave room for system UI
-        // and ensure the target size is not odd (otherwise one of the sides
-        // of the image will have a one-pixel black bar next to it).
-        SDL_Rect src, dst;
-        src.x = src.y = dst.x = dst.y = 0;
-        src.w = m_StreamConfig.width;
-        src.h = m_StreamConfig.height;
-        dst.w = ((int)SDL_ceilf(usableBounds.w * 0.80f) & ~0x1);
-        dst.h = ((int)SDL_ceilf(usableBounds.h * 0.80f) & ~0x1);
-
-        // Scale the window size while preserving aspect ratio
-        StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
-
-        // If the stream window can fit within the usable drawing area with 1:1
-        // scaling, do that rather than filling the screen.
-        if (m_StreamConfig.width < dst.w && m_StreamConfig.height < dst.h) {
+        // If the stream resolution fits within the usable display area, use it directly
+        if (m_StreamConfig.width <= usableBounds.w &&
+            m_StreamConfig.height <= usableBounds.h) {
             width = m_StreamConfig.width;
             height = m_StreamConfig.height;
-        }
-        else {
+        } else {
+            // Otherwise, use 80% of usable bounds and preserve aspect ratio
+            SDL_Rect src, dst;
+            src.x = src.y = dst.x = dst.y = 0;
+            src.w = m_StreamConfig.width;
+            src.h = m_StreamConfig.height;
+
+            dst.w = ((int)(usableBounds.w * 0.80f)) & ~0x1;  // even width
+            dst.h = ((int)(usableBounds.h * 0.80f)) & ~0x1;  // even height
+
+            StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
+
             width = dst.w;
             height = dst.h;
         }


### PR DESCRIPTION
This pull request resolves an issue where the stream window was unnecessarily downscaled to 80% of the display size, even when it could fit at a 1:1 pixel ratio. This caused blurry visuals and a loss of quality.

**Changes:**

The resizing logic in app/streaming/session.cpp has been updated. The new logic checks if the stream resolution fits within the usable display area.

If it fits, the window is displayed at its native resolution (1:1).
If it doesn't fit, it falls back to scaling the window to 80% of the usable display area while preserving the aspect ratio.

**Benefits**:

Achieves pixel-perfect rendering when possible.
Avoids unnecessary scaling and image degradation.
Improves the overall visual quality of the stream.