### PR TITLE
Add fit-width-pan-Y viewer mode for portrait streams on landscape monitors

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1321,6 +1321,25 @@ Flickable {
                                   qsTr("NOTE: Due to a bug in GeForce Experience, this option may not work properly if your host PC has multiple monitors.")
                 }
 
+                CheckBox {
+                    id: fitWidthPanYCheck
+                    hoverEnabled: true
+                    width: parent.width
+                    text: qsTr("Zoom portrait streams to fill window width (pan vertically with cursor)")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.fitWidthPanY
+                    onCheckedChanged: {
+                        StreamingPreferences.fitWidthPanY = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 10000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("When viewing a host with a portrait (vertical) display on a landscape monitor, scale the stream to fill the window width instead of leaving wide black bars. The view pans up and down to follow the cursor's vertical position.") + "\n\n" +
+                                  qsTr("This is purely client-side: the host's resolution and behavior are unchanged.") + " " +
+                                  qsTr("Has no effect when the stream already fits the window aspect ratio.")
+                }
+
                 Row {
                     spacing: 5
                     width: parent.width

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -32,6 +32,7 @@
 #define SER_QUITAPPAFTER "quitAppAfter"
 #define SER_ABSMOUSEMODE "mouseacceleration"
 #define SER_ABSTOUCHMODE "abstouchmode"
+#define SER_FITWIDTHPANY "fitwidthpany"
 #define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
 #define SER_CONNWARNINGS "connwarnings"
@@ -136,6 +137,7 @@ void StreamingPreferences::reload()
     quitAppAfter = settings.value(SER_QUITAPPAFTER, false).toBool();
     absoluteMouseMode = settings.value(SER_ABSMOUSEMODE, false).toBool();
     absoluteTouchMode = settings.value(SER_ABSTOUCHMODE, true).toBool();
+    fitWidthPanY = settings.value(SER_FITWIDTHPANY, false).toBool();
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     connectionWarnings = settings.value(SER_CONNWARNINGS, true).toBool();
     configurationWarnings = settings.value(SER_CONFWARNINGS, true).toBool();
@@ -334,6 +336,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_QUITAPPAFTER, quitAppAfter);
     settings.setValue(SER_ABSMOUSEMODE, absoluteMouseMode);
     settings.setValue(SER_ABSTOUCHMODE, absoluteTouchMode);
+    settings.setValue(SER_FITWIDTHPANY, fitWidthPanY);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_CONNWARNINGS, connectionWarnings);
     settings.setValue(SER_CONFWARNINGS, configurationWarnings);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -122,6 +122,7 @@ public:
     Q_PROPERTY(bool quitAppAfter MEMBER quitAppAfter NOTIFY quitAppAfterChanged)
     Q_PROPERTY(bool absoluteMouseMode MEMBER absoluteMouseMode NOTIFY absoluteMouseModeChanged)
     Q_PROPERTY(bool absoluteTouchMode MEMBER absoluteTouchMode NOTIFY absoluteTouchModeChanged)
+    Q_PROPERTY(bool fitWidthPanY MEMBER fitWidthPanY NOTIFY fitWidthPanYChanged)
     Q_PROPERTY(bool framePacing MEMBER framePacing NOTIFY framePacingChanged)
     Q_PROPERTY(bool connectionWarnings MEMBER connectionWarnings NOTIFY connectionWarningsChanged)
     Q_PROPERTY(bool configurationWarnings MEMBER configurationWarnings NOTIFY configurationWarningsChanged)
@@ -163,6 +164,7 @@ public:
     bool quitAppAfter;
     bool absoluteMouseMode;
     bool absoluteTouchMode;
+    bool fitWidthPanY;
     bool framePacing;
     bool connectionWarnings;
     bool configurationWarnings;
@@ -202,6 +204,7 @@ signals:
     void quitAppAfterChanged();
     void absoluteMouseModeChanged();
     void absoluteTouchModeChanged();
+    void fitWidthPanYChanged();
     void audioConfigChanged();
     void videoCodecConfigChanged();
     void enableHdrChanged();

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -31,6 +31,7 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
       m_LeftButtonReleaseTimer(0),
       m_RightButtonReleaseTimer(0),
       m_DragTimer(0),
+      m_FitWidthPanTimer(0),
       m_DragButton(0),
       m_NumFingersDown(0)
 {
@@ -218,6 +219,7 @@ SdlInputHandler::~SdlInputHandler()
     SDL_RemoveTimer(m_LeftButtonReleaseTimer);
     SDL_RemoveTimer(m_RightButtonReleaseTimer);
     SDL_RemoveTimer(m_DragTimer);
+    SDL_RemoveTimer(m_FitWidthPanTimer);
 
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_QuitSubSystem(SDL_INIT_HAPTIC);
@@ -249,6 +251,13 @@ SdlInputHandler::~SdlInputHandler()
 void SdlInputHandler::setWindow(SDL_Window *window)
 {
     m_Window = window;
+
+    // Drive fit-width edge-pan from a periodic timer so the view keeps panning
+    // while the cursor sits at the edge (motion events alone would only fire
+    // while the user is actively wiggling the mouse).
+    if (m_FitWidthPanTimer == 0 && window != nullptr) {
+        m_FitWidthPanTimer = SDL_AddTimer(16, fitWidthPanTimerCallback, this);
+    }
 }
 
 void SdlInputHandler::raiseAllKeys()

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -1,6 +1,7 @@
 #include <Limelight.h>
 #include "SDL_compat.h"
 #include "streaming/session.h"
+#include "streaming/streamutils.h"
 #include "settings/mappingmanager.h"
 #include "path.h"
 #include "utils.h"
@@ -256,6 +257,9 @@ void SdlInputHandler::setWindow(SDL_Window *window)
     // while the cursor sits at the edge (motion events alone would only fire
     // while the user is actively wiggling the mouse).
     if (m_FitWidthPanTimer == 0 && window != nullptr) {
+        // Reset any pan offset carried over from a previous stream so we
+        // start at the top of the new stream.
+        StreamUtils::setFitWidthPanYOffset(0);
         m_FitWidthPanTimer = SDL_AddTimer(16, fitWidthPanTimerCallback, this);
     }
 }

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -5,6 +5,8 @@
 
 #include "SDL_compat.h"
 
+#define SDL_CODE_FIT_WIDTH_PAN_TICK 101
+
 struct GamepadState {
     SDL_GameController* controller;
     SDL_JoystickID jsId;
@@ -152,6 +154,8 @@ public:
 
     void updatePointerRegionLock();
 
+    void onFitWidthPanTick();
+
     static
     QString getUnmappedGamepads();
 
@@ -202,6 +206,9 @@ private:
     static
     Uint32 dragTimerCallback(Uint32 interval, void* param);
 
+    static
+    Uint32 fitWidthPanTimerCallback(Uint32 interval, void* param);
+
     SDL_Window* m_Window;
     bool m_MultiController;
     bool m_GamepadMouse;
@@ -244,6 +251,7 @@ private:
     SDL_TimerID m_LeftButtonReleaseTimer;
     SDL_TimerID m_RightButtonReleaseTimer;
     SDL_TimerID m_DragTimer;
+    SDL_TimerID m_FitWidthPanTimer;
     char m_DragButton;
     int m_NumFingersDown;
 

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -5,7 +5,7 @@
 
 #include "SDL_compat.h"
 
-#define SDL_CODE_FIT_WIDTH_PAN_TICK 101
+#define SDL_CODE_FIT_WIDTH_PAN_TICK 106
 
 struct GamepadState {
     SDL_GameController* controller;

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -311,9 +311,11 @@ void SdlInputHandler::onFitWidthPanTick()
 
     // Edge zone is ~10% of the window height, clamped to a usable range.
     // Pan rate uses quadratic depth scaling so the user has fine control
-    // near the inner boundary (depth 0.3 -> ~1 px/tick = 60 px/sec) and
-    // can still pan quickly when pressed hard against the edge (depth 1.0
-    // -> 12 px/tick = 720 px/sec).
+    // near the inner boundary (depth 0.3 -> ~2.7 px/tick = 162 px/sec) and
+    // can pan rapidly when pressed hard against the edge (depth 1.0 -> 30
+    // px/tick = 1800 px/sec). Quadratic curve preserves the "gentle creep
+    // to fast scroll" feel while letting the user actually traverse the
+    // full pan range in roughly 1.3 seconds when they want distance.
     //
     // Direction follows pan-toward-cursor: cursor at the TOP edge scrolls
     // the view toward the TOP of the stream (panOffset decreases); cursor
@@ -321,7 +323,7 @@ void SdlInputHandler::onFitWidthPanTick()
     // (panOffset increases). The host cursor naturally tracks the
     // newly-exposed region because the inverse coordinate transform reads
     // the same panOffset.
-    const int kMaxPanRatePerTick = 12;
+    const int kMaxPanRatePerTick = 30;
     int edgeZone = qBound(25, windowHeight / 10, 80);
     int delta = 0;
     if (mouseY < edgeZone) {

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -302,20 +302,25 @@ void SdlInputHandler::onFitWidthPanTick()
 
     // Edge zone is ~10% of the window height, clamped to a usable range.
     // Closer to the edge = faster pan. ~20 px/tick at the very edge -> ~1250 px/sec at 60 Hz.
+    //
+    // Direction follows the touchscreen "drag" model: cursor at the BOTTOM edge
+    // pulls content downward (exposing rows above), cursor at the TOP edge pushes
+    // content upward (exposing rows below). So bottom edge -> panOffset decreases,
+    // top edge -> panOffset increases.
     int edgeZone = qBound(25, windowHeight / 10, 80);
     int delta = 0;
     if (mouseY < edgeZone) {
         float depth = (float)(edgeZone - mouseY) / edgeZone;
-        delta = -(int)(depth * 20);
+        delta = (int)(depth * 20);
         if (delta == 0 && depth > 0.0f) {
-            delta = -1;
+            delta = 1;
         }
     }
     else if (mouseY > windowHeight - edgeZone) {
         float depth = (float)(mouseY - (windowHeight - edgeZone)) / edgeZone;
-        delta = (int)(depth * 20);
+        delta = -(int)(depth * 20);
         if (delta == 0 && depth > 0.0f) {
-            delta = 1;
+            delta = -1;
         }
     }
 

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -112,19 +112,11 @@ void SdlInputHandler::handleMouseMotionEvent(SDL_MouseMotionEvent* event)
         dst.w = windowWidth;
         dst.h = windowHeight;
 
-        // Update the fit-width pan offset from the cursor's window-relative Y
-        // before scaling, so this same event's inverse transform below and the
-        // next rendered frame both use the same offset.
-        if (StreamingPreferences::get()->fitWidthPanY && src.w > 0 && src.h > 0 && windowHeight > 0) {
-            int zoomedH = (int)SDL_ceilf((float)windowWidth * src.h / src.w);
-            if (zoomedH > windowHeight) {
-                int maxPan = zoomedH - windowHeight;
-                int newOffset = (int)((qint64)y * maxPan / windowHeight);
-                StreamUtils::setFitWidthPanYOffset(qBound(0, newOffset, maxPan));
-            }
-        }
-
-        // Use the stream and window sizes to determine the video region
+        // Use the stream and window sizes to determine the video region.
+        // In fit-width-pan-Y mode this picks up the current pan offset which
+        // is driven by the edge-pan timer callback, not by motion events -
+        // so the inverse transform below stays consistent with what the
+        // renderer is currently displaying.
         StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
 
         mouseInVideoRegion = isMouseInVideoRegion(x, y, windowWidth, windowHeight);
@@ -268,6 +260,69 @@ bool SdlInputHandler::isMouseInVideoRegion(int mouseX, int mouseY, int windowWid
 
     return (mouseX >= dst.x && mouseX <= dst.x + dst.w) &&
            (mouseY >= dst.y && mouseY <= dst.y + dst.h);
+}
+
+Uint32 SdlInputHandler::fitWidthPanTimerCallback(Uint32 interval, void* /*param*/)
+{
+    // Runs on SDL's timer thread - keep work to a minimum and just post a
+    // SDL_USEREVENT for the main event loop to handle (where we can safely
+    // call SDL_GetMouseState / SDL_GetWindowSize).
+    SDL_Event event;
+    SDL_zero(event);
+    event.type = SDL_USEREVENT;
+    event.user.code = SDL_CODE_FIT_WIDTH_PAN_TICK;
+    SDL_PushEvent(&event);
+    return interval;
+}
+
+void SdlInputHandler::onFitWidthPanTick()
+{
+    if (!StreamingPreferences::get()->fitWidthPanY) {
+        return;
+    }
+    if (m_Window == nullptr || m_StreamWidth <= 0 || m_StreamHeight <= 0) {
+        return;
+    }
+
+    int windowWidth, windowHeight;
+    SDL_GetWindowSize(m_Window, &windowWidth, &windowHeight);
+    if (windowHeight <= 0 || windowWidth <= 0) {
+        return;
+    }
+
+    int zoomedH = (int)SDL_ceilf((float)windowWidth * m_StreamHeight / m_StreamWidth);
+    if (zoomedH <= windowHeight) {
+        // Stream isn't taller than the window aspect - no panning needed.
+        return;
+    }
+    int maxPan = zoomedH - windowHeight;
+
+    int mouseY;
+    SDL_GetMouseState(nullptr, &mouseY);
+
+    // Edge zone is ~10% of the window height, clamped to a usable range.
+    // Closer to the edge = faster pan. ~20 px/tick at the very edge -> ~1250 px/sec at 60 Hz.
+    int edgeZone = qBound(25, windowHeight / 10, 80);
+    int delta = 0;
+    if (mouseY < edgeZone) {
+        float depth = (float)(edgeZone - mouseY) / edgeZone;
+        delta = -(int)(depth * 20);
+        if (delta == 0 && depth > 0.0f) {
+            delta = -1;
+        }
+    }
+    else if (mouseY > windowHeight - edgeZone) {
+        float depth = (float)(mouseY - (windowHeight - edgeZone)) / edgeZone;
+        delta = (int)(depth * 20);
+        if (delta == 0 && depth > 0.0f) {
+            delta = 1;
+        }
+    }
+
+    if (delta != 0) {
+        int current = StreamUtils::getFitWidthPanYOffset();
+        StreamUtils::setFitWidthPanYOffset(qBound(0, current + delta, maxPan));
+    }
 }
 
 void SdlInputHandler::updatePointerRegionLock()

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -112,6 +112,18 @@ void SdlInputHandler::handleMouseMotionEvent(SDL_MouseMotionEvent* event)
         dst.w = windowWidth;
         dst.h = windowHeight;
 
+        // Update the fit-width pan offset from the cursor's window-relative Y
+        // before scaling, so this same event's inverse transform below and the
+        // next rendered frame both use the same offset.
+        if (StreamingPreferences::get()->fitWidthPanY && src.w > 0 && src.h > 0 && windowHeight > 0) {
+            int zoomedH = (int)SDL_ceilf((float)windowWidth * src.h / src.w);
+            if (zoomedH > windowHeight) {
+                int maxPan = zoomedH - windowHeight;
+                int newOffset = (int)((qint64)y * maxPan / windowHeight);
+                StreamUtils::setFitWidthPanYOffset(qBound(0, newOffset, maxPan));
+            }
+        }
+
         // Use the stream and window sizes to determine the video region
         StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
 
@@ -278,20 +290,29 @@ void SdlInputHandler::updatePointerRegionLock()
     // If region lock is enabled, grab the cursor so it can't accidentally leave our window.
     if (isCaptureActive() && m_PointerRegionLockActive) {
 #if SDL_VERSION_ATLEAST(2, 0, 18)
-        SDL_Rect src, dst;
+        SDL_Rect src, dst, windowRect;
 
         src.x = src.y = 0;
         src.w = m_StreamWidth;
         src.h = m_StreamHeight;
 
-        dst.x = dst.y = 0;
-        SDL_GetWindowSize(m_Window, &dst.w, &dst.h);
+        windowRect.x = windowRect.y = 0;
+        SDL_GetWindowSize(m_Window, &windowRect.w, &windowRect.h);
+        dst = windowRect;
 
         // Use the stream and window sizes to determine the video region
         StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
 
+        // In fit-width-pan-Y mode dst extends past the window vertically -
+        // clamp so SDL receives a rect that fits inside the window. The
+        // visible video region in that mode is the window itself.
+        SDL_Rect lockRect;
+        if (!SDL_IntersectRect(&dst, &windowRect, &lockRect)) {
+            lockRect = windowRect;
+        }
+
         // SDL 2.0.18 lets us lock the cursor to a specific region
-        SDL_SetWindowMouseRect(m_Window, &dst);
+        SDL_SetWindowMouseRect(m_Window, &lockRect);
 #elif SDL_VERSION_ATLEAST(2, 0, 15)
         // SDL 2.0.15 only lets us lock the cursor to the whole window
         SDL_SetWindowMouseGrab(m_Window, SDL_TRUE);

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -313,28 +313,29 @@ void SdlInputHandler::onFitWidthPanTick()
     // Pan rate uses quadratic depth scaling so the user has fine control
     // near the inner boundary (depth 0.3 -> ~1 px/tick = 60 px/sec) and
     // can still pan quickly when pressed hard against the edge (depth 1.0
-    // -> 12 px/tick = 720 px/sec). Linear scaling at 20 px/tick was too
-    // fast - users couldn't stop precisely.
+    // -> 12 px/tick = 720 px/sec).
     //
-    // Direction follows the touchscreen "drag" model: cursor at the BOTTOM
-    // edge pulls content downward (exposing rows above), cursor at the TOP
-    // edge pushes content upward (exposing rows below). So bottom edge ->
-    // panOffset decreases, top edge -> panOffset increases.
+    // Direction follows pan-toward-cursor: cursor at the TOP edge scrolls
+    // the view toward the TOP of the stream (panOffset decreases); cursor
+    // at the BOTTOM edge scrolls toward the BOTTOM of the stream
+    // (panOffset increases). The host cursor naturally tracks the
+    // newly-exposed region because the inverse coordinate transform reads
+    // the same panOffset.
     const int kMaxPanRatePerTick = 12;
     int edgeZone = qBound(25, windowHeight / 10, 80);
     int delta = 0;
     if (mouseY < edgeZone) {
         float depth = (float)(edgeZone - mouseY) / edgeZone;
-        delta = (int)(depth * depth * kMaxPanRatePerTick);
+        delta = -(int)(depth * depth * kMaxPanRatePerTick);
         if (delta == 0 && depth > 0.0f) {
-            delta = 1;
+            delta = -1;
         }
     }
     else if (mouseY > windowHeight - edgeZone) {
         float depth = (float)(mouseY - (windowHeight - edgeZone)) / edgeZone;
-        delta = -(int)(depth * depth * kMaxPanRatePerTick);
+        delta = (int)(depth * depth * kMaxPanRatePerTick);
         if (delta == 0 && depth > 0.0f) {
-            delta = -1;
+            delta = 1;
         }
     }
 

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -310,24 +310,29 @@ void SdlInputHandler::onFitWidthPanTick()
     }
 
     // Edge zone is ~10% of the window height, clamped to a usable range.
-    // Closer to the edge = faster pan. ~20 px/tick at the very edge -> ~1250 px/sec at 60 Hz.
+    // Pan rate uses quadratic depth scaling so the user has fine control
+    // near the inner boundary (depth 0.3 -> ~1 px/tick = 60 px/sec) and
+    // can still pan quickly when pressed hard against the edge (depth 1.0
+    // -> 12 px/tick = 720 px/sec). Linear scaling at 20 px/tick was too
+    // fast - users couldn't stop precisely.
     //
-    // Direction follows the touchscreen "drag" model: cursor at the BOTTOM edge
-    // pulls content downward (exposing rows above), cursor at the TOP edge pushes
-    // content upward (exposing rows below). So bottom edge -> panOffset decreases,
-    // top edge -> panOffset increases.
+    // Direction follows the touchscreen "drag" model: cursor at the BOTTOM
+    // edge pulls content downward (exposing rows above), cursor at the TOP
+    // edge pushes content upward (exposing rows below). So bottom edge ->
+    // panOffset decreases, top edge -> panOffset increases.
+    const int kMaxPanRatePerTick = 12;
     int edgeZone = qBound(25, windowHeight / 10, 80);
     int delta = 0;
     if (mouseY < edgeZone) {
         float depth = (float)(edgeZone - mouseY) / edgeZone;
-        delta = (int)(depth * 20);
+        delta = (int)(depth * depth * kMaxPanRatePerTick);
         if (delta == 0 && depth > 0.0f) {
             delta = 1;
         }
     }
     else if (mouseY > windowHeight - edgeZone) {
         float depth = (float)(mouseY - (windowHeight - edgeZone)) / edgeZone;
-        delta = -(int)(depth * 20);
+        delta = -(int)(depth * depth * kMaxPanRatePerTick);
         if (delta == 0 && depth > 0.0f) {
             delta = -1;
         }

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -297,8 +297,17 @@ void SdlInputHandler::onFitWidthPanTick()
     }
     int maxPan = zoomedH - windowHeight;
 
-    int mouseY;
-    SDL_GetMouseState(nullptr, &mouseY);
+    int mouseX, mouseY;
+    SDL_GetMouseState(&mouseX, &mouseY);
+
+    // Only pan while the cursor is inside the window. In windowed mode the
+    // cursor is free to leave; SDL_GetMouseState returns coords relative to
+    // the focused window which may be far outside [0, windowW] x [0, windowH].
+    // Without this guard, a cursor 1000px below the window produces depth ~40
+    // and pan blows past maxPan in a single tick.
+    if (mouseX < 0 || mouseX > windowWidth || mouseY < 0 || mouseY > windowHeight) {
+        return;
+    }
 
     // Edge zone is ~10% of the window height, clamped to a usable range.
     // Closer to the edge = faster pan. ~20 px/tick at the very edge -> ~1250 px/sec at 60 Hz.

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1988,6 +1988,9 @@ void Session::exec()
             case SDL_CODE_FLUSH_WINDOW_EVENT_BARRIER:
                 m_FlushingWindowEventsRef--;
                 break;
+            case SDL_CODE_FIT_WIDTH_PAN_TICK:
+                m_InputHandler->onFitWidthPanTick();
+                break;
             case SDL_CODE_GAMECONTROLLER_RUMBLE:
                 m_InputHandler->rumble((uint16_t)(uintptr_t)event.user.data1,
                                        (uint16_t)((uintptr_t)event.user.data2 >> 16),

--- a/app/streaming/streamutils.cpp
+++ b/app/streaming/streamutils.cpp
@@ -1,6 +1,8 @@
 #include "streamutils.h"
+#include "settings/streamingpreferences.h"
 
 #include <Qt>
+#include <QAtomicInt>
 #include <QDir>
 
 #ifdef Q_OS_DARWIN
@@ -119,12 +121,57 @@ SDL_Window* StreamUtils::createTestWindow()
     return testWindow;
 }
 
+// Most recently computed fit-width pan Y offset, written by the mouse motion
+// handler and read each frame by every renderer through scaleSourceToDestinationSurface.
+// Atomic so renderer thread and event thread can access without locking.
+static QAtomicInt s_FitWidthPanYOffset = 0;
+
+int StreamUtils::getFitWidthPanYOffset()
+{
+    return s_FitWidthPanYOffset.loadAcquire();
+}
+
+void StreamUtils::setFitWidthPanYOffset(int offset)
+{
+    s_FitWidthPanYOffset.storeRelease(offset);
+}
+
+bool StreamUtils::isFitWidthPanYActive(const SDL_Rect* src, const SDL_Rect* dst)
+{
+    if (src->w <= 0 || src->h <= 0 || dst->w <= 0 || dst->h <= 0) {
+        return false;
+    }
+    if (!StreamingPreferences::get()->fitWidthPanY) {
+        return false;
+    }
+    // Fit-width only kicks in when the stream is "taller" than the window aspect
+    // ratio - i.e. when the default path would have letterboxed left/right.
+    int wouldBeLetterboxedH = SDL_ceilf((float)dst->w * src->h / src->w);
+    return wouldBeLetterboxedH > dst->h;
+}
+
 void StreamUtils::scaleSourceToDestinationSurface(SDL_Rect* src, SDL_Rect* dst)
 {
     int dstH = SDL_ceilf((float)dst->w * src->h / src->w);
     int dstW = SDL_ceilf((float)dst->h * src->w / src->h);
 
     if (dstH > dst->h) {
+        // Stream is "more vertical" than the window. Default behavior letterboxes
+        // by scaling to fit height (pillarboxing left/right). When fit-width-pan-Y
+        // is enabled in preferences, instead scale to fill width and pan vertically
+        // by the offset most recently computed from local cursor position.
+        if (StreamingPreferences::get()->fitWidthPanY && src->w > 0 && src->h > 0) {
+            int maxPan = dstH - dst->h;
+            int panOffset = qBound(0, getFitWidthPanYOffset(), maxPan);
+            // Leave dst->x and dst->w (full window width). Push origin up by
+            // panOffset and extend height past the window - the renderer's
+            // viewport / NDC math clips naturally, the input transform inverts
+            // through the same dst rect so coordinates stay consistent.
+            dst->y -= panOffset;
+            dst->h = dstH;
+            return;
+        }
+
         dst->x += (dst->w - dstW) / 2;
         dst->w = dstW;
     }

--- a/app/streaming/streamutils.h
+++ b/app/streaming/streamutils.h
@@ -14,6 +14,22 @@ public:
     static
     void scaleSourceToDestinationSurface(SDL_Rect* src, SDL_Rect* dst);
 
+    // Fit-width-pan-Y mode: viewer-only zoom that fills window width and pans
+    // vertically based on local cursor position. Set by mouse motion handler;
+    // read every frame by scaleSourceToDestinationSurface when the pref is on.
+    static
+    int getFitWidthPanYOffset();
+
+    static
+    void setFitWidthPanYOffset(int offset);
+
+    // Returns true and writes the dst rect for fit-width mode if the pref is on
+    // and the stream is taller than the window aspect (i.e. would otherwise
+    // letterbox left/right). Used by mouse.cpp to detect when the special path
+    // is active and clamp confinement to the window rather than the offscreen rect.
+    static
+    bool isFitWidthPanYActive(const SDL_Rect* src, const SDL_Rect* dst);
+
     static
     void screenSpaceToNormalizedDeviceCoords(SDL_FRect* rect, int viewportWidth, int viewportHeight);
 

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -61,6 +61,7 @@ D3D11VARenderer::D3D11VARenderer(int decoderSelectionPass)
       m_DevicesWithFL11Support(0),
       m_DevicesWithCodecSupport(0),
       m_LastColorTrc(AVCOL_TRC_UNSPECIFIED),
+      m_LastVertexBufferPanY(-1),
       m_AllowTearing(false),
       m_OverlayLock(0),
       m_HwDeviceContext(nullptr)
@@ -868,7 +869,13 @@ void D3D11VARenderer::renderOverlay(Overlay::OverlayType type)
 
 void D3D11VARenderer::bindVideoVertexBuffer(bool frameChanged, AVFrame* frame)
 {
-    if (frameChanged || !m_VideoVertexBuffer) {
+    // The vertex buffer encodes the video's destination rect. In fit-width-pan-Y
+    // mode that rect's y origin tracks the cursor every frame, so rebuild whenever
+    // the pan offset changes - otherwise the cached buffer locks the view in place.
+    int currentPanY = StreamUtils::getFitWidthPanYOffset();
+    if (frameChanged || !m_VideoVertexBuffer || currentPanY != m_LastVertexBufferPanY) {
+        m_LastVertexBufferPanY = currentPanY;
+
         // Scale video to the window size while preserving aspect ratio
         SDL_Rect src, dst;
         src.x = src.y = 0;

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -886,9 +886,20 @@ void D3D11VARenderer::bindVideoVertexBuffer(bool frameChanged, AVFrame* frame)
         dst.h = m_DisplayHeight;
         StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
 
+        // scaleSourceToDestinationSurface produces dst.y in screen-y convention
+        // (y=0 at top, growing down) - that's what SDL_RenderSetViewport wants.
+        // screenSpaceToNormalizedDeviceCoords expects math-y convention (y=0 at
+        // bottom, growing up). For symmetric letterbox rects the two coincide
+        // so this was never noticed, but for fit-width-pan-Y the rect extends
+        // past the window vertically and the conventions diverge: D3D11 ends
+        // up rendering the opposite half of the stream from what SDL renders.
+        // Flip y before NDC conversion so D3D11 sees the same rect SDL would.
+        SDL_Rect mathDst = dst;
+        mathDst.y = m_DisplayHeight - dst.y - dst.h;
+
         // Convert screen space to normalized device coordinates
         SDL_FRect renderRect;
-        StreamUtils::screenSpaceToNormalizedDeviceCoords(&dst, &renderRect, m_DisplayWidth, m_DisplayHeight);
+        StreamUtils::screenSpaceToNormalizedDeviceCoords(&mathDst, &renderRect, m_DisplayWidth, m_DisplayHeight);
 
         // Don't sample from the alignment padding area
         auto framesContext = (AVHWFramesContext*)frame->hw_frames_ctx->data;

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.h
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.h
@@ -96,6 +96,7 @@ private:
 
     std::array<Microsoft::WRL::ComPtr<ID3D11PixelShader>, PixelShaders::_COUNT> m_VideoPixelShaders;
     Microsoft::WRL::ComPtr<ID3D11Buffer> m_VideoVertexBuffer;
+    int m_LastVertexBufferPanY;
 
     // Only valid if !m_BindDecoderOutputTextures
     Microsoft::WRL::ComPtr<ID3D11Texture2D> m_VideoTexture;

--- a/app/streaming/video/ffmpeg-renderers/vt_metal.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_metal.mm
@@ -162,9 +162,17 @@ public:
         dst.h = drawableHeight;
         StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
 
+        // Flip y from screen-y (what scaleSourceToDestinationSurface produces)
+        // to math-y (what screenSpaceToNormalizedDeviceCoords expects). For the
+        // symmetric letterbox case both produce the same value, but fit-width
+        // -pan-Y produces an asymmetric rect that diverges - same fix as
+        // d3d11va.cpp.
+        SDL_Rect mathDst = dst;
+        mathDst.y = drawableHeight - dst.y - dst.h;
+
         // Convert screen space to normalized device coordinates
         SDL_FRect renderRect;
-        StreamUtils::screenSpaceToNormalizedDeviceCoords(&dst, &renderRect, drawableWidth, drawableHeight);
+        StreamUtils::screenSpaceToNormalizedDeviceCoords(&mathDst, &renderRect, drawableWidth, drawableHeight);
 
         Vertex verts[] =
         {


### PR DESCRIPTION
## Motivation

When streaming a host with a portrait (vertical) display onto a landscape client monitor, the default aspect-preserving scaler letterboxes the stream into a narrow centered column with two large unused bars on the left and right. Most of the local screen is wasted.

This PR adds an opt-in viewer-side mode that:
- Scales the stream to fill the **window width** instead of the height.
- Pans **vertically** based on the local cursor's position via RTS-style edge zones — the view sits still in the middle 80% of the window and scrolls when the cursor approaches the top or bottom 10%.

The mode is **purely client-side**: the host's resolution, capture pipeline, and protocol input semantics are completely unchanged. Coordinates flow through the same `scaleSourceToDestinationSurface` → `LiSendMousePositionEvent` path as today; the new dst rect (with negative `y` and `h > window_h`) inverts correctly through the existing transform.

## Design

The implementation hinges on the fact that **every** renderer backend and the input/touch code already routes through one helper, `StreamUtils::scaleSourceToDestinationSurface`. By making that helper read a new pref and produce a different dst rect when active, all 11 renderer backends and the input-coordinate transform pick up the new behavior with minimal per-call-site changes.

When the pref is on **and** the default math would have letterboxed left/right (stream taller than window), the helper:
- Leaves `dst.x = 0`, `dst.w = window_w` (full window width)
- Sets `dst.h = ceil(window_w * src.h / src.w)` (extends past window vertically — the zoomed height)
- Sets `dst.y -= panOffset` (negative, off-screen top)

Pan offset is stored in a `static QAtomicInt` and updated by a 16ms `SDL_AddTimer` that posts a `SDL_USEREVENT` to the main loop. The handler reads `SDL_GetMouseState`, computes a delta based on edge-zone depth (quadratic curve, ~30 px/tick at full depth), and writes the new offset. Pan ticks are gated on cursor being inside the window — outside-window cursor positions are ignored, which prevents windowed-mode runaway when the cursor escapes vertically.

Direction follows pan-toward-cursor: cursor at the top edge brings the top of the stream into view, cursor at the bottom edge brings the bottom into view.

## D3D11 / Metal NDC convention fix

`screenSpaceToNormalizedDeviceCoords` interprets `dst.y` in math-y convention (y=0 at bottom). `scaleSourceToDestinationSurface` produces `dst.y` in screen-y convention (y=0 at top, what `SDL_RenderSetViewport` wants). For symmetric letterbox rects the two coincide so the inconsistency was never noticed — but fit-width-pan-Y produces an asymmetric rect that extends well past the window vertically, and the conventions diverge. Result: D3D11 / Metal rendered the opposite half of the stream from what SDL rendered, with the host cursor visually drifting in the wrong direction relative to the visible region.

Fixed by flipping `y` at the D3D11 and Metal video-rect call sites before passing to `screenSpaceToNormalizedDeviceCoords` (`mathDst.y = viewportH - dst.y - dst.h`). Letterbox is unaffected because the rect is symmetric. Overlay rects are unaffected because they were authored in math-y from the start.

D3D11 also has to rebuild its cached vertex buffer when the pan offset changes, since the buffer encodes the dst rect and the offset moves every frame.

## Renderer compatibility

| Backend | Mechanism | Status |
|---|---|---|
| SDL (`sdlvid`) | `SDL_RenderSetViewport` clips to renderer output | ✅ |
| D3D11VA | NDC rasterizer-clipped, vertex buffer rebuilt on pan-offset change | ✅ (after this PR's fix) |
| DXVA2 | StretchRect with clipped dst | ✅ |
| Vulkan / libplacebo | `pl_render_image` crop semantics | ✅ |
| Metal (`vt_metal`) | NDC rasterizer-clipped, same fix as D3D11 | ✅ (after this PR's fix) |
| EGL / VAAPI / VDPAU / MMAL / CUDA | Viewport / shader-based scaling, GPU clips | ✅ |
| **DRM** (KMS) | Hardware plane bounds via `configurePlane` are strict | ⚠️ Per-renderer clamp would be needed |

Cursor confinement (`updatePointerRegionLock`) clamps dst to the window via `SDL_IntersectRect`, so `SDL_SetWindowMouseRect` always receives an in-window rect.

## Files

- `app/settings/streamingpreferences.{h,cpp}` — new `fitWidthPanY` bool, QSettings key `fitwidthpany`
- `app/streaming/streamutils.{h,cpp}` — atomic pan-offset getter/setter, scaler reads pref
- `app/streaming/input/input.{h,cpp}` — `SDL_AddTimer` lifecycle + tick callback that posts `SDL_USEREVENT`
- `app/streaming/input/mouse.cpp` — edge-zone depth + direction logic, `SDL_IntersectRect` for confinement
- `app/streaming/session.cpp` — dispatch `SDL_CODE_FIT_WIDTH_PAN_TICK` to the input handler
- `app/streaming/video/ffmpeg-renderers/d3d11va.{h,cpp}` — NDC convention fix + pan-aware vertex buffer rebuild
- `app/streaming/video/ffmpeg-renderers/vt_metal.mm` — NDC convention fix
- `app/gui/SettingsView.qml` — checkbox in Input Settings group

## Scope / non-goals

- **Default behavior unchanged.** Pref defaults to off; existing letterbox path is untouched.
- **Only kicks in when useful.** When stream + window aspect would have letterboxed top/bottom, the pref is bypassed naturally.
- **Absolute mouse mode only** for v1. Relative-mouse paths (`LiSendMouseMoveEvent` for games) don't scale deltas in this PR — the feature is a desktop-streaming tool. Easy follow-up.
- **DRM backend** would need a per-renderer clamp + source-rect adjustment to feed the hardware plane a valid in-bounds rect.
- **Host-side encoder padding** (when stream resolution doesn't match host aspect ratio, e.g. a 2160×3024 host streamed at 1440×2560 produces 272 black rows top + bottom inside the encoded frame) is outside our control — the user must match aspect by configuring stream resolution.

## Testing

Tested end-to-end on Windows D3D11VA against a portrait Sunshine host across multiple iterations:
- Direction matches user expectation (pan toward cursor).
- Pan stops cleanly at content edges (panOffset = 0 and panOffset = maxPan).
- Cursor properly tracks the visible region throughout pan.
- Smooth speed curve: gentle creep near the inner edge zone boundary, fast traversal at the very edge.
- Window resize works; windowed mode works.
- Pan halts when cursor leaves the window (windowed mode cursor escape).

CI green across all platforms (Windows x64 + arm64, macOS, Linux AppImage, Steam Link).