### PR TITLE
metadata: Tidy up

### DIFF
--- a/app/deploy/linux/com.moonlight_stream.Moonlight.appdata.xml
+++ b/app/deploy/linux/com.moonlight_stream.Moonlight.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
 	<id>com.moonlight_stream.Moonlight</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0+</project_license>
@@ -23,6 +23,14 @@
 	<url type="homepage">https://moonlight-stream.org</url>
 	<url type="bugtracker">https://github.com/moonlight-stream/moonlight-qt/issues</url>
 	<url type="help">https://github.com/moonlight-stream/moonlight-docs/wiki/Setup-Guide</url>
+	<url type="vcs-browser">https://github.com/moonlight-stream/moonlight-qt</url>
+	<developer_name>Moonlight Game Streaming Team</developer_name>
+	<update_contact>cameron@moonlight-stream.org</update_contact>
+	<launchable type="desktop-id">com.moonlight_stream.Moonlight.desktop</launchable>
+	<provides>
+		<binary>moonlight</binary>
+	</provides>
+	<content_rating type="oars-1.1" />	
 
 	<screenshots>
 		<screenshot type="default">
@@ -816,19 +824,4 @@
 		</release>
 	</releases>
 
-	<categories>
-		<category>Game</category>
-		<category>Qt</category>
-	</categories>
-
-	<developer_name>Moonlight Game Streaming Team</developer_name>
-	<update_contact>cameron@moonlight-stream.org</update_contact>
-
-	<launchable type="desktop-id">com.moonlight_stream.Moonlight.desktop</launchable>
-
-	<provides>
-		<binary>moonlight</binary>
-	</provides>
-
-	<content_rating type="oars-1.0" />
 </component>


### PR DESCRIPTION
- Use desktop-application as the component type
- Drop categories that are already provided by the desktop file
- Group important information together
- Add vcs-browser URL to point to the source code repository

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines