### PR TITLE
Select correct color matrix for 10-bit SDR

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -709,7 +709,7 @@ void D3D11VARenderer::bindColorConversion(AVFrame* frame)
     bool fullRange = isFrameFullRange(frame);
     int colorspace = getFrameColorspace(frame);
     bool yuv444 = (m_DecoderParams.videoFormat & VIDEO_FORMAT_MASK_YUV444);
-    int bits = (colorspace == COLORSPACE_REC_2020) ? 10 : 8;
+    int bits = (m_DecoderParams.videoFormat & VIDEO_FORMAT_MASK_10BIT) ? 10 : 8;
 
     if (yuv444) {
         // We'll need to use one of the 4:4:4 shaders for this pixel format

--- a/app/streaming/video/ffmpeg-renderers/vt_metal.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_metal.mm
@@ -264,7 +264,7 @@ public:
         if (colorspace != m_LastColorSpace || fullRange != m_LastFullRange || m_HdrMetadataChanged) {
             CGColorSpaceRef newColorSpace;
             ParamBuffer paramBuffer;
-            int bits = (colorspace == COLORSPACE_REC_2020) ? 10 : 8;
+            int bits = (m_VideoFormat & VIDEO_FORMAT_MASK_10BIT) ? 10 : 8;
 
             // Stop the display link before changing the Metal layer
             stopDisplayLink();


### PR DESCRIPTION
The special case of 10-bit SDR wasn't handled correctly in 50223dbdb89a95139201d6fdf8b7efb88a35c3cd.