### PR TITLE
feat(input): DualSense firmware passthrough, player LED and mic LED forwarding

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -46,7 +46,7 @@ win32 {
     }
 
     INCLUDEPATH += $$PWD/../libs/windows/include
-    LIBS += ws2_32.lib winmm.lib dxva2.lib ole32.lib gdi32.lib user32.lib d3d9.lib dwmapi.lib dbghelp.lib
+    LIBS += ws2_32.lib winmm.lib dxva2.lib ole32.lib gdi32.lib user32.lib d3d9.lib dwmapi.lib dbghelp.lib hid.lib
 }
 macx:!disable-prebuilts {
     INCLUDEPATH += $$PWD/../libs/mac/include $$PWD/../libs/mac/include/SDL2

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -6,6 +6,13 @@
 
 #include <QtMath>
 
+#ifdef _WIN32
+#include <Windows.h>
+extern "C" {
+#include <hidsdi.h>
+}
+#endif
+
 // How long the Start button must be pressed to toggle mouse emulation
 #define MOUSE_EMULATION_LONG_PRESS_TIME 750
 
@@ -708,7 +715,47 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
 #endif
             type == LI_CTYPE_PS;
 
-        LiSendControllerArrivalEvent(state->index, m_GamepadMask, type, supportedButtonFlags, capabilities);
+        // Read firmware info from DualSense controllers for passthrough to the host
+        uint8_t metadataBuf[4 + 64] = {}; // TLV header + firmware report
+        uint16_t metadataLen = 0;
+
+#if SDL_VERSION_ATLEAST(2, 0, 18) && defined(_WIN32)
+        if (SDL_GameControllerGetType(state->controller) == SDL_CONTROLLER_TYPE_PS5) {
+            SDL_Joystick *joy = SDL_GameControllerGetJoystick(state->controller);
+            Uint16 vid = SDL_JoystickGetVendor(joy);
+            Uint16 pid = SDL_JoystickGetProduct(joy);
+
+            // SDL_hid_open fails when the game controller backend already holds the
+            // device. Use SDL_hid_enumerate to get the device path, then open via the
+            // Windows HID API with shared access to read the firmware feature report.
+            SDL_hid_init();
+            struct SDL_hid_device_info *devs = SDL_hid_enumerate(vid, pid);
+            for (struct SDL_hid_device_info *cur = devs; cur; cur = cur->next) {
+                HANDLE hid = CreateFileA(cur->path, GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
+                if (hid != INVALID_HANDLE_VALUE) {
+                    unsigned char report[65] = {};
+                    report[0] = 0x20;
+                    if (HidD_GetFeature(hid, report, sizeof(report))) {
+                        metadataBuf[0] = LI_CTRL_META_TAG_FIRMWARE_INFO;
+                        metadataBuf[1] = 0;
+                        metadataBuf[2] = 64;
+                        metadataBuf[3] = 0;
+                        memcpy(metadataBuf + 4, report, 64);
+                        metadataLen = 4 + 64;
+                        capabilities |= LI_CCAP_FIRMWARE_INFO;
+                    }
+                    CloseHandle(hid);
+                    break;
+                }
+            }
+            SDL_hid_free_enumeration(devs);
+            SDL_hid_exit();
+        }
+#endif
+
+        LiSendControllerArrivalEventWithMetadata(state->index, m_GamepadMask, type,
+            supportedButtonFlags, capabilities, metadataLen > 0 ? metadataBuf : NULL, metadataLen);
 #else
 
         // Send an empty event to tell the PC we've arrived


### PR DESCRIPTION
## Summary
Three DualSense streaming enhancements:

**Firmware version passthrough:**
- Reads HID feature report 0x20 from the physical DualSense on controller arrival
- Sends the raw 64-byte firmware blob to the host as a TLV metadata extension
- Host uses it to configure the virtual DualSense with matching firmware, preventing "firmware update required" prompts from Steam/Windows
- Uses Windows HID API (CreateFile + HidD_GetFeature) with shared access since SDL's game controller backend holds the device exclusively
- Gracefully skips if the device can't be opened or the report read fails

**Player LED forwarding (protocol 0x5504):**
- Receives player indicator LED state from the host and applies it to the physical DualSense via `SDL_GameControllerSendEffect`
- Standard values: P1=0x04, P2=0x0A, P3=0x15, P4=0x1B, all=0x1F

**Mic LED forwarding (protocol 0x5505):**
- Receives mic mute LED state from the host (off/on/pulse) and applies it to the physical DualSense

All features are PS5-only (`SDL_CONTROLLER_TYPE_PS5` check) and require SDL 2.0.16+. Firmware read requires SDL 2.0.18+ and is Windows-only (`#ifdef _WIN32`).

## Dependencies
- moonlight-stream/moonlight-common-c#137 (TLV metadata + LED protocol extensions)

## Test plan
- [x] Physical DualSense firmware `Jul 4 2025` successfully passed through to virtual DualSense on host
- [x] Player LED indicators reflect on physical controller when set by host games
- [x] Mic LED state (off/on/pulse) reflects on physical controller
- [x] All existing controller features (rumble, lightbar, adaptive triggers, gyro) unaffected
- [x] Builds on Windows, macOS, Linux (AppImage), SteamLink — CI passes all platforms