### PR TITLE
Enable Game Mode on Apple Platforms

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -48,5 +48,7 @@
 	<string>VERSION</string>
 	<key>CFBundleDisplayName</key>
 	<string>Moonlight</string>
+    <key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds three keys to the `info.plist` that add support for [Game Mode](https://support.apple.com/en-us/105118) on Apple Platforms.

Game mode gives moonlight priority access to the CPU and GPU, and reduces background tasks. It also doubles the Bluetooth sampling rate, which reduces latency for Game Controllers. In macOS 26, iPadOS 26, and iOS 26, there is also a new game mode overlay that gives access to common settings without leaving Moonlight.

Resources:
- [How to Enable Game Mode](https://developer.apple.com/forums/thread/782343)
- [Use Game Mode on Mac](https://support.apple.com/en-us/105118)