### PR TITLE
Reduce idle CPU by pausing hidden spinners

### DIFF
--- a/app/gui/CliPair.qml
+++ b/app/gui/CliPair.qml
@@ -53,6 +53,7 @@ Item {
 
         BusyIndicator {
             id: stageSpinner
+            running: visible
         }
 
         Label {

--- a/app/gui/CliQuitStreamSegue.qml
+++ b/app/gui/CliQuitStreamSegue.qml
@@ -34,6 +34,7 @@ Item {
 
         BusyIndicator {
             id: stageSpinner
+            running: visible
         }
 
         Label {

--- a/app/gui/CliStartStreamSegue.qml
+++ b/app/gui/CliStartStreamSegue.qml
@@ -52,6 +52,7 @@ Item {
 
         BusyIndicator {
             id: stageSpinner
+            running: visible
         }
 
         Label {

--- a/app/gui/NavigableMessageDialog.qml
+++ b/app/gui/NavigableMessageDialog.qml
@@ -24,6 +24,7 @@ NavigableDialog {
         BusyIndicator {
             id: dialogSpinner
             visible: false
+            running: visible
         }
 
         Image {

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -90,6 +90,7 @@ CenteredGridView {
         BusyIndicator {
             id: searchSpinner
             visible: StreamingPreferences.enableMdns
+            running: visible
         }
 
         Label {
@@ -143,6 +144,7 @@ CenteredGridView {
             width: 75
             height: 75
             visible: model.statusUnknown
+            running: visible
         }
 
         Label {

--- a/app/gui/QuitSegue.qml
+++ b/app/gui/QuitSegue.qml
@@ -60,6 +60,7 @@ Item {
 
         BusyIndicator {
             id: stageSpinner
+            running: visible
         }
 
         Label {


### PR DESCRIPTION
  ## Summary
  - bind each BusyIndicator’s `running` property to `visible`
  - stop hidden spinners from scheduling frames when the UI is idle
  - avoids the steady render-loop churn that kept the process around 15% CPU

  ## Testing
  - launched `app/moonlight` after the change and observed idle CPU drop from ~15% to effectively 0%

