### PR TITLE
(Fix) macOS arm64: include arm_acle.h for Qt __yield / -Werror builds

### DIFF
--- a/globaldefs.pri
+++ b/globaldefs.pri
@@ -32,3 +32,10 @@ CONFIG(release, debug|release) {
 QMAKE_CFLAGS   += $$(CFLAGS)
 QMAKE_CXXFLAGS += $$(CXXFLAGS)
 QMAKE_LFLAGS   += $$(LDFLAGS)
+
+# Qt 6 qyieldcpu.h calls __yield() on AArch64 without including <arm_acle.h>.
+# Apple Clang then treats it as an implicit declaration; with -Werror (e.g. from
+# CXXFLAGS) the build fails. Force the ACLE header so the intrinsic is declared.
+macx:contains(QT_ARCH, arm64) {
+    QMAKE_CXXFLAGS += -include arm_acle.h
+}


### PR DESCRIPTION
## Problem

On Apple Silicon, compiling against Qt 6 (e.g. Homebrew) can fail with:

`error: implicitly declaring library function '__yield' with type 'void ()' [-Werror,-Wimplicit-function-declaration]`

from `QtCore/qyieldcpu.h`. Clang expects `__yield` to be declared via `<arm_acle.h>`; when warnings are errors (e.g. `CXXFLAGS=-Werror`, which `globaldefs.pri` forwards from the environment), the build stops.

## Solution

For **macOS** and **`QT_ARCH` containing `arm64`**, add `-include arm_acle.h` to `QMAKE_CXXFLAGS` in `globaldefs.pri` so the ACLE header is always seen before Qt headers.

Intel macOS and non-mac targets are unchanged.

## Testing

- `qmake6 moonlight-qt.pro && make release` on macOS arm64 (Homebrew Qt 6.11).
- Optional: same with `CXXFLAGS=-Werror` to confirm the previous failure is gone.

## Notes

This is a small workaround for Qt/clang interaction on AArch64; upstream Qt may adjust `qyieldcpu.h` in a future release.