### PR TITLE
Add adaptive bitrate streaming for Sunshine hosts

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -192,6 +192,7 @@ SOURCES += \
     streaming/input/mouse.cpp \
     streaming/input/reltouch.cpp \
     streaming/session.cpp \
+    streaming/adaptivebitrateservice.cpp \
     streaming/audio/audio.cpp \
     streaming/audio/renderers/sdlaud.cpp \
     gui/computermodel.cpp \
@@ -229,6 +230,7 @@ HEADERS += \
     settings/streamingpreferences.h \
     streaming/input/input.h \
     streaming/session.h \
+    streaming/adaptivebitrateservice.h \
     streaming/audio/renderers/renderer.h \
     streaming/audio/renderers/sdl.h \
     gui/computermodel.h \

--- a/app/backend/nvhttp.cpp
+++ b/app/backend/nvhttp.cpp
@@ -11,9 +11,13 @@
 #include <QImageReader>
 #include <QtEndian>
 #include <QNetworkProxy>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 
 #define FAST_FAIL_TIMEOUT_MS 2000
 #define REQUEST_TIMEOUT_MS 5000
+#define ABR_TIMEOUT_MS 10000
 #define LAUNCH_TIMEOUT_MS 120000
 #define RESUME_TIMEOUT_MS 30000
 #define QUIT_TIMEOUT_MS 30000
@@ -266,6 +270,158 @@ NvHTTP::quitApp()
         // that they can't kill someone else's stream.
         throw GfeHttpResponseException(599, "");
     }
+}
+
+bool
+NvHTTP::setBitrate(int bitrateKbps)
+{
+    QString response = openConnectionToString(m_BaseUrlHttps,
+                                            "bitrate",
+                                            QString("bitrate=%1").arg(bitrateKbps),
+                                            ABR_TIMEOUT_MS,
+                                            NvLogLevel::NVLL_ERROR);
+    return getXmlString(response, "bitrate") != "0";
+}
+
+QString
+NvHTTP::abrGet(const QString& pathSegments)
+{
+    QUrl url(m_BaseUrlHttps);
+    url.setPath("/" + pathSegments);
+
+    QNetworkRequest request(url);
+    request.setSslConfiguration(IdentityManager::get()->getSslConfig());
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+    request.setAttribute(QNetworkRequest::ConnectionCacheExpiryTimeoutSecondsAttribute, 0);
+#endif
+
+    auto sslErrorsConnection = connect(m_Nam, &QNetworkAccessManager::sslErrors, this, &NvHTTP::handleSslErrors);
+    QNetworkReply* reply = m_Nam->get(request);
+
+    QEventLoop loop;
+    connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, &loop, &QEventLoop::quit);
+    QTimer::singleShot(ABR_TIMEOUT_MS, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    disconnect(sslErrorsConnection);
+
+    QString ret;
+    if (reply->error() == QNetworkReply::NoError) {
+        ret = QString::fromUtf8(reply->readAll());
+    }
+    delete reply;
+    return ret;
+}
+
+QString
+NvHTTP::abrPost(const QString& pathSegments, const QByteArray& payload)
+{
+    QUrl url(m_BaseUrlHttps);
+    url.setPath("/" + pathSegments);
+
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json; charset=utf-8");
+    request.setSslConfiguration(IdentityManager::get()->getSslConfig());
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+    request.setAttribute(QNetworkRequest::ConnectionCacheExpiryTimeoutSecondsAttribute, 0);
+#endif
+
+    auto sslErrorsConnection = connect(m_Nam, &QNetworkAccessManager::sslErrors, this, &NvHTTP::handleSslErrors);
+    QNetworkReply* reply = m_Nam->post(request, payload);
+
+    QEventLoop loop;
+    connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, &loop, &QEventLoop::quit);
+    QTimer::singleShot(ABR_TIMEOUT_MS, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    disconnect(sslErrorsConnection);
+
+    QString ret;
+    if (reply->error() == QNetworkReply::NoError) {
+        ret = QString::fromUtf8(reply->readAll());
+    }
+    delete reply;
+    return ret;
+}
+
+AbrCapabilities
+NvHTTP::getAbrCapabilities()
+{
+    QString body = abrGet("api/abr/capabilities");
+    if (body.isEmpty()) {
+        return {false, 0, {}};
+    }
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(body.toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isObject()) {
+        return {false, 0, {}};
+    }
+
+    QJsonObject json = doc.object();
+    QStringList features;
+    QJsonArray featureArray = json.value("features").toArray();
+    for (const QJsonValue& feature : featureArray) {
+        features.append(feature.toString());
+    }
+
+    return {
+        json.value("supported").toBool(false),
+        json.value("version").toInt(0),
+        features
+    };
+}
+
+bool
+NvHTTP::setAbrMode(const AbrConfig& config)
+{
+    QJsonObject payload;
+    payload.insert("enabled", config.enabled);
+    payload.insert("minBitrate", config.minBitrate);
+    payload.insert("maxBitrate", config.maxBitrate);
+    payload.insert("mode", config.mode);
+
+    return !abrPost("api/abr", QJsonDocument(payload).toJson(QJsonDocument::Compact)).isEmpty();
+}
+
+std::optional<AbrAction>
+NvHTTP::reportNetworkFeedback(const NetworkFeedback& feedback)
+{
+    QJsonObject payload;
+    payload.insert("packetLoss", static_cast<double>(feedback.packetLoss));
+    payload.insert("rttMs", feedback.rttMs);
+    payload.insert("decodeFps", static_cast<double>(feedback.decodeFps));
+    payload.insert("droppedFrames", feedback.droppedFrames);
+    payload.insert("currentBitrate", feedback.currentBitrate);
+
+    QString body = abrPost("api/abr/feedback", QJsonDocument(payload).toJson(QJsonDocument::Compact));
+    if (body.isEmpty()) {
+        return std::nullopt;
+    }
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(body.toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isObject()) {
+        return std::nullopt;
+    }
+
+    QJsonObject json = doc.object();
+    AbrAction action;
+    if (json.contains("newBitrate")) {
+        action.newBitrate = json.value("newBitrate").toInt();
+    }
+    if (json.contains("reason")) {
+        action.reason = json.value("reason").toString();
+    }
+    return action;
 }
 
 QVector<NvDisplayMode>

--- a/app/backend/nvhttp.h
+++ b/app/backend/nvhttp.h
@@ -10,6 +10,34 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 
+#include <optional>
+
+struct AbrCapabilities {
+    bool supported;
+    int version;
+    QStringList features;
+};
+
+struct AbrConfig {
+    bool enabled;
+    int minBitrate;
+    int maxBitrate;
+    QString mode;
+};
+
+struct NetworkFeedback {
+    float packetLoss;
+    int rttMs;
+    float decodeFps;
+    int droppedFrames;
+    int currentBitrate;
+};
+
+struct AbrAction {
+    std::optional<int> newBitrate;
+    std::optional<QString> reason;
+};
+
 class NvComputer;
 
 class NvDisplayMode
@@ -182,6 +210,18 @@ public:
     QVector<NvDisplayMode>
     getDisplayModeList(QString serverInfo);
 
+    bool
+    setBitrate(int bitrateKbps);
+
+    AbrCapabilities
+    getAbrCapabilities();
+
+    bool
+    setAbrMode(const AbrConfig& config);
+
+    std::optional<AbrAction>
+    reportNetworkFeedback(const NetworkFeedback& feedback);
+
     QUrl m_BaseUrlHttp;
     QUrl m_BaseUrlHttps;
 private:
@@ -194,6 +234,12 @@ private:
                    QString arguments,
                    int timeoutMs,
                    NvLogLevel logLevel);
+
+    QString
+    abrGet(const QString& pathSegments);
+
+    QString
+    abrPost(const QString& pathSegments, const QByteArray& payload);
 
     NvAddress m_Address;
     QNetworkAccessManager* m_Nam;

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1703,6 +1703,51 @@ Flickable {
                 }
 
                 CheckBox {
+                    id: enableAdaptiveBitrate
+                    width: parent.width
+                    text: qsTr("Adaptive bitrate")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.enableAdaptiveBitrate
+                    onCheckedChanged: {
+                        StreamingPreferences.enableAdaptiveBitrate = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Automatically adjust bitrate based on packet loss and latency. Uses Sunshine server-side ABR when available, otherwise falls back to a local controller.")
+                }
+
+                Label {
+                    width: parent.width
+                    visible: enableAdaptiveBitrate.checked
+                    text: qsTr("ABR mode:")
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                }
+
+                ComboBox {
+                    id: abrModeCombo
+                    width: parent.width
+                    visible: enableAdaptiveBitrate.checked
+                    model: [
+                        { text: qsTr("Quality"), value: 0 },
+                        { text: qsTr("Balanced"), value: 1 },
+                        { text: qsTr("Low latency"), value: 2 }
+                    ]
+                    textRole: "text"
+                    currentIndex: StreamingPreferences.abrMode
+                    onActivated: {
+                        StreamingPreferences.abrMode = model[currentIndex].value
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Quality prefers higher bitrate. Low latency drops faster on packet loss.")
+                }
+
+                CheckBox {
                     id: enableMdns
                     width: parent.width
                     text: qsTr("Automatically find PCs on the local network (Recommended)")

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -17,6 +17,8 @@
 #define SER_BITRATE "bitrate"
 #define SER_UNLOCK_BITRATE "unlockbitrate"
 #define SER_AUTOADJUSTBITRATE "autoadjustbitrate"
+#define SER_ENABLEADAPTIVEBITRATE "enableadaptivebitrate"
+#define SER_ABRMODE "abrmode"
 #define SER_FULLSCREEN "fullscreen"
 #define SER_VSYNC "vsync"
 #define SER_GAMEOPTS "gameopts"
@@ -128,6 +130,9 @@ void StreamingPreferences::reload()
     bitrateKbps = settings.value(SER_BITRATE, getDefaultBitrate(width, height, fps, enableYUV444)).toInt();
     unlockBitrate = settings.value(SER_UNLOCK_BITRATE, false).toBool();
     autoAdjustBitrate = settings.value(SER_AUTOADJUSTBITRATE, true).toBool();
+    enableAdaptiveBitrate = settings.value(SER_ENABLEADAPTIVEBITRATE, false).toBool();
+    abrMode = static_cast<AbrMode>(settings.value(SER_ABRMODE,
+                                                   static_cast<int>(AbrMode::ABR_BALANCED)).toInt());
     enableVsync = settings.value(SER_VSYNC, true).toBool();
     gameOptimizations = settings.value(SER_GAMEOPTS, true).toBool();
     playAudioOnHost = settings.value(SER_HOSTAUDIO, false).toBool();
@@ -326,6 +331,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_BITRATE, bitrateKbps);
     settings.setValue(SER_UNLOCK_BITRATE, unlockBitrate);
     settings.setValue(SER_AUTOADJUSTBITRATE, autoAdjustBitrate);
+    settings.setValue(SER_ENABLEADAPTIVEBITRATE, enableAdaptiveBitrate);
+    settings.setValue(SER_ABRMODE, static_cast<int>(abrMode));
     settings.setValue(SER_VSYNC, enableVsync);
     settings.setValue(SER_GAMEOPTS, gameOptimizations);
     settings.setValue(SER_HOSTAUDIO, playAudioOnHost);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -108,12 +108,22 @@ public:
     };
     Q_ENUM(CaptureSysKeysMode);
 
+    enum AbrMode
+    {
+        ABR_QUALITY,
+        ABR_BALANCED,
+        ABR_LOW_LATENCY,
+    };
+    Q_ENUM(AbrMode);
+
     Q_PROPERTY(int width MEMBER width NOTIFY displayModeChanged)
     Q_PROPERTY(int height MEMBER height NOTIFY displayModeChanged)
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
     Q_PROPERTY(int bitrateKbps MEMBER bitrateKbps NOTIFY bitrateChanged)
     Q_PROPERTY(bool unlockBitrate MEMBER unlockBitrate NOTIFY unlockBitrateChanged)
     Q_PROPERTY(bool autoAdjustBitrate MEMBER autoAdjustBitrate NOTIFY autoAdjustBitrateChanged)
+    Q_PROPERTY(bool enableAdaptiveBitrate MEMBER enableAdaptiveBitrate NOTIFY enableAdaptiveBitrateChanged)
+    Q_PROPERTY(AbrMode abrMode MEMBER abrMode NOTIFY abrModeChanged)
     Q_PROPERTY(bool enableVsync MEMBER enableVsync NOTIFY enableVsyncChanged)
     Q_PROPERTY(bool gameOptimizations MEMBER gameOptimizations NOTIFY gameOptimizationsChanged)
     Q_PROPERTY(bool playAudioOnHost MEMBER playAudioOnHost NOTIFY playAudioOnHostChanged)
@@ -155,6 +165,8 @@ public:
     int bitrateKbps;
     bool unlockBitrate;
     bool autoAdjustBitrate;
+    bool enableAdaptiveBitrate;
+    AbrMode abrMode;
     bool enableVsync;
     bool gameOptimizations;
     bool playAudioOnHost;
@@ -193,6 +205,8 @@ signals:
     void bitrateChanged();
     void unlockBitrateChanged();
     void autoAdjustBitrateChanged();
+    void enableAdaptiveBitrateChanged();
+    void abrModeChanged();
     void enableVsyncChanged();
     void gameOptimizationsChanged();
     void playAudioOnHostChanged();

--- a/app/streaming/adaptivebitrateservice.cpp
+++ b/app/streaming/adaptivebitrateservice.cpp
@@ -1,0 +1,331 @@
+#include "adaptivebitrateservice.h"
+
+#include "backend/nvhttp.h"
+
+#include <QMetaObject>
+#include <QDateTime>
+
+AdaptiveBitrateService::AdaptiveBitrateService(NvHttpFactory nvHttpFactory,
+                                               StatsProvider statsProvider,
+                                               BitrateChangedCallback onBitrateChanged,
+                                               QObject* parent) :
+    QObject(parent),
+    m_NvHttpFactory(std::move(nvHttpFactory)),
+    m_StatsProvider(std::move(statsProvider)),
+    m_OnBitrateChanged(std::move(onBitrateChanged)),
+    m_NvHttp(nullptr),
+    m_Enabled(false),
+    m_ServerSupported(false),
+    m_CurrentBitrate(0),
+    m_InitialBitrate(0),
+    m_Mode(StreamingPreferences::AbrMode::ABR_BALANCED),
+    m_MinBitrate(3000),
+    m_MaxBitrate(100000),
+    m_StableSeconds(0),
+    m_LossStreak(0),
+    m_LastAdjustWallClock(0),
+    m_LastDirection(k_DirNone),
+    m_ServerEnableRetries(0),
+    m_ServerRetryTickCounter(0),
+    m_TickCount(0)
+{
+    m_Timer.setInterval(1000);
+    m_Timer.setSingleShot(false);
+    connect(&m_Timer, &QTimer::timeout, this, &AdaptiveBitrateService::tick);
+
+    moveToThread(&m_WorkerThread);
+    m_WorkerThread.start();
+}
+
+AdaptiveBitrateService::~AdaptiveBitrateService()
+{
+    if (m_Enabled) {
+        QMetaObject::invokeMethod(this, [this]() {
+            m_Timer.stop();
+            if (m_NvHttp != nullptr) {
+                if (m_ServerSupported) {
+                    m_NvHttp->setAbrMode({false, 0, 0, abrModeToString(StreamingPreferences::AbrMode::ABR_BALANCED)});
+                }
+                if (m_CurrentBitrate != m_InitialBitrate) {
+                    applyBitrateInternal(m_NvHttp, m_InitialBitrate, QStringLiteral("restore"), QStringLiteral("local"));
+                }
+            }
+            m_Enabled = false;
+        }, Qt::BlockingQueuedConnection);
+    }
+
+    m_WorkerThread.quit();
+    m_WorkerThread.wait();
+}
+
+QString AdaptiveBitrateService::abrModeToString(StreamingPreferences::AbrMode mode)
+{
+    switch (mode) {
+    case StreamingPreferences::AbrMode::ABR_QUALITY:
+        return QStringLiteral("quality");
+    case StreamingPreferences::AbrMode::ABR_LOW_LATENCY:
+        return QStringLiteral("lowLatency");
+    case StreamingPreferences::AbrMode::ABR_BALANCED:
+    default:
+        return QStringLiteral("balanced");
+    }
+}
+
+void AdaptiveBitrateService::start(int initialBitrateKbps, StreamingPreferences::AbrMode mode)
+{
+    QMetaObject::invokeMethod(this, [this, initialBitrateKbps, mode]() {
+        if (m_Enabled) {
+            return;
+        }
+
+        m_InitialBitrate = initialBitrateKbps;
+        m_CurrentBitrate = initialBitrateKbps;
+        m_Mode = mode;
+        applyModePreset(mode);
+        resetState();
+        m_Enabled = true;
+        m_TickCount = 0;
+
+        if (m_NvHttp == nullptr) {
+            m_NvHttp = m_NvHttpFactory();
+        }
+
+        QTimer::singleShot(k_StartDelaySeconds * 1000, this, &AdaptiveBitrateService::probeServerCapabilities);
+        m_Timer.start();
+
+        qInfo() << "[ABR] Starting:" << initialBitrateKbps << "kbps, mode:" << abrModeToString(mode);
+    }, Qt::QueuedConnection);
+}
+
+void AdaptiveBitrateService::stop()
+{
+    QMetaObject::invokeMethod(this, [this]() {
+        if (!m_Enabled) {
+            return;
+        }
+
+        m_Enabled = false;
+        m_Timer.stop();
+
+        if (m_NvHttp != nullptr) {
+            if (m_ServerSupported) {
+                m_NvHttp->setAbrMode({false, 0, 0, abrModeToString(StreamingPreferences::AbrMode::ABR_BALANCED)});
+            }
+            if (m_CurrentBitrate != m_InitialBitrate) {
+                applyBitrateInternal(m_NvHttp, m_InitialBitrate, QStringLiteral("restore"), QStringLiteral("local"));
+            }
+        }
+
+        qInfo() << "[ABR] Stopped, restored bitrate:" << m_InitialBitrate << "kbps";
+
+        delete m_NvHttp;
+        m_NvHttp = nullptr;
+    }, Qt::BlockingQueuedConnection);
+}
+
+QString AdaptiveBitrateService::statusText() const
+{
+    if (!m_Enabled) {
+        return QString();
+    }
+
+    QString sub;
+    if (m_ServerSupported && m_ServerEnableRetries == 0) {
+        sub = QStringLiteral("server");
+    }
+    else if (m_ServerSupported && m_ServerEnableRetries > 0) {
+        sub = QStringLiteral("connecting");
+    }
+    else {
+        sub = QStringLiteral("local");
+    }
+
+    return QStringLiteral("ABR:%1 %2M").arg(sub).arg(m_CurrentBitrate / 1000);
+}
+
+void AdaptiveBitrateService::probeServerCapabilities()
+{
+    if (!m_Enabled || m_NvHttp == nullptr) {
+        return;
+    }
+
+    try {
+        AbrCapabilities caps = m_NvHttp->getAbrCapabilities();
+        m_ServerSupported = caps.supported;
+        if (caps.supported) {
+            m_ServerEnableRetries = 1;
+        }
+        qInfo() << "[ABR] Server capabilities:" << caps.supported << "version:" << caps.version;
+    }
+    catch (const std::exception& e) {
+        qWarning() << "[ABR] Capability probe failed:" << e.what();
+    }
+}
+
+void AdaptiveBitrateService::applyModePreset(StreamingPreferences::AbrMode mode)
+{
+    switch (mode) {
+    case StreamingPreferences::AbrMode::ABR_QUALITY:
+        m_MinBitrate = qMax(5000, static_cast<int>(m_InitialBitrate * 0.5));
+        m_MaxBitrate = qMin(150000, static_cast<int>(m_InitialBitrate * 1.5));
+        break;
+    case StreamingPreferences::AbrMode::ABR_LOW_LATENCY:
+        m_MinBitrate = 2000;
+        m_MaxBitrate = static_cast<int>(m_InitialBitrate * 1.2);
+        break;
+    case StreamingPreferences::AbrMode::ABR_BALANCED:
+    default:
+        m_MinBitrate = qMax(3000, static_cast<int>(m_InitialBitrate * 0.3));
+        m_MaxBitrate = qMin(150000, m_InitialBitrate * 2);
+        break;
+    }
+}
+
+void AdaptiveBitrateService::resetState()
+{
+    m_StableSeconds = 0;
+    m_LossStreak = 0;
+    m_LastAdjustWallClock = 0;
+    m_LastDirection = k_DirNone;
+    m_ServerEnableRetries = 0;
+    m_ServerRetryTickCounter = 0;
+}
+
+void AdaptiveBitrateService::tick()
+{
+    if (!m_Enabled || m_NvHttp == nullptr) {
+        return;
+    }
+
+    if (m_TickCount++ < k_StartDelaySeconds) {
+        return;
+    }
+
+    auto stats = m_StatsProvider();
+    if (!stats.has_value()) {
+        return;
+    }
+
+    if (m_ServerSupported && m_ServerEnableRetries > 0) {
+        if (++m_ServerRetryTickCounter >= k_ServerRetryIntervalTicks) {
+            m_ServerRetryTickCounter = 0;
+            AbrConfig config;
+            config.enabled = true;
+            config.minBitrate = m_MinBitrate;
+            config.maxBitrate = m_MaxBitrate;
+            config.mode = abrModeToString(m_Mode);
+            if (m_NvHttp->setAbrMode(config)) {
+                qInfo() << "[ABR] Server ABR enabled on retry" << m_ServerEnableRetries;
+                m_ServerEnableRetries = 0;
+            }
+            else if (++m_ServerEnableRetries > k_MaxServerEnableRetries) {
+                m_ServerSupported = false;
+                qWarning() << "[ABR] Server enable failed after" << k_MaxServerEnableRetries << "retries, using local controller";
+            }
+        }
+    }
+
+    if (m_ServerSupported && m_ServerEnableRetries == 0) {
+        tickServer(m_NvHttp, stats.value());
+    }
+    else {
+        tickLocal(stats.value());
+    }
+}
+
+void AdaptiveBitrateService::tickServer(NvHTTP* http, const AbrStats& stats)
+{
+    NetworkFeedback feedback;
+    feedback.packetLoss = stats.packetLoss;
+    feedback.rttMs = stats.rttMs;
+    feedback.decodeFps = stats.decodeFps;
+    feedback.droppedFrames = stats.droppedFrames;
+    feedback.currentBitrate = m_CurrentBitrate;
+
+    std::optional<AbrAction> action = http->reportNetworkFeedback(feedback);
+    if (!action.has_value() || !action->newBitrate.has_value()) {
+        return;
+    }
+
+    int newBitrate = action->newBitrate.value();
+    if (newBitrate == m_CurrentBitrate) {
+        return;
+    }
+
+    int clamped = qBound(m_MinBitrate, newBitrate, m_MaxBitrate);
+    applyBitrateInternal(http, clamped, action->reason.value_or(QStringLiteral("server")), QStringLiteral("server"));
+}
+
+bool AdaptiveBitrateService::applyBitrateInternal(NvHTTP* http, int kbps, const QString& reason, const QString& source)
+{
+    int from = m_CurrentBitrate;
+    try {
+        if (http->setBitrate(kbps)) {
+            m_CurrentBitrate = kbps;
+            qInfo() << "[ABR][" << source << "]" << from << "kbps ->" << kbps << "kbps (" << reason << ")";
+            if (m_OnBitrateChanged) {
+                m_OnBitrateChanged(kbps, reason);
+            }
+            return true;
+        }
+    }
+    catch (const std::exception& e) {
+        qWarning() << "[ABR] setBitrate failed:" << e.what();
+    }
+    return false;
+}
+
+void AdaptiveBitrateService::tickLocal(const AbrStats& stats)
+{
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    int cooldown = (m_Mode == StreamingPreferences::AbrMode::ABR_LOW_LATENCY) ? 1500 : 2000;
+    if (now - m_LastAdjustWallClock < cooldown) {
+        return;
+    }
+
+    double newBitrate = m_CurrentBitrate;
+    QString reason;
+
+    if (stats.packetLoss > 5.0f) {
+        newBitrate = m_CurrentBitrate * 0.7;
+        reason = QStringLiteral("loss=%1% emergency").arg(stats.packetLoss, 0, 'f', 1);
+        m_StableSeconds = 0;
+        m_LossStreak++;
+    }
+    else if (stats.packetLoss > 2.0f) {
+        m_LossStreak++;
+        if (m_LossStreak >= 2) {
+            newBitrate = m_CurrentBitrate * 0.9;
+            reason = QStringLiteral("loss=%1% sustained").arg(stats.packetLoss, 0, 'f', 1);
+            m_StableSeconds = 0;
+        }
+    }
+    else if (stats.packetLoss > 0.5f) {
+        m_LossStreak++;
+        m_StableSeconds = 0;
+        if (m_LossStreak >= 4) {
+            newBitrate = m_CurrentBitrate * 0.95;
+            reason = QStringLiteral("loss=%1% mild").arg(stats.packetLoss, 0, 'f', 1);
+        }
+    }
+    else {
+        m_LossStreak = 0;
+        m_StableSeconds++;
+        int probeThreshold = (m_Mode == StreamingPreferences::AbrMode::ABR_QUALITY) ? 3 : 5;
+        if (m_StableSeconds >= probeThreshold && m_CurrentBitrate < m_MaxBitrate) {
+            double step = (m_LastDirection == k_DirDown) ? 1.02 : 1.05;
+            newBitrate = m_CurrentBitrate * step;
+            reason = QStringLiteral("stable %1s probe").arg(m_StableSeconds);
+            m_StableSeconds = 0;
+        }
+    }
+
+    int target = qBound(m_MinBitrate, static_cast<int>(newBitrate), m_MaxBitrate);
+    if (target != m_CurrentBitrate) {
+        int direction = (target > m_CurrentBitrate) ? k_DirUp : k_DirDown;
+        if (applyBitrateInternal(m_NvHttp, target, reason, QStringLiteral("local"))) {
+            m_LastDirection = direction;
+            m_LastAdjustWallClock = now;
+        }
+    }
+}

--- a/app/streaming/adaptivebitrateservice.h
+++ b/app/streaming/adaptivebitrateservice.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "settings/streamingpreferences.h"
+
+#include <QObject>
+#include <QThread>
+#include <QTimer>
+#include <functional>
+#include <optional>
+
+class NvHTTP;
+
+class AdaptiveBitrateService : public QObject
+{
+    Q_OBJECT
+
+public:
+    struct AbrStats {
+        float packetLoss;
+        int rttMs;
+        float decodeFps;
+        int droppedFrames;
+    };
+
+    using NvHttpFactory = std::function<NvHTTP*()>;
+    using StatsProvider = std::function<std::optional<AbrStats>()>;
+    using BitrateChangedCallback = std::function<void(int bitrateKbps, const QString& reason)>;
+
+    AdaptiveBitrateService(NvHttpFactory nvHttpFactory,
+                           StatsProvider statsProvider,
+                           BitrateChangedCallback onBitrateChanged,
+                           QObject* parent = nullptr);
+    ~AdaptiveBitrateService() override;
+
+    void start(int initialBitrateKbps, StreamingPreferences::AbrMode mode);
+    void stop();
+
+    bool isEnabled() const
+    {
+        return m_Enabled;
+    }
+
+    QString statusText() const;
+
+private slots:
+    void probeServerCapabilities();
+    void tick();
+
+private:
+    void applyModePreset(StreamingPreferences::AbrMode mode);
+    void resetState();
+    void tickServer(NvHTTP* http, const AbrStats& stats);
+    void tickLocal(const AbrStats& stats);
+    bool applyBitrateInternal(NvHTTP* http, int kbps, const QString& reason, const QString& source);
+    static QString abrModeToString(StreamingPreferences::AbrMode mode);
+
+    NvHttpFactory m_NvHttpFactory;
+    StatsProvider m_StatsProvider;
+    BitrateChangedCallback m_OnBitrateChanged;
+
+    QThread m_WorkerThread;
+    QTimer m_Timer;
+
+    NvHTTP* m_NvHttp;
+    bool m_Enabled;
+    bool m_ServerSupported;
+    int m_CurrentBitrate;
+    int m_InitialBitrate;
+    StreamingPreferences::AbrMode m_Mode;
+    int m_MinBitrate;
+    int m_MaxBitrate;
+
+    int m_StableSeconds;
+    int m_LossStreak;
+    qint64 m_LastAdjustWallClock;
+    int m_LastDirection;
+
+    int m_ServerEnableRetries;
+    int m_ServerRetryTickCounter;
+    int m_TickCount;
+
+    static constexpr int k_StartDelaySeconds = 3;
+    static constexpr int k_ServerRetryIntervalTicks = 5;
+    static constexpr int k_MaxServerEnableRetries = 10;
+    static constexpr int k_DirNone = 0;
+    static constexpr int k_DirUp = 1;
+    static constexpr int k_DirDown = -1;
+};

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1,6 +1,8 @@
 #include "session.h"
 #include "settings/streamingpreferences.h"
 #include "streaming/streamutils.h"
+#include "streaming/adaptivebitrateservice.h"
+#include "backend/nvhttp.h"
 #include "backend/richpresencemanager.h"
 
 #include <Limelight.h>
@@ -38,6 +40,7 @@
 #include <QPainter>
 #include <QImage>
 #include <QGuiApplication>
+#include <optional>
 #include <QCursor>
 #include <QScreen>
 
@@ -567,7 +570,8 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_OpusDecoder(nullptr),
       m_AudioRenderer(nullptr),
       m_AudioSampleCount(0),
-      m_DropAudioEndTime(0)
+      m_DropAudioEndTime(0),
+      m_AdaptiveBitrateService(nullptr)
 {
 }
 
@@ -1940,6 +1944,8 @@ void Session::exec()
     // Toggle the stats overlay if requested by the user
     m_OverlayManager.setOverlayState(Overlay::OverlayDebug, m_Preferences->showPerformanceOverlay);
 
+    startAdaptiveBitrateIfEnabled();
+
     // Switch to async logging mode when we enter the SDL loop
     StreamUtils::enterAsyncLoggingMode();
 
@@ -2293,6 +2299,8 @@ DispatchDeferredCleanup:
     // Switch back to synchronous logging mode
     StreamUtils::exitAsyncLoggingMode();
 
+    stopAdaptiveBitrate();
+
     // Uncapture the mouse and hide the window immediately,
     // so we can return to the Qt GUI ASAP.
     m_InputHandler->setCaptureActive(false);
@@ -2358,4 +2366,56 @@ DispatchDeferredCleanup:
     // When it is complete, it will release our s_ActiveSessionSemaphore
     // reference.
     QThreadPool::globalInstance()->start(new DeferredSessionCleanupTask(this));
+}
+
+void Session::startAdaptiveBitrateIfEnabled()
+{
+    if (!m_Preferences->enableAdaptiveBitrate) {
+        return;
+    }
+
+    if (m_AdaptiveBitrateService != nullptr) {
+        return;
+    }
+
+    Session* session = this;
+    m_AdaptiveBitrateService = new AdaptiveBitrateService(
+        [session]() {
+            return new NvHTTP(session->m_Computer);
+        },
+        [session]() -> std::optional<AdaptiveBitrateService::AbrStats> {
+            ADAPTIVE_BITRATE_STATS stats = {};
+            SDL_LockMutex(session->m_DecoderLock);
+            if (session->m_VideoDecoder == nullptr ||
+                !session->m_VideoDecoder->getAdaptiveBitrateStats(&stats) ||
+                !stats.valid) {
+                SDL_UnlockMutex(session->m_DecoderLock);
+                return std::nullopt;
+            }
+            SDL_UnlockMutex(session->m_DecoderLock);
+
+            return AdaptiveBitrateService::AbrStats{
+                stats.packetLossPercent,
+                stats.rttMs,
+                stats.totalFps,
+                stats.droppedFrames
+            };
+        },
+        [session](int bitrateKbps, const QString& reason) {
+            Q_UNUSED(reason);
+            session->m_StreamConfig.bitrate = bitrateKbps;
+        });
+
+    m_AdaptiveBitrateService->start(m_StreamConfig.bitrate, m_Preferences->abrMode);
+}
+
+void Session::stopAdaptiveBitrate()
+{
+    if (m_AdaptiveBitrateService == nullptr) {
+        return;
+    }
+
+    m_AdaptiveBitrateService->stop();
+    delete m_AdaptiveBitrateService;
+    m_AdaptiveBitrateService = nullptr;
 }

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -11,6 +11,8 @@
 #include "audio/renderers/renderer.h"
 #include "video/overlaymanager.h"
 
+class AdaptiveBitrateService;
+
 class SupportedVideoFormatList : public QList<int>
 {
 public:
@@ -171,6 +173,10 @@ private:
 
     void updateOptimalWindowDisplayMode();
 
+    void startAdaptiveBitrateIfEnabled();
+
+    void stopAdaptiveBitrate();
+
     enum class DecoderAvailability {
         None,
         Software,
@@ -280,6 +286,8 @@ private:
     Uint32 m_DropAudioEndTime;
 
     Overlay::OverlayManager m_OverlayManager;
+
+    AdaptiveBitrateService* m_AdaptiveBitrateService;
 
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;

--- a/app/streaming/video/decoder.h
+++ b/app/streaming/video/decoder.h
@@ -61,6 +61,14 @@ typedef struct _WINDOW_STATE_CHANGE_INFO {
     int displayIndex;
 } WINDOW_STATE_CHANGE_INFO, *PWINDOW_STATE_CHANGE_INFO;
 
+typedef struct _ADAPTIVE_BITRATE_STATS {
+    float packetLossPercent;
+    int rttMs;
+    float totalFps;
+    int droppedFrames;
+    bool valid;
+} ADAPTIVE_BITRATE_STATS, *PADAPTIVE_BITRATE_STATS;
+
 class IVideoDecoder {
 public:
     virtual ~IVideoDecoder() {}
@@ -76,4 +84,9 @@ public:
     virtual void renderFrameOnMainThread() = 0;
     virtual void setHdrMode(bool enabled) = 0;
     virtual bool notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info) = 0;
+    virtual bool getAdaptiveBitrateStats(PADAPTIVE_BITRATE_STATS stats)
+    {
+        Q_UNUSED(stats);
+        return false;
+    }
 };

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -754,6 +754,31 @@ bool FFmpegVideoDecoder::completeInitialization(const AVCodec* decoder, enum AVP
     return true;
 }
 
+bool FFmpegVideoDecoder::getAdaptiveBitrateStats(PADAPTIVE_BITRATE_STATS stats)
+{
+    VIDEO_STATS combined = {};
+    addVideoStats(m_LastWndVideoStats, combined);
+    addVideoStats(m_ActiveWndVideoStats, combined);
+
+    if (combined.totalFrames == 0) {
+        stats->valid = false;
+        return false;
+    }
+
+    uint32_t rtt = 0;
+    uint32_t rttVariance = 0;
+    if (!LiGetEstimatedRttInfo(&rtt, &rttVariance)) {
+        rtt = 0;
+    }
+
+    stats->packetLossPercent = (float)combined.networkDroppedFrames / combined.totalFrames * 100.0f;
+    stats->rttMs = static_cast<int>(rtt);
+    stats->totalFps = static_cast<float>(combined.totalFps);
+    stats->droppedFrames = static_cast<int>(combined.pacerDroppedFrames);
+    stats->valid = true;
+    return true;
+}
+
 void FFmpegVideoDecoder::addVideoStats(VIDEO_STATS& src, VIDEO_STATS& dst)
 {
     dst.receivedFrames += src.receivedFrames;

--- a/app/streaming/video/ffmpeg.h
+++ b/app/streaming/video/ffmpeg.h
@@ -29,6 +29,7 @@ public:
     virtual void renderFrameOnMainThread() override;
     virtual void setHdrMode(bool enabled) override;
     virtual bool notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info) override;
+    virtual bool getAdaptiveBitrateStats(PADAPTIVE_BITRATE_STATS stats) override;
 
     virtual IFFmpegRenderer* getBackendRenderer();
 


### PR DESCRIPTION
## Summary
- Adds runtime adaptive bitrate (ABR) during active streaming sessions, ported from moonlight-vplus
- Prefers Sunshine server-side ABR (`api/abr/*` endpoints) when available; falls back to a local packet-loss controller
- Adds Settings UI toggle and mode selector (Quality / Balanced / Low latency)

## Implementation details
- **`AdaptiveBitrateService`**: 1 Hz tick loop on a background thread; probes server capabilities after a 3 s delay, then either posts network feedback to Sunshine or runs local decrease/increase logic based on frame loss %
- **`NvHTTP`**: New `setBitrate()`, `getAbrCapabilities()`, `setAbrMode()`, and `reportNetworkFeedback()` methods using Sunshine's HTTPS ABR API
- **`Session`**: Starts ABR when streaming begins (if enabled); stops and restores initial bitrate on disconnect
- **Stats**: Uses existing `VIDEO_STATS` frame-gap loss, RTT from `LiGetEstimatedRttInfo()`, and FPS from the decoder

## Test plan
- [x] Build succeeds on macOS (Qt 6.4, arm64) with `qmake6 moonlight-qt.pro && make`
- [ ] Enable "Adaptive bitrate" in Settings → Stream and start a session against a Sunshine host
- [ ] Verify `[ABR]` log lines appear and bitrate adjusts under simulated packet loss
- [ ] Verify initial bitrate is restored when the session ends
- [ ] Confirm behavior against a host without ABR API support (local fallback)


Made with [Cursor](https://cursor.com)