### PR TITLE
Add outline to stream overlay text

### DIFF
--- a/app/streaming/video/overlaymanager.cpp
+++ b/app/streaming/video/overlaymanager.cpp
@@ -151,11 +151,15 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
         (void**)&m_Overlays[type].surface,
         m_Overlays[type].enabled ?
             // The _Wrapped variant is required for line breaks to work
-            TTF_RenderText_Blended_Wrapped(m_Overlays[type].font,
-                                           m_Overlays[type].text,
-                                           m_Overlays[type].color,
-                                           1024)
+	    RenderTextOutlinedWrapped(m_Overlays[type].font,
+		                      m_Overlays[type].text,
+				      m_Overlays[type].color,
+				      {0, 0, 0, 255},
+				      4,
+				      1024)
             : nullptr);
+
+        //newSurface);
 
     // Notify the renderer
     m_Renderer->notifyOverlayUpdated(type);
@@ -165,3 +169,22 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
         SDL_FreeSurface(oldSurface);
     }
 }
+
+SDL_Surface* OverlayManager::RenderTextOutlinedWrapped(TTF_Font* font, const char* text, SDL_Color textColor, SDL_Color outlineColor, int outlineWidth, int wrapWidth) {
+	// Draw text twice, but outline is a bit bigger
+	int oldOutline = TTF_GetFontOutline(font);
+	TTF_SetFontOutline(font, outlineWidth);
+	auto outlineSurface = TTF_RenderText_Blended_Wrapped(font, text, outlineColor, wrapWidth);
+	TTF_SetFontOutline(font, 0);
+	auto textSurface = TTF_RenderText_Blended_Wrapped(font, text, textColor, wrapWidth);
+	TTF_SetFontOutline(font, oldOutline);
+
+	// Merge the texts
+	SDL_Rect dst = { outlineWidth, outlineWidth, textSurface->w, textSurface->h };
+	SDL_BlitSurface(textSurface, nullptr, outlineSurface, &dst);
+
+	SDL_FreeSurface(textSurface);
+	return outlineSurface;
+}
+
+

--- a/app/streaming/video/overlaymanager.cpp
+++ b/app/streaming/video/overlaymanager.cpp
@@ -171,6 +171,10 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
 }
 
 SDL_Surface* OverlayManager::RenderTextOutlinedWrapped(TTF_Font* font, const char* text, SDL_Color textColor, SDL_Color outlineColor, int outlineWidth, int wrapWidth) {
+	if (text == nullptr || text[0] == '\0') {
+		return nullptr;
+	}
+
 	// Draw text twice, but outline is a bit bigger
 	int oldOutline = TTF_GetFontOutline(font);
 	TTF_SetFontOutline(font, outlineWidth);
@@ -178,6 +182,12 @@ SDL_Surface* OverlayManager::RenderTextOutlinedWrapped(TTF_Font* font, const cha
 	TTF_SetFontOutline(font, 0);
 	auto textSurface = TTF_RenderText_Blended_Wrapped(font, text, textColor, wrapWidth);
 	TTF_SetFontOutline(font, oldOutline);
+
+	if (outlineSurface == nullptr || textSurface == nullptr) {
+		if (outlineSurface) SDL_FreeSurface(outlineSurface);
+		if (textSurface) SDL_FreeSurface(textSurface);
+		return nullptr;
+	}
 
 	// Merge the texts
 	SDL_Rect dst = { outlineWidth, outlineWidth, textSurface->w, textSurface->h };

--- a/app/streaming/video/overlaymanager.cpp
+++ b/app/streaming/video/overlaymanager.cpp
@@ -151,15 +151,13 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
         (void**)&m_Overlays[type].surface,
         m_Overlays[type].enabled ?
             // The _Wrapped variant is required for line breaks to work
-	    RenderTextOutlinedWrapped(m_Overlays[type].font,
-		                      m_Overlays[type].text,
-				      m_Overlays[type].color,
-				      {0, 0, 0, 255},
-				      4,
-				      1024)
+            RenderTextOutlinedWrapped(m_Overlays[type].font,
+                                      m_Overlays[type].text,
+                                      m_Overlays[type].color,
+                                      {0, 0, 0, 255},
+                                      4,
+                                      1024)
             : nullptr);
-
-        //newSurface);
 
     // Notify the renderer
     m_Renderer->notifyOverlayUpdated(type);
@@ -171,30 +169,30 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
 }
 
 SDL_Surface* OverlayManager::RenderTextOutlinedWrapped(TTF_Font* font, const char* text, SDL_Color textColor, SDL_Color outlineColor, int outlineWidth, int wrapWidth) {
-	if (text == nullptr || text[0] == '\0') {
-		return nullptr;
-	}
+    if (text == nullptr || text[0] == '\0') {
+        return nullptr;
+    }
 
-	// Draw text twice, but outline is a bit bigger
-	int oldOutline = TTF_GetFontOutline(font);
-	TTF_SetFontOutline(font, outlineWidth);
-	auto outlineSurface = TTF_RenderText_Blended_Wrapped(font, text, outlineColor, wrapWidth);
-	TTF_SetFontOutline(font, 0);
-	auto textSurface = TTF_RenderText_Blended_Wrapped(font, text, textColor, wrapWidth);
-	TTF_SetFontOutline(font, oldOutline);
+    // Draw text twice, but outline is a bit bigger
+    int oldOutline = TTF_GetFontOutline(font);
+    TTF_SetFontOutline(font, outlineWidth);
+    auto outlineSurface = TTF_RenderText_Blended_Wrapped(font, text, outlineColor, wrapWidth);
+    TTF_SetFontOutline(font, 0);
+    auto textSurface = TTF_RenderText_Blended_Wrapped(font, text, textColor, wrapWidth);
+    TTF_SetFontOutline(font, oldOutline);
 
-	if (outlineSurface == nullptr || textSurface == nullptr) {
-		if (outlineSurface) SDL_FreeSurface(outlineSurface);
-		if (textSurface) SDL_FreeSurface(textSurface);
-		return nullptr;
-	}
+    if (outlineSurface == nullptr || textSurface == nullptr) {
+        SDL_FreeSurface(outlineSurface);
+        SDL_FreeSurface(textSurface);
+        return nullptr;
+    }
 
-	// Merge the texts
-	SDL_Rect dst = { outlineWidth, outlineWidth, textSurface->w, textSurface->h };
-	SDL_BlitSurface(textSurface, nullptr, outlineSurface, &dst);
+    // Merge the texts
+    SDL_Rect dst = { outlineWidth, outlineWidth, textSurface->w, textSurface->h };
+    SDL_BlitSurface(textSurface, nullptr, outlineSurface, &dst);
 
-	SDL_FreeSurface(textSurface);
-	return outlineSurface;
+    SDL_FreeSurface(textSurface);
+    return outlineSurface;
 }
 
 

--- a/app/streaming/video/overlaymanager.h
+++ b/app/streaming/video/overlaymanager.h
@@ -41,6 +41,7 @@ public:
 
 private:
     void notifyOverlayUpdated(OverlayType type);
+    SDL_Surface* RenderTextOutlinedWrapped(TTF_Font* font, const char* text, SDL_Color textColor, SDL_Color outlineColor, int outlineWidth, int wrapWidth);
 
     struct {
         bool enabled;


### PR DESCRIPTION
Hi, this fixes issue #1877.

Although that issue suggest using text shadows, I figured that drawing an outline is simpler and equally effective. I settled for an outline of 4px width. Thinner outlines were okay on 1080p screens, but only marginally improved legibility on my 43" 4K display.

I also noticed that there is a similar PR #1606 which solves this issue by putting a transparent black box behind all the text. However, that box is larger than the text itself, which unneccessarily hinders visibility where there is no text.

Below are some screenshots. The thumbnails are not that legible, so you should look at them in fullscreen to get a sense of how a user will perceive the outline.

1080p (The statistics show it's a 4K stream, but it's played back on a 1080p screen):
<img width="1920" height="1080" alt="4px-border-1080p" src="https://github.com/user-attachments/assets/733529a4-5c81-4f1a-9dd9-f4ce4c833438" />

4K:
<img width="3840" height="2160" alt="4px-border-4k" src="https://github.com/user-attachments/assets/5f53caf0-c067-41d7-975b-54285700599c" />

I look forward to hearing from you soon :)