### PR TITLE
Disable automatic mouse grab in windowed mode, add setting to opt-in

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1279,6 +1279,21 @@ Flickable {
                     ToolTip.visible: hovered
                     ToolTip.text: qsTr("Prevents the screensaver from starting or the display from going to sleep while streaming.")
                 }
+                CheckBox {
+                    id: mouseGrabCheck
+                    width: parent.width
+                    text: qsTr("Grab the mouse pointer in windowed mode")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.allowMouseGrabInWindowed
+                    onCheckedChanged: {
+                        StreamingPreferences.allowMouseGrabInWindowed = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Capture the mouse pointer even when not in full-screen, preventing it from leaving the application window.")
+                }
             }
         }
     }

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -50,6 +50,7 @@
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
+#define SER_MOUSEGRAB "allowmousegrab"
 #define SER_LANGUAGE "language"
 
 #define CURRENT_DEFAULT_VER 2
@@ -150,6 +151,7 @@ void StreamingPreferences::reload()
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
+    allowMouseGrabInWindowed = settings.value(SER_MOUSEGRAB, false).toBool();
     enableHdr = settings.value(SER_HDR, false).toBool();
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
                                                          static_cast<int>(CaptureSysKeysMode::CSK_OFF)).toInt());
@@ -358,6 +360,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+    settings.setValue(SER_MOUSEGRAB, allowMouseGrabInWindowed);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -143,6 +143,7 @@ public:
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
+    Q_PROPERTY(bool allowMouseGrabInWindowed MEMBER allowMouseGrabInWindowed NOTIFY allowMouseGrabInWindowedChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
 
@@ -176,6 +177,7 @@ public:
     bool reverseScrollDirection;
     bool swapFaceButtons;
     bool keepAwake;
+    bool allowMouseGrabInWindowed;
     int packetSize;
     AudioConfig audioConfig;
     VideoCodecConfig videoCodecConfig;
@@ -223,6 +225,7 @@ signals:
     void swapFaceButtonsChanged();
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
+    void allowMouseGrabInWindowedChanged();
     void languageChanged();
 
 private:

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -2202,7 +2202,9 @@ void Session::exec()
                 // As of SDL 2.0.12, SDL_RecreateWindow() doesn't carry over mouse capture
                 // or mouse hiding state to the new window. By capturing after the decoder
                 // is set up, this ensures the window re-creation is already done.
-                if (needsPostDecoderCreationCapture) {
+                if (needsPostDecoderCreationCapture &&
+                        (m_Preferences->windowMode != StreamingPreferences::WM_WINDOWED ||
+                       m_Preferences->allowMouseGrabInWindowed)) {
                     m_InputHandler->setCaptureActive(true);
                     needsPostDecoderCreationCapture = false;
                 }


### PR DESCRIPTION
By default, a new streaming session immediately grabs the mouse pointer on initialization. In windowed mode this is undesirable. You can't reposition the session window before the cursor gets captured, forcing a tab-out each time. This causes unnecessary fatigue.

This change makes windowed mode skip automatic mouse grab by default. Users can opt-in to grab in windowed mode via a new setting.

**Changes:**
- **`StreamingPreferences`**: Added `allowMouseGrabInWindowed` property (default `false`). When `true`, the session will grab the mouse even in windowed mode.
- **`Session::exec()`**: Extended the `needsPostDecoderCreationCapture` logic to skip grab in windowed mode unless `allowMouseGrabInWindowed` is enabled.
- **`SettingsView.qml`**: Added a checkbox "Grab the mouse pointer in windowed mode" in the Input Settings section.

## Test plan

- [ ] Build and launch the app, start a stream in windowed mode
- [ ] **Default behavior (unchecked)**: Verify the mouse pointer is NOT grabbed — you can click outside the window and move the window freely
- [ ] **Windowed mode with grab enabled**: Check the checkbox, reconnect the stream, verify the mouse pointer is captured within the application window
- [ ] **Fullscreen/fdesktop modes (regardless of setting)**: Verify mouse capture still works automatically in fullscreen modes
- [ ] **Persistence**: Toggle the checkbox, restart the app, verify the setting persists correctly