### PR TITLE
audio: make SDL queue threshold configurable

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -906,6 +906,36 @@ Flickable {
                     }
                 }
 
+                Label {
+                    width: parent.width
+                    text: qsTr("Maximum queued audio in Moonlight's buffer (ms)")
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                }
+
+                TextField {
+                    id: audioQueueThresholdField
+                    width: Math.min(parent.width, 120)
+                    text: StreamingPreferences.audioQueueThresholdMs.toString()
+                    maximumLength: 4
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    validator: IntValidator { bottom: 1; top: 1000 }
+
+                    onEditingFinished: {
+                        if (acceptableInput) {
+                            StreamingPreferences.audioQueueThresholdMs = parseInt(text)
+                            text = StreamingPreferences.audioQueueThresholdMs.toString()
+                        }
+                        else {
+                            text = StreamingPreferences.audioQueueThresholdMs.toString()
+                        }
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Default: 30 ms. Increase this if you want Moonlight to tolerate more queued audio before dropping new samples.")
+                }
 
                 CheckBox {
                     id: audioPcCheck

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -42,6 +42,24 @@ Flickable {
         duration: 100
     }
 
+    function commitAudioThresholdSettings() {
+        if (audioPlaybackThresholdField.acceptableInput) {
+            StreamingPreferences.audioPlaybackThresholdMs = parseInt(audioPlaybackThresholdField.text)
+            audioPlaybackThresholdField.text = StreamingPreferences.audioPlaybackThresholdMs.toString()
+        }
+        else {
+            audioPlaybackThresholdField.text = StreamingPreferences.audioPlaybackThresholdMs.toString()
+        }
+
+        if (audioDropThresholdField.acceptableInput) {
+            StreamingPreferences.audioDropThresholdMs = parseInt(audioDropThresholdField.text)
+            audioDropThresholdField.text = StreamingPreferences.audioDropThresholdMs.toString()
+        }
+        else {
+            audioDropThresholdField.text = StreamingPreferences.audioDropThresholdMs.toString()
+        }
+    }
+
     Window.onActiveFocusItemChanged: {
         var item = Window.activeFocusItem
         if (item) {
@@ -84,12 +102,14 @@ Flickable {
         SdlGamepadKeyNavigation.setUiNavMode(false)
 
         // Save the prefs so the Session can observe the changes
+        commitAudioThresholdSettings()
         StreamingPreferences.save()
     }
 
     Component.onDestruction: {
         // Also save preferences on destruction, since we won't get a
         // deactivating callback if the user just closes Moonlight
+        commitAudioThresholdSettings()
         StreamingPreferences.save()
     }
 
@@ -908,33 +928,52 @@ Flickable {
 
                 Label {
                     width: parent.width
-                    text: qsTr("Maximum queued audio in Moonlight's buffer (ms)")
+                    text: qsTr("SDL audio: queued audio before playback starts or resumes (ms)")
                     font.pointSize: 12
                     wrapMode: Text.Wrap
                 }
 
                 TextField {
-                    id: audioQueueThresholdField
+                    id: audioPlaybackThresholdField
                     width: Math.min(parent.width, 120)
-                    text: StreamingPreferences.audioQueueThresholdMs.toString()
+                    text: StreamingPreferences.audioPlaybackThresholdMs.toString()
                     maximumLength: 4
                     inputMethodHints: Qt.ImhDigitsOnly
-                    validator: IntValidator { bottom: 1; top: 1000 }
+                    validator: IntValidator { bottom: 0; top: 1000 }
 
                     onEditingFinished: {
-                        if (acceptableInput) {
-                            StreamingPreferences.audioQueueThresholdMs = parseInt(text)
-                            text = StreamingPreferences.audioQueueThresholdMs.toString()
-                        }
-                        else {
-                            text = StreamingPreferences.audioQueueThresholdMs.toString()
-                        }
+                        commitAudioThresholdSettings()
                     }
 
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Default: 30 ms. Increase this if you want Moonlight to tolerate more queued audio before dropping new samples.")
+                    ToolTip.text: qsTr("SDL audio only. Default: 0 ms. Set this above 0 if you want Moonlight to wait for buffered SDL audio before starting playback or resuming after an underrun.")
+                }
+
+                Label {
+                    width: parent.width
+                    text: qsTr("SDL audio: maximum queued audio in Moonlight's buffer (ms)")
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                }
+
+                TextField {
+                    id: audioDropThresholdField
+                    width: Math.min(parent.width, 120)
+                    text: StreamingPreferences.audioDropThresholdMs.toString()
+                    maximumLength: 4
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    validator: IntValidator { bottom: 1; top: 1000 }
+
+                    onEditingFinished: {
+                        commitAudioThresholdSettings()
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("SDL audio only. Default: 30 ms. Increase this if you want Moonlight to tolerate more queued audio before dropping new samples.")
                 }
 
                 CheckBox {

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -50,9 +50,21 @@
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
+#define SER_AUDIOQUEUETHRESHOLDMS "audioqueuethresholdms"
 #define SER_LANGUAGE "language"
 
 #define CURRENT_DEFAULT_VER 2
+
+namespace {
+constexpr int kDefaultAudioQueueThresholdMs = 30;
+constexpr int kMinimumAudioQueueThresholdMs = 1;
+constexpr int kMaximumAudioQueueThresholdMs = 1000;
+
+int clampAudioQueueThreshold(int value)
+{
+    return qBound(kMinimumAudioQueueThresholdMs, value, kMaximumAudioQueueThresholdMs);
+}
+}
 
 static StreamingPreferences* s_GlobalPrefs;
 
@@ -150,6 +162,8 @@ void StreamingPreferences::reload()
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
+    audioQueueThresholdMs = clampAudioQueueThreshold(settings.value(SER_AUDIOQUEUETHRESHOLDMS,
+                                                                    kDefaultAudioQueueThresholdMs).toInt());
     enableHdr = settings.value(SER_HDR, false).toBool();
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
                                                          static_cast<int>(CaptureSysKeysMode::CSK_OFF)).toInt());
@@ -358,6 +372,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+    settings.setValue(SER_AUDIOQUEUETHRESHOLDMS, clampAudioQueueThreshold(audioQueueThresholdMs));
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -50,19 +50,28 @@
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
+#define SER_AUDIOPLAYBACKTHRESHOLDMS "audioplaybackthresholdms"
+#define SER_AUDIODROPTHRESHOLDMS "audiodropthresholdms"
 #define SER_AUDIOQUEUETHRESHOLDMS "audioqueuethresholdms"
 #define SER_LANGUAGE "language"
 
 #define CURRENT_DEFAULT_VER 2
 
 namespace {
-constexpr int kDefaultAudioQueueThresholdMs = 30;
-constexpr int kMinimumAudioQueueThresholdMs = 1;
-constexpr int kMaximumAudioQueueThresholdMs = 1000;
+constexpr int kDefaultAudioPlaybackThresholdMs = 0;
+constexpr int kDefaultAudioDropThresholdMs = 30;
+constexpr int kMinimumAudioPlaybackThresholdMs = 0;
+constexpr int kMinimumAudioDropThresholdMs = 1;
+constexpr int kMaximumAudioThresholdMs = 1000;
 
-int clampAudioQueueThreshold(int value)
+int clampAudioPlaybackThreshold(int value)
 {
-    return qBound(kMinimumAudioQueueThresholdMs, value, kMaximumAudioQueueThresholdMs);
+    return qBound(kMinimumAudioPlaybackThresholdMs, value, kMaximumAudioThresholdMs);
+}
+
+int clampAudioDropThreshold(int value)
+{
+    return qBound(kMinimumAudioDropThresholdMs, value, kMaximumAudioThresholdMs);
 }
 }
 
@@ -162,8 +171,11 @@ void StreamingPreferences::reload()
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
-    audioQueueThresholdMs = clampAudioQueueThreshold(settings.value(SER_AUDIOQUEUETHRESHOLDMS,
-                                                                    kDefaultAudioQueueThresholdMs).toInt());
+    audioPlaybackThresholdMs = clampAudioPlaybackThreshold(settings.value(SER_AUDIOPLAYBACKTHRESHOLDMS,
+                                                                          kDefaultAudioPlaybackThresholdMs).toInt());
+    audioDropThresholdMs = clampAudioDropThreshold(settings.value(SER_AUDIODROPTHRESHOLDMS,
+                                                                  settings.value(SER_AUDIOQUEUETHRESHOLDMS,
+                                                                                 kDefaultAudioDropThresholdMs).toInt()).toInt());
     enableHdr = settings.value(SER_HDR, false).toBool();
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
                                                          static_cast<int>(CaptureSysKeysMode::CSK_OFF)).toInt());
@@ -372,7 +384,9 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
-    settings.setValue(SER_AUDIOQUEUETHRESHOLDMS, clampAudioQueueThreshold(audioQueueThresholdMs));
+    settings.setValue(SER_AUDIOPLAYBACKTHRESHOLDMS, clampAudioPlaybackThreshold(audioPlaybackThresholdMs));
+    settings.setValue(SER_AUDIODROPTHRESHOLDMS, clampAudioDropThreshold(audioDropThresholdMs));
+    settings.setValue(SER_AUDIOQUEUETHRESHOLDMS, clampAudioDropThreshold(audioDropThresholdMs));
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -143,6 +143,7 @@ public:
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
+    Q_PROPERTY(int audioQueueThresholdMs MEMBER audioQueueThresholdMs NOTIFY audioQueueThresholdMsChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
 
@@ -176,6 +177,7 @@ public:
     bool reverseScrollDirection;
     bool swapFaceButtons;
     bool keepAwake;
+    int audioQueueThresholdMs;
     int packetSize;
     AudioConfig audioConfig;
     VideoCodecConfig videoCodecConfig;
@@ -223,6 +225,7 @@ signals:
     void swapFaceButtonsChanged();
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
+    void audioQueueThresholdMsChanged();
     void languageChanged();
 
 private:
@@ -232,4 +235,3 @@ private:
 
     QQmlEngine* m_QmlEngine;
 };
-

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -143,7 +143,8 @@ public:
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
-    Q_PROPERTY(int audioQueueThresholdMs MEMBER audioQueueThresholdMs NOTIFY audioQueueThresholdMsChanged)
+    Q_PROPERTY(int audioPlaybackThresholdMs MEMBER audioPlaybackThresholdMs NOTIFY audioPlaybackThresholdMsChanged)
+    Q_PROPERTY(int audioDropThresholdMs MEMBER audioDropThresholdMs NOTIFY audioDropThresholdMsChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
 
@@ -177,7 +178,8 @@ public:
     bool reverseScrollDirection;
     bool swapFaceButtons;
     bool keepAwake;
-    int audioQueueThresholdMs;
+    int audioPlaybackThresholdMs;
+    int audioDropThresholdMs;
     int packetSize;
     AudioConfig audioConfig;
     VideoCodecConfig videoCodecConfig;
@@ -225,7 +227,8 @@ signals:
     void swapFaceButtonsChanged();
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
-    void audioQueueThresholdMsChanged();
+    void audioPlaybackThresholdMsChanged();
+    void audioDropThresholdMsChanged();
     void languageChanged();
 
 private:

--- a/app/streaming/audio/audio.cpp
+++ b/app/streaming/audio/audio.cpp
@@ -30,7 +30,7 @@ IAudioRenderer* Session::createAudioRenderer(const POPUS_MULTISTREAM_CONFIGURATI
     // Handle explicit ML_AUDIO setting and fail if the requested backend fails
     QString mlAudio = qgetenv("ML_AUDIO").toLower();
     if (mlAudio == "sdl") {
-        TRY_INIT_RENDERER_ARGS(SdlAudioRenderer, opusConfig, m_Preferences->audioQueueThresholdMs)
+        TRY_INIT_RENDERER_ARGS(SdlAudioRenderer, opusConfig, m_Preferences->audioPlaybackThresholdMs, m_Preferences->audioDropThresholdMs)
         return nullptr;
     }
 #if defined(HAVE_SLAUDIO)
@@ -54,7 +54,7 @@ IAudioRenderer* Session::createAudioRenderer(const POPUS_MULTISTREAM_CONFIGURATI
 #endif
 
     // Default to SDL
-    TRY_INIT_RENDERER_ARGS(SdlAudioRenderer, opusConfig, m_Preferences->audioQueueThresholdMs)
+    TRY_INIT_RENDERER_ARGS(SdlAudioRenderer, opusConfig, m_Preferences->audioPlaybackThresholdMs, m_Preferences->audioDropThresholdMs)
 
     return nullptr;
 }

--- a/app/streaming/audio/audio.cpp
+++ b/app/streaming/audio/audio.cpp
@@ -17,12 +17,20 @@
     delete __renderer;                                 \
 }
 
+#define TRY_INIT_RENDERER_ARGS(renderer, opusConfig, ...) \
+{                                                         \
+    IAudioRenderer* __renderer = new renderer(__VA_ARGS__); \
+    if (__renderer->prepareForPlayback(opusConfig))       \
+        return __renderer;                                \
+    delete __renderer;                                    \
+}
+
 IAudioRenderer* Session::createAudioRenderer(const POPUS_MULTISTREAM_CONFIGURATION opusConfig)
 {
     // Handle explicit ML_AUDIO setting and fail if the requested backend fails
     QString mlAudio = qgetenv("ML_AUDIO").toLower();
     if (mlAudio == "sdl") {
-        TRY_INIT_RENDERER(SdlAudioRenderer, opusConfig)
+        TRY_INIT_RENDERER_ARGS(SdlAudioRenderer, opusConfig, m_Preferences->audioQueueThresholdMs)
         return nullptr;
     }
 #if defined(HAVE_SLAUDIO)
@@ -46,7 +54,7 @@ IAudioRenderer* Session::createAudioRenderer(const POPUS_MULTISTREAM_CONFIGURATI
 #endif
 
     // Default to SDL
-    TRY_INIT_RENDERER(SdlAudioRenderer, opusConfig)
+    TRY_INIT_RENDERER_ARGS(SdlAudioRenderer, opusConfig, m_Preferences->audioQueueThresholdMs)
 
     return nullptr;
 }

--- a/app/streaming/audio/renderers/sdl.h
+++ b/app/streaming/audio/renderers/sdl.h
@@ -6,7 +6,7 @@
 class SdlAudioRenderer : public IAudioRenderer
 {
 public:
-    explicit SdlAudioRenderer(int audioQueueThresholdMs = 30);
+    explicit SdlAudioRenderer(int audioPlaybackThresholdMs = 30, int audioDropThresholdMs = 30);
 
     virtual ~SdlAudioRenderer();
 
@@ -22,5 +22,8 @@ private:
     SDL_AudioDeviceID m_AudioDevice;
     void* m_AudioBuffer;
     int m_FrameSize;
-    int m_AudioQueueThresholdMs;
+    int m_BytesPerMs;
+    int m_AudioPlaybackThresholdMs;
+    int m_AudioDropThresholdMs;
+    bool m_WaitingForPlaybackThreshold;
 };

--- a/app/streaming/audio/renderers/sdl.h
+++ b/app/streaming/audio/renderers/sdl.h
@@ -6,7 +6,7 @@
 class SdlAudioRenderer : public IAudioRenderer
 {
 public:
-    SdlAudioRenderer();
+    explicit SdlAudioRenderer(int audioQueueThresholdMs = 30);
 
     virtual ~SdlAudioRenderer();
 
@@ -22,4 +22,5 @@ private:
     SDL_AudioDeviceID m_AudioDevice;
     void* m_AudioBuffer;
     int m_FrameSize;
+    int m_AudioQueueThresholdMs;
 };

--- a/app/streaming/audio/renderers/sdlaud.cpp
+++ b/app/streaming/audio/renderers/sdlaud.cpp
@@ -2,10 +2,13 @@
 
 #include <Limelight.h>
 
-SdlAudioRenderer::SdlAudioRenderer(int audioQueueThresholdMs)
+SdlAudioRenderer::SdlAudioRenderer(int audioPlaybackThresholdMs, int audioDropThresholdMs)
     : m_AudioDevice(0),
       m_AudioBuffer(nullptr),
-      m_AudioQueueThresholdMs(SDL_max(1, audioQueueThresholdMs))
+      m_BytesPerMs(0),
+      m_AudioPlaybackThresholdMs(SDL_max(0, audioPlaybackThresholdMs)),
+      m_AudioDropThresholdMs(SDL_max(1, audioDropThresholdMs)),
+      m_WaitingForPlaybackThreshold(audioPlaybackThresholdMs > 0)
 {
     SDL_assert(!SDL_WasInit(SDL_INIT_AUDIO));
 
@@ -33,10 +36,6 @@ bool SdlAudioRenderer::prepareForPlayback(const OPUS_MULTISTREAM_CONFIGURATION* 
     // The buffering helps avoid audio underruns due to network jitter.
     want.samples = SDL_max(480, opusConfig->samplesPerFrame * 3);
 
-    m_FrameSize = opusConfig->samplesPerFrame *
-                  opusConfig->channelCount *
-                  getAudioBufferSampleSize();
-
     m_AudioDevice = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
     if (m_AudioDevice == 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
@@ -44,6 +43,11 @@ bool SdlAudioRenderer::prepareForPlayback(const OPUS_MULTISTREAM_CONFIGURATION* 
                      SDL_GetError());
         return false;
     }
+
+    m_FrameSize = opusConfig->samplesPerFrame *
+                  have.channels *
+                  getAudioBufferSampleSize();
+    m_BytesPerMs = SDL_max(1, (have.freq * have.channels * getAudioBufferSampleSize()) / 1000);
 
     m_AudioBuffer = SDL_malloc(m_FrameSize);
     if (m_AudioBuffer == nullptr) {
@@ -66,8 +70,9 @@ bool SdlAudioRenderer::prepareForPlayback(const OPUS_MULTISTREAM_CONFIGURATION* 
                 "SDL audio driver: %s",
                 SDL_GetCurrentAudioDriver());
 
-    // Start playback
-    SDL_PauseAudioDevice(m_AudioDevice, 0);
+    if (!m_WaitingForPlaybackThreshold) {
+        SDL_PauseAudioDevice(m_AudioDevice, 0);
+    }
 
     return true;
 }
@@ -102,7 +107,7 @@ bool SdlAudioRenderer::submitAudio(int bytesWritten)
 
     // Don't queue if there's already more than the configured amount of audio
     // in Moonlight's audio queue.
-    if (LiGetPendingAudioDuration() > m_AudioQueueThresholdMs) {
+    if (LiGetPendingAudioDuration() > m_AudioDropThresholdMs) {
         return true;
     }
 
@@ -124,10 +129,25 @@ bool SdlAudioRenderer::submitAudio(int bytesWritten)
         SDL_Delay(1);
     }
 
+    Uint32 queuedAudioSize = SDL_GetQueuedAudioSize(m_AudioDevice);
+    if (!m_WaitingForPlaybackThreshold && queuedAudioSize == 0) {
+        SDL_PauseAudioDevice(m_AudioDevice, 1);
+        m_WaitingForPlaybackThreshold = true;
+    }
+
     if (SDL_QueueAudio(m_AudioDevice, m_AudioBuffer, bytesWritten) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "Failed to queue audio sample: %s",
                      SDL_GetError());
+        return true;
+    }
+
+    if (m_WaitingForPlaybackThreshold) {
+        queuedAudioSize = SDL_GetQueuedAudioSize(m_AudioDevice);
+        if (queuedAudioSize >= (Uint32)(m_AudioPlaybackThresholdMs * m_BytesPerMs)) {
+            SDL_PauseAudioDevice(m_AudioDevice, 0);
+            m_WaitingForPlaybackThreshold = false;
+        }
     }
 
     return true;

--- a/app/streaming/audio/renderers/sdlaud.cpp
+++ b/app/streaming/audio/renderers/sdlaud.cpp
@@ -2,9 +2,10 @@
 
 #include <Limelight.h>
 
-SdlAudioRenderer::SdlAudioRenderer()
+SdlAudioRenderer::SdlAudioRenderer(int audioQueueThresholdMs)
     : m_AudioDevice(0),
-      m_AudioBuffer(nullptr)
+      m_AudioBuffer(nullptr),
+      m_AudioQueueThresholdMs(SDL_max(1, audioQueueThresholdMs))
 {
     SDL_assert(!SDL_WasInit(SDL_INIT_AUDIO));
 
@@ -99,9 +100,9 @@ bool SdlAudioRenderer::submitAudio(int bytesWritten)
         return true;
     }
 
-    // Don't queue if there's already more than 30 ms of audio data waiting
+    // Don't queue if there's already more than the configured amount of audio
     // in Moonlight's audio queue.
-    if (LiGetPendingAudioDuration() > 30) {
+    if (LiGetPendingAudioDuration() > m_AudioQueueThresholdMs) {
         return true;
     }
 


### PR DESCRIPTION
## Summary
- add a user-configurable setting for Moonlight's pending SDL audio queue threshold
- keep the default threshold at 30 ms so existing behavior is unchanged unless the user opts in
- pass the configured threshold through to the SDL audio renderer instead of hardcoding it

## Why
I was experimenting with higher values to reduce audio stuttering on my setup. Making the threshold configurable seemed preferable to changing the default for everyone.

## Testing
- no clean upstream build/test run included with this branch on this machine
- feature change reviewed locally and kept narrowly scoped to settings/UI plus SDL audio threshold plumbing

## Notes
For certain music like Cyberpunk 2077 title screen, the 30ms can cause the audio glitch very disorienting. For me, increasing it to 100 makes it unnoticeable for most of the time and only glitch a bit every now and then. See my comment in #1691 

I got the idea when I had similar issues with [chiaki-ng](https://github.com/streetpea/chiaki-ng) to play my PS5 games on SteamDeck. When in a bad spot, it may behave the same way. But Chiaki-ng has a setting to change something I assume do the same thing. And it worked for me.