### PR TITLE
fix(ffmpeg): try more times when receive EAGAIN during init

### DIFF
--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -689,23 +689,33 @@ bool FFmpegVideoDecoder::completeInitialization(const AVCodec* decoder, enum AVP
             return false;
         }
 
-        err = avcodec_receive_frame(m_VideoDecoderCtx, frame);
-        if (err == 0) {
-            // Allow the renderer to do any validation it wants on this frame
-            if (!m_FrontendRenderer->testRenderFrame(frame)) {
+        // Some decoders require some time to output the first frame, so we'll
+        // retry a few times if we get an EAGAIN error.
+        for (int retries = 0; retries < 5; retries++) {
+            err = avcodec_receive_frame(m_VideoDecoderCtx, frame);
+            if (err == 0) {
+                // Allow the renderer to do any validation it wants on this frame
+                if (!m_FrontendRenderer->testRenderFrame(frame)) {
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                "Test decode failed (testRenderFrame)");
+                    av_frame_free(&frame);
+                    return false;
+                }
+                break;
+            }
+            else if (err == AVERROR(EAGAIN)) {
+                // Wait a little while to let the hardware work
+                SDL_Delay(100);
+                continue;
+            }
+            else if (err < 0) {
+                char errorstring[512];
+                av_strerror(err, errorstring, sizeof(errorstring));
                 SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                            "Test decode failed (testRenderFrame)");
+                            "Test decode failed (avcodec_receive_frame): %s", errorstring);
                 av_frame_free(&frame);
                 return false;
             }
-        }
-        else if (err < 0) {
-            char errorstring[512];
-            av_strerror(err, errorstring, sizeof(errorstring));
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Test decode failed (avcodec_receive_frame): %s", errorstring);
-            av_frame_free(&frame);
-            return false;
         }
 
         av_frame_free(&frame);


### PR DESCRIPTION
Some decoders require some time to produce the first decoded frame. However, commit [66a30c6](https://github.com/moonlight-stream/moonlight-qt/commit/66a30c66f3f2534f551f3b2e0f4c91c6751ab67a#diff-b079c7f05ea0ed57f958aff5a148e3d7f7959f7bff4243949adfcca74d3f50cfL674-L700) removed the retry mechanism when `avcodec_receive_frame` returns `EAGAIN` during the `FFmpegVideoDecoder` initialization stage.

This PR reintroduces the retry mechanism to avoid missing potential hardware acceleration opportunities.

I reused the retry count and delay duration that were used before that commit. I'm not sure whether the delay might be too long.

I observed this issue on the Spacemit K1 using the PowerVR driver.