### PR TITLE
ci: refactor workflows to use reusable workflow calls

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,17 +1,24 @@
-name: Build Linux AppImage
+---
+name: Build - Linux AppImage
+permissions:
+  contents: read
 
 on:
-  push:
-  pull_request:
-    branches: [ "master" ]
+  workflow_call:
+    inputs:
+      ci_version:
+        required: true
+        type: string
 
 jobs:
   build:
+    env:
+      CI_VERSION: ${{ inputs.ci_version }}
     runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 1
@@ -28,16 +35,11 @@ jobs:
             wayland-protocols libopus-dev libvdpau-dev libgl-dev libpipewire-0.3-dev vulkan-sdk
           sudo pip3 install meson
           mkdir -p dep_root/{bin,include,lib}
-          echo "DEP_ROOT=$PWD/dep_root" >> $GITHUB_ENV
-          echo "$PWD/dep_root/bin" >> $GITHUB_PATH
-
-      - name: Set CI version
-        run: |
-          CI_VERSION=`echo $GITHUB_SHA | cut -c1-6`
-          echo "CI_VERSION=$CI_VERSION" >> $GITHUB_ENV
+          echo "DEP_ROOT=$PWD/dep_root" >> "${GITHUB_ENV}"
+          echo "$PWD/dep_root/bin" >> "${GITHUB_PATH}"
 
       - name: Checkout SDL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: libsdl-org/SDL
           ref: 235e4870af091ea7e3814ee2dbdb8e2ec627aaf0
@@ -52,7 +54,7 @@ jobs:
           sudo make install
 
       - name: Checkout SDL_ttf
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: libsdl-org/SDL_ttf
           ref: release-2.22.0
@@ -68,7 +70,7 @@ jobs:
           sudo make install
 
       - name: Checkout libva
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: intel/libva
           ref: 2.22.0
@@ -83,7 +85,7 @@ jobs:
           sudo make install
 
       - name: Checkout libplacebo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: haasn/libplacebo
           ref: 63a3d64ac32eaaa56aa60b5000d43c02544c6508
@@ -111,7 +113,7 @@ jobs:
           popd
 
       - name: Checkout FFmpeg
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: FFmpeg/FFmpeg
           ref: dd00a614e16a15db0b230dfe45790e913e593695
@@ -141,7 +143,7 @@ jobs:
           scripts/build-appimage.sh
 
       - name: Upload Binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Moonlight-LinuxAppImage-${{ env.CI_VERSION }}
           path: build/installer-release/Moonlight-${{ env.CI_VERSION }}-x86_64.AppImage

--- a/.github/workflows/build-steamlink.yml
+++ b/.github/workflows/build-steamlink.yml
@@ -1,38 +1,40 @@
-name: Build Steam Link
+---
+name: Build - Steam Link
+permissions:
+  contents: read
 
 on:
-  push:
-  pull_request:
-    branches: [ "master" ]
+  workflow_call:
+    inputs:
+      ci_version:
+        required: true
+        type: string
 
 jobs:
   build:
+    env:
+      CI_VERSION: ${{ inputs.ci_version }}
     runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 1
 
       - name: Checkout Steam Link SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ValveSoftware/steamlink-sdk
           path: steamlink-sdk
           fetch-depth: 1
 
-      - name: Set CI version
-        run: |
-          CI_VERSION=`echo $GITHUB_SHA | cut -c1-6`
-          echo "CI_VERSION=$CI_VERSION" >> $GITHUB_ENV
-
       - name: Build binaries
         run: STEAMLINK_SDK_PATH=$PWD/steamlink-sdk scripts/build-steamlink-app.sh
 
       - name: Upload Binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Moonlight-SteamLink-${{ env.CI_VERSION }}
           path: build/deploy-release/*

--- a/.github/workflows/build-win-mac.yml
+++ b/.github/workflows/build-win-mac.yml
@@ -1,12 +1,19 @@
-name: Build Windows and macOS
+---
+name: Build - Windows and macOS
+permissions:
+  contents: read
 
 on:
-  push:
-  pull_request:
-    branches: [ "master" ]
+  workflow_call:
+    inputs:
+      ci_version:
+        required: true
+        type: string
 
 jobs:
   build:
+    env:
+      CI_VERSION: ${{ inputs.ci_version }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,16 +29,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           fetch-depth: 1
-
-      - name: Set CI version
-        shell: bash
-        run: |
-          CI_VERSION=`echo $GITHUB_SHA | cut -c1-6`
-          echo "CI_VERSION=$CI_VERSION" >> $GITHUB_ENV
 
       - name: Install create-dmg (macOS)
         if: runner.os == 'macOS'
@@ -85,7 +86,7 @@ jobs:
           }
 
       - name: Upload Binaries (Windows x64)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: runner.os == 'Windows'
         with:
           name: Moonlight-${{ runner.os }}-x64-${{ env.CI_VERSION }}
@@ -93,7 +94,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Binaries (Windows arm64)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: runner.os == 'Windows'
         with:
           name: Moonlight-${{ runner.os }}-arm64-${{ env.CI_VERSION }}
@@ -101,7 +102,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Binaries (macOS)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: runner.os == 'macOS'
         with:
           name: Moonlight-${{ runner.os }}-${{ env.CI_VERSION }}
@@ -110,7 +111,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: zDevDbgSyms-${{ runner.os }}-${{ env.CI_VERSION }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+---
+name: Build
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      ci_version: ${{ steps.set-ci-version.outputs.ci_version }}
+    steps:
+      - name: Set CI version
+        id: set-ci-version
+        shell: bash
+        run: |
+          CI_VERSION=`echo ${GITHUB_SHA} | cut -c1-6`
+          echo "ci_version=${CI_VERSION}" >> "${GITHUB_OUTPUT}"
+
+  build-appimage:
+    needs: setup
+    uses: ./.github/workflows/build-appimage.yml
+    with:
+      ci_version: ${{ needs.setup.outputs.ci_version }}
+
+  build-steamlink:
+    needs: setup
+    uses: ./.github/workflows/build-steamlink.yml
+    with:
+      ci_version: ${{ needs.setup.outputs.ci_version }}
+
+  build-windows-macos:
+    needs: setup
+    uses: ./.github/workflows/build-win-mac.yml
+    with:
+      ci_version: ${{ needs.setup.outputs.ci_version }}

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ Moonlight also has mobile versions for [Android](https://github.com/moonlight-st
 
 You can follow development on our [Discord server](https://moonlight-stream.org/discord) and help translate Moonlight into your language on [Weblate](https://hosted.weblate.org/projects/moonlight/moonlight-qt/).
 
- [![Windows and macOS CI Builds](https://github.com/moonlight-stream/moonlight-qt/actions/workflows/build-win-mac.yml/badge.svg?branch=master)](https://github.com/moonlight-stream/moonlight-qt/actions/workflows/build-win-mac.yml?query=branch%3Amaster)
- [![Linux AppImage CI Builds](https://github.com/moonlight-stream/moonlight-qt/actions/workflows/build-appimage.yml/badge.svg?branch=master)](https://github.com/moonlight-stream/moonlight-qt/actions/workflows/build-appimage.yml?query=branch%3Amaster)
- [![Steam Link CI Builds](https://github.com/moonlight-stream/moonlight-qt/actions/workflows/build-steamlink.yml/badge.svg?branch=master)](https://github.com/moonlight-stream/moonlight-qt/actions/workflows/build-steamlink.yml?query=branch%3Amaster)
-
+ [![Build](https://img.shields.io/github/actions/workflow/status/moonlight-stream/moonlight-qt/build.yml?branch=master)](https://github.com/moonlight-stream/moonlight-qt/actions/workflows/build.yml?query=branch%3Amaster)
  [![Downloads](https://img.shields.io/github/downloads/moonlight-stream/moonlight-qt/total)](https://github.com/moonlight-stream/moonlight-qt/releases)
  [![Translation Status](https://hosted.weblate.org/widgets/moonlight/-/moonlight-qt/svg-badge.svg)](https://hosted.weblate.org/projects/moonlight/moonlight-qt/)
 
@@ -33,6 +30,9 @@ You can follow development on our [Discord server](https://moonlight-stream.org/
 - [Generic ARM 32-bit and 64-bit Debian packages](https://github.com/moonlight-stream/moonlight-docs/wiki/Installing-Moonlight-Qt-on-ARM%E2%80%90based-Single-Board-Computers) (not for Raspberry Pi)
 - [Experimental RISC-V Debian packages](https://github.com/moonlight-stream/moonlight-docs/wiki/Installing-Moonlight-Qt-on-RISC%E2%80%90V-Single-Board-Computers)
 - [NVIDIA Jetson and Nintendo Switch (Ubuntu L4T)](https://github.com/moonlight-stream/moonlight-docs/wiki/Installing-Moonlight-Qt-on-Linux4Tegra-(L4T)-Ubuntu)
+
+### Nightly Builds
+- [Downloads](https://nightly.link/moonlight-stream/moonlight-qt/workflows/build/master)
 
 #### Special Thanks
 


### PR DESCRIPTION
Added a new build.yml workflow to orchestrate builds for AppImage, Steam Link, and Windows/macOS using reusable workflows. This will make it easier for users to navigate builds and obtain artifacts from a single link.

Additionally:

- Updated build workflows to use workflow_call triggers and accept ci_version as input, removing the repeated inline CI version generation from each workflow.
- Upgraded all checkout and upload artifact actions to v5 (latest).
- Updated readme to use single badge for new single `build` workflow and updated style to match existing badges.
- Updated readme to include nightly download links which do not require user authentication.

Each job will display like so:
<img width="525" height="535" alt="image" src="https://github.com/user-attachments/assets/e6a39319-db64-4ec7-a9a3-c74d700b1938" />

Let me know if you'd like to use different names for each job.