### PR TITLE
Fix keyboard and gamepad settings navigation on macOS

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,4 +1,5 @@
 #include <QGuiApplication>
+#include <QStyleHints>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QIcon>
@@ -752,6 +753,16 @@ int main(int argc, char *argv[])
     }
 
     QGuiApplication app(argc, argv);
+
+#ifdef Q_OS_DARWIN
+    // macOS defaults "Keyboard navigation" to text fields and lists only, which
+    // prevents Tab (and the gamepad navigation that synthesizes it) from moving
+    // focus between non-text controls on the settings page. Force Tab to reach
+    // all controls so keyboard and gamepad UI navigation work without requiring
+    // the user to enable a system accessibility setting. Other platforms already
+    // default to this behavior.
+    app.styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
+#endif
 
 #ifdef Q_OS_UNIX
     // Register signal handlers to arbitrate between SDL and Qt.


### PR DESCRIPTION
On macOS, "Keyboard navigation" (System Settings → Keyboard) defaults to moving Tab focus between text fields and lists only. Moonlight's settings page is navigated with Tab/Shift+Tab — and `SdlGamepadKeyNavigation` synthesizes those keys for D-pad input — so on a default macOS setup, focus can't leave the first control (the resolution combo box). Keyboard and gamepad users can open Settings but can't move between controls.

This sets the tab focus behavior to `Qt::TabFocusAllControls` on macOS (guarded by `Q_OS_DARWIN`), so Tab reaches every control regardless of the system setting. Other platforms already default to this and are unaffected. Keyboard-only users can then operate the settings page without first discovering and enabling a macOS accessibility setting.

## Testing

- Built on macOS (arm64, Qt 6.11.1).
- With "Keyboard navigation" at its default (off), Tab/Shift+Tab now move through all settings controls. Before the change, focus stayed pinned to the resolution combo box.
- No regression: the PC grid/toolbar and dialog buttons still navigate as before.
