### PR TITLE
Expose DualSense Edge paddles

### DIFF
--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -60,11 +60,11 @@ static const char* const DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[DUALSENSE_EDGE_PADDL
     "paddle4",
 };
 
-static const char* const DUALSENSE_EDGE_PADDLE_MAPPING_VALUES[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
-    "b20",
-    "b19",
-    "b18",
-    "b17",
+static const int DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
+    20,
+    19,
+    18,
+    17,
 };
 
 const int SdlInputHandler::k_ButtonMap[] = {
@@ -123,11 +123,20 @@ static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controll
 {
 #if SDL_VERSION_ATLEAST(2, 0, 14)
     // Raw joystick button count only proves SDL can see the physical controls.
-    // The controller-button layer is what Moonlight can transmit as paddles.
-    return SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1) &&
-           SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2) &&
-           SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3) &&
-           SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4);
+    // Moonlight can only transmit the controller-button layer, and the bindings
+    // must point at SDL2's canonical Edge raw buttons to preserve physical labels.
+    for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+        SDL_GameControllerButton button = (SDL_GameControllerButton)(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 + i);
+        SDL_GameControllerButtonBind binding = SDL_GameControllerGetBindForButton(controller, button);
+
+        if (!SDL_GameControllerHasButton(controller, button) ||
+            binding.bindType != SDL_CONTROLLER_BINDTYPE_BUTTON ||
+            binding.value.button != DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[i]) {
+            return false;
+        }
+    }
+
+    return true;
 #else
     return false;
 #endif
@@ -136,7 +145,7 @@ static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controll
 static QString dualSenseEdgePaddleMappingEntry(int mappingIndex)
 {
     return QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[mappingIndex]) + ":" +
-           QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_VALUES[mappingIndex]);
+           "b" + QString::number(DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[mappingIndex]);
 }
 
 static int dualSenseEdgePaddleMappingIndex(const QString& mappingEntry)
@@ -287,7 +296,7 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         }
         else {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "DualSense Edge paddle mappings are present, but SDL did not expose the paddle controller buttons");
+                        "DualSense Edge paddle mappings are present, but SDL did not expose the expected paddle controller bindings");
         }
         SDL_free(mapping);
         return false;
@@ -306,7 +315,7 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     // bind this controller to it before sending arrival capabilities.
     else if (ret == 0 && !dualSenseEdgeHasPaddleControllerButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "DualSense Edge paddle mapping update did not expose the paddle controller buttons");
+                    "DualSense Edge paddle mapping update did not expose the expected paddle controller bindings");
         return false;
     }
     else {

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -166,6 +166,24 @@ static int dualSenseEdgePaddleMappingIndex(const QString& mappingEntry)
     return -1;
 }
 
+static int dualSenseEdgePaddleRawButtonMappingIndex(const QString& mappingEntry)
+{
+    int separatorIndex = mappingEntry.indexOf(':');
+    if (separatorIndex < 0) {
+        return -1;
+    }
+
+    QString binding = mappingEntry.mid(separatorIndex + 1);
+    for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+        QString expectedBinding = "b" + QString::number(DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[i]);
+        if (binding == expectedBinding) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
 static bool isDualSenseEdgeMappingMetadataEntry(const QString& mappingEntry)
 {
     return mappingEntry.startsWith("crc:") ||
@@ -197,14 +215,21 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
     changedMappings->clear();
 
     // Normalize existing paddle entries too, because a stale mapping can expose
-    // paddle buttons while assigning the wrong raw DualSense Edge buttons. Pull
-    // them out and reinsert the canonical block below so they never sit behind
-    // SDL metadata entries like platform: or crc:.
+    // paddle buttons while assigning the wrong raw DualSense Edge buttons. Also
+    // remove non-paddle entries that point at the Edge-only raw buttons, so one
+    // physical Edge control never reports as both a normal button and a paddle.
     for (int i = 0; i < entries.size(); i++) {
         const QString& entry = entries.at(i);
         int mappingIndex = dualSenseEdgePaddleMappingIndex(entry);
 
         if (mappingIndex < 0) {
+            mappingIndex = dualSenseEdgePaddleRawButtonMappingIndex(entry);
+            if (mappingIndex >= 0) {
+                changedMappingEntries[mappingIndex] = true;
+                hasChangedMappingEntries = true;
+                continue;
+            }
+
             updatedEntries.append(entry);
             continue;
         }

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -227,6 +227,34 @@ static int dualSenseEdgePaddleRawButtonMappingIndex(const QString& mappingEntry)
     return -1;
 }
 
+static int dualSenseEdgePaddleRawButtonIndex(int rawButton)
+{
+    for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+        if (rawButton == DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[i]) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static int dualSenseEdgeControllerButtonRawPaddleIndex(SDL_GameController* controller, Uint8 button)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    SDL_GameControllerButtonBind binding = SDL_GameControllerGetBindForButton(controller, (SDL_GameControllerButton)button);
+
+    if (binding.bindType != SDL_CONTROLLER_BINDTYPE_BUTTON) {
+        return -1;
+    }
+
+    return dualSenseEdgePaddleRawButtonIndex(binding.value.button);
+#else
+    Q_UNUSED(controller);
+    Q_UNUSED(button);
+    return -1;
+#endif
+}
+
 static bool isDualSenseEdgeMappingMetadataEntry(const QString& mappingEntry)
 {
     return mappingEntry.startsWith("crc:") ||
@@ -648,6 +676,23 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
                      "Ignoring DualSense Edge %s event without verified paddle bindings",
                      dualSenseEdgePaddleButtonName(event->button));
         return;
+    }
+    if (isDualSenseEdgeController(state->controller) &&
+        !dualSenseEdgeHasPaddleControllerButtons(state->controller)) {
+        int rawPaddleIndex = dualSenseEdgeControllerButtonRawPaddleIndex(state->controller, event->button);
+        if (rawPaddleIndex >= 0) {
+            int previousButtons = state->buttons;
+            const char* buttonName = SDL_GameControllerGetStringForButton((SDL_GameControllerButton)event->button);
+            state->buttons &= ~k_ButtonMap[event->button];
+            if (previousButtons != state->buttons && state->mouseEmulationTimer == 0) {
+                sendGamepadState(state);
+            }
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "Ignoring DualSense Edge controller button %s bound to raw %s without verified paddle bindings",
+                         buttonName != nullptr ? buttonName : "<unknown>",
+                         qPrintable(dualSenseEdgePaddleMappingEntry(rawPaddleIndex)));
+            return;
+        }
     }
 
     if (m_SwapFaceButtons) {

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -148,6 +148,49 @@ static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controll
 #endif
 }
 
+static QString dualSenseEdgePaddleBindingSummary(SDL_GameController* controller)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    QStringList bindings;
+
+    for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+        SDL_GameControllerButton button = (SDL_GameControllerButton)(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 + i);
+        SDL_GameControllerButtonBind binding = SDL_GameControllerGetBindForButton(controller, button);
+        QString value;
+
+        if (!SDL_GameControllerHasButton(controller, button)) {
+            value = "missing";
+        }
+        else {
+            switch (binding.bindType) {
+            case SDL_CONTROLLER_BINDTYPE_NONE:
+                value = "none";
+                break;
+            case SDL_CONTROLLER_BINDTYPE_BUTTON:
+                value = "b" + QString::number(binding.value.button);
+                break;
+            case SDL_CONTROLLER_BINDTYPE_AXIS:
+                value = "a" + QString::number(binding.value.axis);
+                break;
+            case SDL_CONTROLLER_BINDTYPE_HAT:
+                value = "h" + QString::number(binding.value.hat.hat) + "." + QString::number(binding.value.hat.hat_mask);
+                break;
+            default:
+                value = "unknown";
+                break;
+            }
+        }
+
+        bindings.append(QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[i]) + "=" + value);
+    }
+
+    return bindings.join(",");
+#else
+    Q_UNUSED(controller);
+    return QString::fromLatin1("unavailable before SDL 2.0.14");
+#endif
+}
+
 static QString dualSenseEdgePaddleMappingEntry(int mappingIndex)
 {
     return QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[mappingIndex]) + ":" +
@@ -327,7 +370,8 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         }
         else {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "DualSense Edge paddle mappings are present, but SDL did not expose the expected paddle controller bindings");
+                        "DualSense Edge paddle mappings are present, but SDL did not expose the expected paddle controller bindings (actual: %s)",
+                        qPrintable(dualSenseEdgePaddleBindingSummary(controller)));
         }
         SDL_free(mapping);
         return false;
@@ -346,7 +390,8 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     // bind this controller to it before sending arrival capabilities.
     else if (ret == 0 && !dualSenseEdgeHasPaddleControllerButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "DualSense Edge paddle mapping update did not expose the expected paddle controller bindings");
+                    "DualSense Edge paddle mapping update did not expose the expected paddle controller bindings (actual: %s)",
+                    qPrintable(dualSenseEdgePaddleBindingSummary(controller)));
         return false;
     }
     else {
@@ -910,7 +955,8 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
                         "Reopened DualSense Edge after adding paddle mappings");
             if (!dualSenseEdgeHasPaddleControllerButtons(controller)) {
                 SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                            "DualSense Edge paddle mapping add did not expose the expected paddle controller bindings");
+                            "DualSense Edge paddle mapping add did not expose the expected paddle controller bindings (actual: %s)",
+                            qPrintable(dualSenseEdgePaddleBindingSummary(controller)));
             }
         }
 
@@ -1094,11 +1140,12 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
 
         if (isDualSenseEdge) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                        "DualSense Edge arrival support: buttons=%d supportedButtonFlags=0x%08x paddle/Fn=0x%08x capabilities=0x%08x",
+                        "DualSense Edge arrival support: buttons=%d supportedButtonFlags=0x%08x paddle/Fn=0x%08x capabilities=0x%08x bindings=%s",
                         dualSenseEdgeButtonCount,
                         (unsigned int)supportedButtonFlags,
                         (unsigned int)(supportedButtonFlags & DUALSENSE_EDGE_PADDLE_FLAGS),
-                        (unsigned int)capabilities);
+                        (unsigned int)capabilities,
+                        qPrintable(dualSenseEdgePaddleBindingSummary(state->controller)));
         }
 
         LiSendControllerArrivalEvent(state->index, m_GamepadMask, type, supportedButtonFlags, capabilities);

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -121,15 +121,20 @@ static int dualSenseEdgeJoystickButtonCount(SDL_GameController* controller)
     return joystick != nullptr ? SDL_JoystickNumButtons(joystick) : -1;
 }
 
+static bool dualSenseEdgeHasSdl3VersionHint()
+{
+    const char* sdl3Version = SDL_GetHint("SDL3_VERSION");
+    return sdl3Version != nullptr && sdl3Version[0] != '\0';
+}
+
 static bool dualSenseEdgeUsesSdl3CompatMappings(SDL_GameController* controller)
 {
-    if (SDL_GetHint("SDL3_VERSION") != nullptr) {
+    if (dualSenseEdgeHasSdl3VersionHint()) {
         return true;
     }
 
     int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
-    return buttonCount >= DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS &&
-           buttonCount < DUALSENSE_EDGE_SDL2_MIN_BUTTONS;
+    return buttonCount == DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS;
 }
 
 static const char* dualSenseEdgeRawMappingName(SDL_GameController* controller)
@@ -148,7 +153,7 @@ static QString dualSenseEdgeRuntimeSdlSummary()
             .arg(version.patch);
 
     const char* sdl3Version = SDL_GetHint("SDL3_VERSION");
-    if (sdl3Version != nullptr && sdl3Version[0] != '\0') {
+    if (dualSenseEdgeHasSdl3VersionHint()) {
         summary += QString::fromLatin1(", SDL3 ") + QString::fromUtf8(sdl3Version);
     }
 

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -255,6 +255,12 @@ static int dualSenseEdgeControllerButtonRawPaddleIndex(SDL_GameController* contr
 #endif
 }
 
+static bool dualSenseEdgeControllerButtonIsStaleRawAlias(SDL_GameController* controller, Uint8 button)
+{
+    return !isDualSenseEdgePaddleControllerButton(button) &&
+           dualSenseEdgeControllerButtonRawPaddleIndex(controller, button) >= 0;
+}
+
 static bool isDualSenseEdgeMappingMetadataEntry(const QString& mappingEntry)
 {
     return mappingEntry.startsWith("crc:") ||
@@ -682,21 +688,20 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
                      dualSenseEdgePaddleButtonName(event->button));
         return;
     }
-    if (isDualSenseEdge && !isDualSenseEdgePaddleButton) {
+    if (isDualSenseEdge &&
+        dualSenseEdgeControllerButtonIsStaleRawAlias(state->controller, event->button)) {
         int rawPaddleIndex = dualSenseEdgeControllerButtonRawPaddleIndex(state->controller, event->button);
-        if (rawPaddleIndex >= 0) {
-            int previousButtons = state->buttons;
-            const char* buttonName = SDL_GameControllerGetStringForButton((SDL_GameControllerButton)event->button);
-            state->buttons &= ~k_ButtonMap[event->button];
-            if (previousButtons != state->buttons && state->mouseEmulationTimer == 0) {
-                sendGamepadState(state);
-            }
-            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "Ignoring DualSense Edge controller button %s bound to raw %s as stale Edge raw alias",
-                         buttonName != nullptr ? buttonName : "<unknown>",
-                         qPrintable(dualSenseEdgePaddleMappingEntry(rawPaddleIndex)));
-            return;
+        int previousButtons = state->buttons;
+        const char* buttonName = SDL_GameControllerGetStringForButton((SDL_GameControllerButton)event->button);
+        state->buttons &= ~k_ButtonMap[event->button];
+        if (previousButtons != state->buttons && state->mouseEmulationTimer == 0) {
+            sendGamepadState(state);
         }
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                     "Ignoring DualSense Edge controller button %s bound to raw %s as stale Edge raw alias",
+                     buttonName != nullptr ? buttonName : "<unknown>",
+                     qPrintable(dualSenseEdgePaddleMappingEntry(rawPaddleIndex)));
+        return;
     }
 
     if (m_SwapFaceButtons) {
@@ -1108,13 +1113,23 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
 #if SDL_VERSION_ATLEAST(2, 0, 14)
         // On SDL 2.0.14 and later, we can provide enhanced controller information to the host PC
         // for it to use as a hint for the type of controller to emulate.
+        bool isDualSenseEdge = isDualSenseEdgeController(state->controller);
         uint32_t supportedButtonFlags = 0;
         for (int i = 0; i < (int)SDL_arraysize(k_ButtonMap); i++) {
             if (SDL_GameControllerHasButton(state->controller, (SDL_GameControllerButton)i)) {
+                if (isDualSenseEdge &&
+                    dualSenseEdgeControllerButtonIsStaleRawAlias(state->controller, (Uint8)i)) {
+                    const char* buttonName = SDL_GameControllerGetStringForButton((SDL_GameControllerButton)i);
+                    int rawPaddleIndex = dualSenseEdgeControllerButtonRawPaddleIndex(state->controller, (Uint8)i);
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                "DualSense Edge controller button %s is bound to raw %s; not advertising it as a normal button",
+                                buttonName != nullptr ? buttonName : "<unknown>",
+                                qPrintable(dualSenseEdgePaddleMappingEntry(rawPaddleIndex)));
+                    continue;
+                }
                 supportedButtonFlags |= k_ButtonMap[i];
             }
         }
-        bool isDualSenseEdge = isDualSenseEdgeController(state->controller);
         int dualSenseEdgeButtonCount = isDualSenseEdge ? dualSenseEdgeJoystickButtonCount(state->controller) : 0;
         bool hasDualSenseEdgePaddleButtons = isDualSenseEdge && dualSenseEdgeHasPaddleControllerButtons(state->controller);
         if (isDualSenseEdge) {

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -4,8 +4,7 @@
 #include "SDL_compat.h"
 #include "settings/mappingmanager.h"
 
-#include <cstring>
-
+#include <QStringList>
 #include <QtMath>
 
 // How long the Start button must be pressed to toggle mouse emulation
@@ -39,6 +38,21 @@
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2 17
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3 18
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 19
+#define DUALSENSE_EDGE_PADDLE_MAPPING_COUNT 4
+
+static const char* const DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
+    "paddle1",
+    "paddle2",
+    "paddle3",
+    "paddle4",
+};
+
+static const char* const DUALSENSE_EDGE_PADDLE_MAPPING_VALUES[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
+    "b20",
+    "b19",
+    "b18",
+    "b17",
+};
 
 const int SdlInputHandler::k_ButtonMap[] = {
     A_FLAG, B_FLAG, X_FLAG, Y_FLAG,
@@ -104,23 +118,87 @@ static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controll
 #endif
 }
 
-static QString missingDualSenseEdgePaddleMappings(const char* mapping)
+static QString dualSenseEdgePaddleMappingEntry(int mappingIndex)
 {
-    QString missingMappings;
-    if (std::strstr(mapping, "paddle1:") == nullptr) {
-        missingMappings.append("paddle1:b20,");
-    }
-    if (std::strstr(mapping, "paddle2:") == nullptr) {
-        missingMappings.append("paddle2:b19,");
-    }
-    if (std::strstr(mapping, "paddle3:") == nullptr) {
-        missingMappings.append("paddle3:b18,");
-    }
-    if (std::strstr(mapping, "paddle4:") == nullptr) {
-        missingMappings.append("paddle4:b17,");
+    return QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[mappingIndex]) + ":" +
+           QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_VALUES[mappingIndex]);
+}
+
+static int dualSenseEdgePaddleMappingIndex(const QString& mappingEntry)
+{
+    for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+        QString prefix = QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[i]) + ":";
+        if (mappingEntry.startsWith(prefix)) {
+            return i;
+        }
     }
 
-    return missingMappings;
+    return -1;
+}
+
+static void addDualSenseEdgePaddleMappingChange(QString* changedMappings, int mappingIndex)
+{
+    if (!changedMappings->isEmpty()) {
+        changedMappings->append(",");
+    }
+    changedMappings->append(dualSenseEdgePaddleMappingEntry(mappingIndex));
+}
+
+static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString* changedMappings)
+{
+    QStringList entries = QString::fromUtf8(mapping).split(',');
+    QStringList updatedEntries;
+    bool foundMappings[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {};
+
+    changedMappings->clear();
+
+    // Normalize existing paddle entries too, because a stale mapping can expose
+    // paddle buttons while assigning the wrong raw DualSense Edge buttons.
+    for (int i = 0; i < entries.size(); i++) {
+        const QString& entry = entries.at(i);
+        int mappingIndex = dualSenseEdgePaddleMappingIndex(entry);
+
+        if (mappingIndex < 0) {
+            updatedEntries.append(entry);
+            continue;
+        }
+
+        if (foundMappings[mappingIndex]) {
+            addDualSenseEdgePaddleMappingChange(changedMappings, mappingIndex);
+            continue;
+        }
+
+        QString expectedEntry = dualSenseEdgePaddleMappingEntry(mappingIndex);
+        updatedEntries.append(expectedEntry);
+        foundMappings[mappingIndex] = true;
+
+        if (entry != expectedEntry) {
+            addDualSenseEdgePaddleMappingChange(changedMappings, mappingIndex);
+        }
+    }
+
+    int insertionIndex = -1;
+    for (int i = 0; i < updatedEntries.size(); i++) {
+        if (updatedEntries.at(i).startsWith("platform:")) {
+            insertionIndex = i;
+            break;
+        }
+    }
+    if (insertionIndex < 0) {
+        insertionIndex = updatedEntries.size();
+        if (!updatedEntries.isEmpty() && updatedEntries.last().isEmpty()) {
+            insertionIndex--;
+        }
+    }
+
+    for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+        if (!foundMappings[i]) {
+            updatedEntries.insert(insertionIndex++, dualSenseEdgePaddleMappingEntry(i));
+            addDualSenseEdgePaddleMappingChange(changedMappings, i);
+        }
+    }
+
+    return updatedEntries.join(",");
 }
 
 static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
@@ -154,8 +232,9 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         return false;
     }
 
-    QString missingMappings = missingDualSenseEdgePaddleMappings(mapping);
-    if (missingMappings.isEmpty()) {
+    QString changedMappings;
+    QString updatedMapping = normalizeDualSenseEdgePaddleMappings(mapping, &changedMappings);
+    if (changedMappings.isEmpty()) {
         if (dualSenseEdgeHasPaddleControllerButtons(controller)) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                         "DualSense Edge paddle mappings already present");
@@ -167,20 +246,7 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         SDL_free(mapping);
         return false;
     }
-
-    QString updatedMapping = QString::fromUtf8(mapping);
     SDL_free(mapping);
-
-    int platformIndex = updatedMapping.indexOf(",platform:");
-    if (platformIndex >= 0) {
-        updatedMapping.insert(platformIndex + 1, missingMappings);
-    }
-    else {
-        if (!updatedMapping.endsWith(",")) {
-            updatedMapping.append(",");
-        }
-        updatedMapping.append(missingMappings);
-    }
 
     int ret = SDL_GameControllerAddMapping(qPrintable(updatedMapping));
     if (ret < 0) {
@@ -198,7 +264,7 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "Applied DualSense Edge paddle mappings (%s): %s",
                     ret > 0 ? "added" : "updated",
-                    qPrintable(missingMappings));
+                    qPrintable(changedMappings));
         return ret > 0;
     }
 #endif

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -157,7 +157,8 @@ static bool isDualSenseEdgeMappingMetadataEntry(const QString& mappingEntry)
            mappingEntry.startsWith("hint:") ||
            mappingEntry.startsWith("platform:") ||
            mappingEntry.startsWith("sdk>=:") ||
-           mappingEntry.startsWith("sdk<=:");
+           mappingEntry.startsWith("sdk<=:") ||
+           mappingEntry.startsWith("type:");
 }
 
 static void addDualSenseEdgePaddleMappingChange(QString* changedMappings, int mappingIndex)

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -27,14 +27,17 @@
 #define SONY_VENDOR_ID 0x054c
 #define DUALSENSE_EDGE_PRODUCT_ID 0x0df2
 
-// SDL 2's DualSense Edge HIDAPI driver exposes the Edge-specific controls as
-// raw joystick buttons 17-20. Its generated mapping is paddle1:b20,
+// Native SDL2's DualSense Edge HIDAPI driver exposes the Edge-specific controls
+// as raw joystick buttons 17-20. Its generated mapping is paddle1:b20,
 // paddle2:b19, paddle3:b18, paddle4:b17, matching right rear, left rear,
-// right Fn, and left Fn. Older controller DB entries identify the Edge as a
-// generic PS5 controller and omit these bindings. Once mapped, SDL reports
-// those raw buttons as controller buttons 16-19, matching the PADDLE1-4 order
-// in k_ButtonMap.
-#define DUALSENSE_EDGE_MIN_BUTTONS 21
+// right Fn, and left Fn. Moonlight builds may also run through sdl2-compat over
+// SDL3, where the same semantic controls are exposed as raw buttons 13-16 and
+// generated as paddle1:b16,paddle2:b15,paddle3:b14,paddle4:b13. Older
+// controller DB entries identify the Edge as a generic PS5 controller and omit
+// these bindings. Once mapped, SDL reports those raw buttons as controller
+// buttons 16-19, matching the PADDLE1-4 order in k_ButtonMap.
+#define DUALSENSE_EDGE_SDL2_MIN_BUTTONS 21
+#define DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS 17
 #define DUALSENSE_EDGE_PADDLE_FLAGS (PADDLE1_FLAG | PADDLE2_FLAG | PADDLE3_FLAG | PADDLE4_FLAG)
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 16
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2 17
@@ -77,11 +80,18 @@ static const char* const DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[DUALSENSE_EDGE_PADDL
     "paddle4",
 };
 
-static const int DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
+static const int DUALSENSE_EDGE_SDL2_PADDLE_MAPPING_BUTTONS[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
     20,
     19,
     18,
     17,
+};
+
+static const int DUALSENSE_EDGE_SDL3_COMPAT_PADDLE_MAPPING_BUTTONS[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
+    16,
+    15,
+    14,
+    13,
 };
 
 const int SdlInputHandler::k_ButtonMap[] = {
@@ -111,13 +121,43 @@ static int dualSenseEdgeJoystickButtonCount(SDL_GameController* controller)
     return joystick != nullptr ? SDL_JoystickNumButtons(joystick) : -1;
 }
 
+static bool dualSenseEdgeUsesSdl3CompatMappings(SDL_GameController* controller)
+{
+    if (SDL_GetHint("SDL3_VERSION") != nullptr) {
+        return true;
+    }
+
+    int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
+    return buttonCount >= DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS &&
+           buttonCount < DUALSENSE_EDGE_SDL2_MIN_BUTTONS;
+}
+
+static const char* dualSenseEdgeRawMappingName(SDL_GameController* controller)
+{
+    return dualSenseEdgeUsesSdl3CompatMappings(controller) ? "SDL3/sdl2-compat" : "SDL2";
+}
+
+static int dualSenseEdgeMinimumButtonCount(SDL_GameController* controller)
+{
+    return dualSenseEdgeUsesSdl3CompatMappings(controller) ?
+        DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS :
+        DUALSENSE_EDGE_SDL2_MIN_BUTTONS;
+}
+
+static const int* dualSenseEdgePaddleMappingButtons(SDL_GameController* controller)
+{
+    return dualSenseEdgeUsesSdl3CompatMappings(controller) ?
+        DUALSENSE_EDGE_SDL3_COMPAT_PADDLE_MAPPING_BUTTONS :
+        DUALSENSE_EDGE_SDL2_PADDLE_MAPPING_BUTTONS;
+}
+
 static bool dualSenseEdgeExposesPaddleButtons(SDL_GameController* controller)
 {
     if (!isDualSenseEdgeController(controller)) {
         return false;
     }
 
-    return dualSenseEdgeJoystickButtonCount(controller) >= DUALSENSE_EDGE_MIN_BUTTONS;
+    return dualSenseEdgeJoystickButtonCount(controller) >= dualSenseEdgeMinimumButtonCount(controller);
 }
 
 static const char* dualSenseEdgePaddleButtonName(Uint8 button)
@@ -147,14 +187,15 @@ static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controll
 #if SDL_VERSION_ATLEAST(2, 0, 14)
     // Raw joystick button count only proves SDL can see the physical controls.
     // Moonlight can only transmit the controller-button layer, and the bindings
-    // must point at SDL2's canonical Edge raw buttons to preserve physical labels.
+    // must point at the current SDL Edge raw buttons to preserve physical labels.
+    const int* paddleMappingButtons = dualSenseEdgePaddleMappingButtons(controller);
     for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
         SDL_GameControllerButton button = (SDL_GameControllerButton)(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 + i);
         SDL_GameControllerButtonBind binding = SDL_GameControllerGetBindForButton(controller, button);
 
         if (!SDL_GameControllerHasButton(controller, button) ||
             binding.bindType != SDL_CONTROLLER_BINDTYPE_BUTTON ||
-            binding.value.button != DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[i]) {
+            binding.value.button != paddleMappingButtons[i]) {
             return false;
         }
     }
@@ -208,10 +249,10 @@ static QString dualSenseEdgePaddleBindingSummary(SDL_GameController* controller)
 #endif
 }
 
-static QString dualSenseEdgePaddleMappingEntry(int mappingIndex)
+static QString dualSenseEdgePaddleMappingEntry(int mappingIndex, const int* paddleMappingButtons)
 {
     return QString::fromLatin1(DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[mappingIndex]) + ":" +
-           "b" + QString::number(DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[mappingIndex]);
+           "b" + QString::number(paddleMappingButtons[mappingIndex]);
 }
 
 static int dualSenseEdgePaddleMappingIndex(const QString& mappingEntry)
@@ -226,7 +267,7 @@ static int dualSenseEdgePaddleMappingIndex(const QString& mappingEntry)
     return -1;
 }
 
-static int dualSenseEdgePaddleRawButtonMappingIndex(const QString& mappingEntry)
+static int dualSenseEdgePaddleRawButtonMappingIndex(const QString& mappingEntry, const int* paddleMappingButtons)
 {
     int separatorIndex = mappingEntry.indexOf(':');
     if (separatorIndex < 0) {
@@ -235,7 +276,7 @@ static int dualSenseEdgePaddleRawButtonMappingIndex(const QString& mappingEntry)
 
     QString binding = mappingEntry.mid(separatorIndex + 1);
     for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
-        QString expectedBinding = "b" + QString::number(DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[i]);
+        QString expectedBinding = "b" + QString::number(paddleMappingButtons[i]);
         if (binding == expectedBinding) {
             return i;
         }
@@ -244,10 +285,11 @@ static int dualSenseEdgePaddleRawButtonMappingIndex(const QString& mappingEntry)
     return -1;
 }
 
-static int dualSenseEdgePaddleRawButtonIndex(int rawButton)
+static int dualSenseEdgePaddleRawButtonIndex(SDL_GameController* controller, int rawButton)
 {
+    const int* paddleMappingButtons = dualSenseEdgePaddleMappingButtons(controller);
     for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
-        if (rawButton == DUALSENSE_EDGE_PADDLE_MAPPING_BUTTONS[i]) {
+        if (rawButton == paddleMappingButtons[i]) {
             return i;
         }
     }
@@ -264,7 +306,7 @@ static int dualSenseEdgeControllerButtonRawPaddleIndex(SDL_GameController* contr
         return -1;
     }
 
-    return dualSenseEdgePaddleRawButtonIndex(binding.value.button);
+    return dualSenseEdgePaddleRawButtonIndex(controller, binding.value.button);
 #else
     Q_UNUSED(controller);
     Q_UNUSED(button);
@@ -289,15 +331,15 @@ static bool isDualSenseEdgeMappingMetadataEntry(const QString& mappingEntry)
            mappingEntry.startsWith("type:");
 }
 
-static void addDualSenseEdgePaddleMappingChange(QString* changedMappings, int mappingIndex)
+static void addDualSenseEdgePaddleMappingChange(QString* changedMappings, int mappingIndex, const int* paddleMappingButtons)
 {
     if (!changedMappings->isEmpty()) {
         changedMappings->append(",");
     }
-    changedMappings->append(dualSenseEdgePaddleMappingEntry(mappingIndex));
+    changedMappings->append(dualSenseEdgePaddleMappingEntry(mappingIndex, paddleMappingButtons));
 }
 
-static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString* changedMappings)
+static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString* changedMappings, const int* paddleMappingButtons)
 {
     QString originalMapping = QString::fromUtf8(mapping);
     QStringList entries = originalMapping.split(',');
@@ -317,7 +359,7 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
         int mappingIndex = dualSenseEdgePaddleMappingIndex(entry);
 
         if (mappingIndex < 0) {
-            mappingIndex = dualSenseEdgePaddleRawButtonMappingIndex(entry);
+            mappingIndex = dualSenseEdgePaddleRawButtonMappingIndex(entry, paddleMappingButtons);
             if (mappingIndex >= 0) {
                 changedMappingEntries[mappingIndex] = true;
                 hasChangedMappingEntries = true;
@@ -334,7 +376,7 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
             continue;
         }
 
-        QString expectedEntry = dualSenseEdgePaddleMappingEntry(mappingIndex);
+        QString expectedEntry = dualSenseEdgePaddleMappingEntry(mappingIndex, paddleMappingButtons);
         foundMappings[mappingIndex] = true;
 
         if (entry != expectedEntry) {
@@ -362,7 +404,7 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
             changedMappingEntries[i] = true;
             hasChangedMappingEntries = true;
         }
-        updatedEntries.insert(insertionIndex++, dualSenseEdgePaddleMappingEntry(i));
+        updatedEntries.insert(insertionIndex++, dualSenseEdgePaddleMappingEntry(i, paddleMappingButtons));
     }
 
     QString updatedMapping = updatedEntries.join(",");
@@ -374,7 +416,7 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
 
     for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
         if (changedMappingEntries[i]) {
-            addDualSenseEdgePaddleMappingChange(changedMappings, i);
+            addDualSenseEdgePaddleMappingChange(changedMappings, i, paddleMappingButtons);
         }
     }
 
@@ -395,8 +437,10 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     SDL_version version;
     SDL_GetVersion(&version);
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "DualSense Edge detected with %d SDL joystick buttons (VID/PID: 0x%.4x/0x%.4x) (SDL %d.%d.%d)",
+                "DualSense Edge detected with %d SDL joystick buttons (need %d for %s Edge raw mapping) (VID/PID: 0x%.4x/0x%.4x) (SDL %d.%d.%d)",
                 buttonCount,
+                dualSenseEdgeMinimumButtonCount(controller),
+                dualSenseEdgeRawMappingName(controller),
                 (unsigned int)SDL_GameControllerGetVendor(controller),
                 (unsigned int)SDL_GameControllerGetProduct(controller),
                 version.major,
@@ -405,9 +449,10 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
 
     if (!dualSenseEdgeExposesPaddleButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "DualSense Edge detected, but SDL exposes %d buttons; need at least %d for Edge-specific buttons",
+                    "DualSense Edge detected, but SDL exposes %d buttons; need at least %d for Edge-specific buttons with %s raw mapping",
                     buttonCount,
-                    DUALSENSE_EDGE_MIN_BUTTONS);
+                    dualSenseEdgeMinimumButtonCount(controller),
+                    dualSenseEdgeRawMappingName(controller));
         return false;
     }
 
@@ -420,7 +465,8 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     }
 
     QString changedMappings;
-    QString updatedMapping = normalizeDualSenseEdgePaddleMappings(mapping, &changedMappings);
+    const int* paddleMappingButtons = dualSenseEdgePaddleMappingButtons(controller);
+    QString updatedMapping = normalizeDualSenseEdgePaddleMappings(mapping, &changedMappings, paddleMappingButtons);
     if (changedMappings.isEmpty()) {
         if (dualSenseEdgeHasPaddleControllerButtons(controller)) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -717,6 +763,10 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
         int rawPaddleIndex = dualSenseEdgeControllerButtonRawPaddleIndex(state->controller, event->button);
         int previousButtons = state->buttons;
         const char* buttonName = SDL_GameControllerGetStringForButton((SDL_GameControllerButton)event->button);
+        QString rawPaddleEntry = dualSenseEdgePaddleMappingEntry(
+            rawPaddleIndex,
+            dualSenseEdgePaddleMappingButtons(state->controller)
+        );
         state->buttons &= ~k_ButtonMap[event->button];
         if (previousButtons != state->buttons && state->mouseEmulationTimer == 0) {
             sendGamepadState(state);
@@ -724,7 +774,7 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
         SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
                      "Ignoring DualSense Edge controller button %s bound to raw %s as stale Edge raw alias",
                      buttonName != nullptr ? buttonName : "<unknown>",
-                     qPrintable(dualSenseEdgePaddleMappingEntry(rawPaddleIndex)));
+                     qPrintable(rawPaddleEntry));
         return;
     }
 
@@ -1145,10 +1195,14 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
                     dualSenseEdgeControllerButtonIsStaleRawAlias(state->controller, (Uint8)i)) {
                     const char* buttonName = SDL_GameControllerGetStringForButton((SDL_GameControllerButton)i);
                     int rawPaddleIndex = dualSenseEdgeControllerButtonRawPaddleIndex(state->controller, (Uint8)i);
+                    QString rawPaddleEntry = dualSenseEdgePaddleMappingEntry(
+                        rawPaddleIndex,
+                        dualSenseEdgePaddleMappingButtons(state->controller)
+                    );
                     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                                 "DualSense Edge controller button %s is bound to raw %s; not advertising it as a normal button",
                                 buttonName != nullptr ? buttonName : "<unknown>",
-                                qPrintable(dualSenseEdgePaddleMappingEntry(rawPaddleIndex)));
+                                qPrintable(rawPaddleEntry));
                     continue;
                 }
                 supportedButtonFlags |= k_ButtonMap[i];

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -140,6 +140,15 @@ static int dualSenseEdgePaddleMappingIndex(const QString& mappingEntry)
     return -1;
 }
 
+static bool isDualSenseEdgeMappingMetadataEntry(const QString& mappingEntry)
+{
+    return mappingEntry.startsWith("crc:") ||
+           mappingEntry.startsWith("hint:") ||
+           mappingEntry.startsWith("platform:") ||
+           mappingEntry.startsWith("sdk>=:") ||
+           mappingEntry.startsWith("sdk<=:");
+}
+
 static void addDualSenseEdgePaddleMappingChange(QString* changedMappings, int mappingIndex)
 {
     if (!changedMappings->isEmpty()) {
@@ -183,7 +192,7 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
 
     int insertionIndex = -1;
     for (int i = 0; i < updatedEntries.size(); i++) {
-        if (updatedEntries.at(i).startsWith("platform:")) {
+        if (isDualSenseEdgeMappingMetadataEntry(updatedEntries.at(i))) {
             insertionIndex = i;
             break;
         }

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -62,6 +62,12 @@ static_assert(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3 == SDL_CONTROLLER_BUTTON_
               "DualSense Edge PADDLE3 mapping must match SDL2's controller button order");
 static_assert(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 == SDL_CONTROLLER_BUTTON_PADDLE4,
               "DualSense Edge PADDLE4 mapping must match SDL2's controller button order");
+static_assert(SDL_CONTROLLER_BUTTON_MISC1 == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 - 1,
+              "Moonlight's button map must keep MISC immediately before Edge paddle buttons");
+static_assert(SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 + 1,
+              "Moonlight's button map must keep TOUCHPAD immediately after Edge paddle buttons");
+static_assert(SDL_CONTROLLER_BUTTON_MAX == SDL_CONTROLLER_BUTTON_TOUCHPAD + 1,
+              "Moonlight's button map must cover every SDL2 controller button");
 #endif
 
 static const char* const DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -32,7 +32,6 @@
 // left/right rear paddles as joystick buttons 17-20. Older controller DB
 // entries identify the Edge as a generic PS5 controller and omit these bindings.
 #define DUALSENSE_EDGE_MIN_BUTTONS 21
-#define DUALSENSE_EDGE_PADDLE_MAPPINGS "paddle1:b20,paddle2:b19,paddle3:b18,paddle4:b17,"
 
 const int SdlInputHandler::k_ButtonMap[] = {
     A_FLAG, B_FLAG, X_FLAG, Y_FLAG,
@@ -51,12 +50,23 @@ static bool isDualSenseEdgeController(SDL_GameController* controller)
            SDL_GameControllerGetProduct(controller) == DUALSENSE_EDGE_PRODUCT_ID;
 }
 
-static bool mappingHasPaddles(const char* mapping)
+static QString missingDualSenseEdgePaddleMappings(const char* mapping)
 {
-    return std::strstr(mapping, "paddle1:") != nullptr ||
-           std::strstr(mapping, "paddle2:") != nullptr ||
-           std::strstr(mapping, "paddle3:") != nullptr ||
-           std::strstr(mapping, "paddle4:") != nullptr;
+    QString missingMappings;
+    if (std::strstr(mapping, "paddle1:") == nullptr) {
+        missingMappings.append("paddle1:b20,");
+    }
+    if (std::strstr(mapping, "paddle2:") == nullptr) {
+        missingMappings.append("paddle2:b19,");
+    }
+    if (std::strstr(mapping, "paddle3:") == nullptr) {
+        missingMappings.append("paddle3:b18,");
+    }
+    if (std::strstr(mapping, "paddle4:") == nullptr) {
+        missingMappings.append("paddle4:b17,");
+    }
+
+    return missingMappings;
 }
 
 static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
@@ -77,7 +87,8 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         return;
     }
 
-    if (mappingHasPaddles(mapping)) {
+    QString missingMappings = missingDualSenseEdgePaddleMappings(mapping);
+    if (missingMappings.isEmpty()) {
         SDL_free(mapping);
         return;
     }
@@ -87,13 +98,13 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
 
     int platformIndex = updatedMapping.indexOf(",platform:");
     if (platformIndex >= 0) {
-        updatedMapping.insert(platformIndex + 1, DUALSENSE_EDGE_PADDLE_MAPPINGS);
+        updatedMapping.insert(platformIndex + 1, missingMappings);
     }
     else {
         if (!updatedMapping.endsWith(",")) {
             updatedMapping.append(",");
         }
-        updatedMapping.append(DUALSENSE_EDGE_PADDLE_MAPPINGS);
+        updatedMapping.append(missingMappings);
     }
 
     int ret = SDL_GameControllerAddMapping(qPrintable(updatedMapping));

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -50,6 +50,16 @@ static bool isDualSenseEdgeController(SDL_GameController* controller)
            SDL_GameControllerGetProduct(controller) == DUALSENSE_EDGE_PRODUCT_ID;
 }
 
+static bool dualSenseEdgeExposesPaddleButtons(SDL_GameController* controller)
+{
+    if (!isDualSenseEdgeController(controller)) {
+        return false;
+    }
+
+    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(controller);
+    return joystick != nullptr && SDL_JoystickNumButtons(joystick) >= DUALSENSE_EDGE_MIN_BUTTONS;
+}
+
 static QString missingDualSenseEdgePaddleMappings(const char* mapping)
 {
     QString missingMappings;
@@ -75,8 +85,7 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         return;
     }
 
-    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(controller);
-    if (joystick == nullptr || SDL_JoystickNumButtons(joystick) < DUALSENSE_EDGE_MIN_BUTTONS) {
+    if (!dualSenseEdgeExposesPaddleButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                     "DualSense Edge detected, but SDL does not expose the Edge-specific buttons");
         return;
@@ -735,6 +744,9 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
             if (SDL_GameControllerHasButton(state->controller, (SDL_GameControllerButton)i)) {
                 supportedButtonFlags |= k_ButtonMap[i];
             }
+        }
+        if (dualSenseEdgeExposesPaddleButtons(state->controller)) {
+            supportedButtonFlags |= PADDLE1_FLAG | PADDLE2_FLAG | PADDLE3_FLAG | PADDLE4_FLAG;
         }
 
         uint32_t capabilities = 0;

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -27,11 +27,13 @@
 #define SONY_VENDOR_ID 0x054c
 #define DUALSENSE_EDGE_PRODUCT_ID 0x0df2
 
-// SDL 2's DualSense Edge HIDAPI driver exposes the left/right Fn buttons and
-// left/right rear paddles as joystick buttons 17-20. Older controller DB
-// entries identify the Edge as a generic PS5 controller and omit these bindings.
-// Once mapped, SDL reports those raw joystick buttons as controller buttons
-// 16-19, matching the PADDLE1-4 order in k_ButtonMap.
+// SDL 2's DualSense Edge HIDAPI driver exposes the Edge-specific controls as
+// raw joystick buttons 17-20. Its generated mapping is paddle1:b20,
+// paddle2:b19, paddle3:b18, paddle4:b17, matching right rear, left rear,
+// right Fn, and left Fn. Older controller DB entries identify the Edge as a
+// generic PS5 controller and omit these bindings. Once mapped, SDL reports
+// those raw buttons as controller buttons 16-19, matching the PADDLE1-4 order
+// in k_ButtonMap.
 #define DUALSENSE_EDGE_MIN_BUTTONS 21
 #define DUALSENSE_EDGE_PADDLE_FLAGS (PADDLE1_FLAG | PADDLE2_FLAG | PADDLE3_FLAG | PADDLE4_FLAG)
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 16

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -1186,8 +1186,9 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
             capabilities |= LI_CCAP_RGB_LED;
         }
 
+        SDL_GameControllerType sdlControllerType = SDL_GameControllerGetType(state->controller);
         uint8_t type;
-        switch (SDL_GameControllerGetType(state->controller)) {
+        switch (sdlControllerType) {
         case SDL_CONTROLLER_TYPE_XBOX360:
         case SDL_CONTROLLER_TYPE_XBOXONE:
             type = LI_CTYPE_XBOX;
@@ -1209,6 +1210,14 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
             type = LI_CTYPE_UNKNOWN;
             break;
         }
+        if (isDualSenseEdge && type != LI_CTYPE_PS) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "DualSense Edge SDL controller type %d is not PlayStation; advertising PlayStation arrival type because VID/PID is 0x%.4x/0x%.4x",
+                        sdlControllerType,
+                        (unsigned int)SONY_VENDOR_ID,
+                        (unsigned int)DUALSENSE_EDGE_PRODUCT_ID);
+            type = LI_CTYPE_PS;
+        }
 
         // If this is a PlayStation controller that doesn't have a touchpad button mapped,
         // we'll allow the Select+PS button combo to act as the touchpad.
@@ -1220,8 +1229,10 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
 
         if (isDualSenseEdge) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                        "DualSense Edge arrival support: buttons=%d supportedButtonFlags=0x%08x paddle/Fn=0x%08x capabilities=0x%08x bindings=%s",
+                        "DualSense Edge arrival support: buttons=%d sdlType=%d arrivalType=0x%02x supportedButtonFlags=0x%08x paddle/Fn=0x%08x capabilities=0x%08x bindings=%s",
                         dualSenseEdgeButtonCount,
+                        sdlControllerType,
+                        (unsigned int)type,
                         (unsigned int)supportedButtonFlags,
                         (unsigned int)(supportedButtonFlags & DUALSENSE_EDGE_PADDLE_FLAGS),
                         (unsigned int)capabilities,

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -154,6 +154,7 @@ static int dualSenseEdgePaddleMappingIndex(const QString& mappingEntry)
 static bool isDualSenseEdgeMappingMetadataEntry(const QString& mappingEntry)
 {
     return mappingEntry.startsWith("crc:") ||
+           mappingEntry.startsWith("face:") ||
            mappingEntry.startsWith("hint:") ||
            mappingEntry.startsWith("platform:") ||
            mappingEntry.startsWith("sdk>=:") ||

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -119,6 +119,12 @@ static const char* dualSenseEdgePaddleButtonName(Uint8 button)
     }
 }
 
+static bool isDualSenseEdgePaddleControllerButton(Uint8 button)
+{
+    return button >= DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 &&
+           button <= DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4;
+}
+
 static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controller)
 {
 #if SDL_VERSION_ATLEAST(2, 0, 14)
@@ -560,6 +566,16 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
         return;
     }
 
+    if (isDualSenseEdgeController(state->controller) &&
+        isDualSenseEdgePaddleControllerButton(event->button) &&
+        !dualSenseEdgeHasPaddleControllerButtons(state->controller)) {
+        state->buttons &= ~k_ButtonMap[event->button];
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                     "Ignoring DualSense Edge %s event without verified paddle bindings",
+                     dualSenseEdgePaddleButtonName(event->button));
+        return;
+    }
+
     if (m_SwapFaceButtons) {
         switch (event->button) {
         case SDL_CONTROLLER_BUTTON_A:
@@ -977,6 +993,9 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
         bool isDualSenseEdge = isDualSenseEdgeController(state->controller);
         int dualSenseEdgeButtonCount = isDualSenseEdge ? dualSenseEdgeJoystickButtonCount(state->controller) : 0;
         bool hasDualSenseEdgePaddleButtons = isDualSenseEdge && dualSenseEdgeHasPaddleControllerButtons(state->controller);
+        if (isDualSenseEdge) {
+            supportedButtonFlags &= ~DUALSENSE_EDGE_PADDLE_FLAGS;
+        }
         if (hasDualSenseEdgePaddleButtons) {
             supportedButtonFlags |= DUALSENSE_EDGE_PADDLE_FLAGS;
         }

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -137,6 +137,24 @@ static const char* dualSenseEdgeRawMappingName(SDL_GameController* controller)
     return dualSenseEdgeUsesSdl3CompatMappings(controller) ? "SDL3/sdl2-compat" : "SDL2";
 }
 
+static QString dualSenseEdgeRuntimeSdlSummary()
+{
+    SDL_version version;
+    SDL_GetVersion(&version);
+
+    QString summary = QString("SDL %1.%2.%3")
+            .arg(version.major)
+            .arg(version.minor)
+            .arg(version.patch);
+
+    const char* sdl3Version = SDL_GetHint("SDL3_VERSION");
+    if (sdl3Version != nullptr && sdl3Version[0] != '\0') {
+        summary += QString::fromLatin1(", SDL3 ") + QString::fromUtf8(sdl3Version);
+    }
+
+    return summary;
+}
+
 static int dualSenseEdgeMinimumButtonCount(SDL_GameController* controller)
 {
     return dualSenseEdgeUsesSdl3CompatMappings(controller) ?
@@ -434,18 +452,15 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     }
 
     int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
-    SDL_version version;
-    SDL_GetVersion(&version);
+    QString runtimeSdlSummary = dualSenseEdgeRuntimeSdlSummary();
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "DualSense Edge detected with %d SDL joystick buttons (need %d for %s Edge raw mapping) (VID/PID: 0x%.4x/0x%.4x) (SDL %d.%d.%d)",
+                "DualSense Edge detected with %d SDL joystick buttons (need %d for %s Edge raw mapping) (VID/PID: 0x%.4x/0x%.4x) (%s)",
                 buttonCount,
                 dualSenseEdgeMinimumButtonCount(controller),
                 dualSenseEdgeRawMappingName(controller),
                 (unsigned int)SDL_GameControllerGetVendor(controller),
                 (unsigned int)SDL_GameControllerGetProduct(controller),
-                version.major,
-                version.minor,
-                version.patch);
+                qPrintable(runtimeSdlSummary));
 
     if (!dualSenseEdgeExposesPaddleButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -31,7 +31,14 @@
 // SDL 2's DualSense Edge HIDAPI driver exposes the left/right Fn buttons and
 // left/right rear paddles as joystick buttons 17-20. Older controller DB
 // entries identify the Edge as a generic PS5 controller and omit these bindings.
+// Once mapped, SDL reports those raw joystick buttons as controller buttons
+// 16-19, matching the PADDLE1-4 order in k_ButtonMap.
 #define DUALSENSE_EDGE_MIN_BUTTONS 21
+#define DUALSENSE_EDGE_PADDLE_FLAGS (PADDLE1_FLAG | PADDLE2_FLAG | PADDLE3_FLAG | PADDLE4_FLAG)
+#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 16
+#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2 17
+#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3 18
+#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 19
 
 const int SdlInputHandler::k_ButtonMap[] = {
     A_FLAG, B_FLAG, X_FLAG, Y_FLAG,
@@ -50,14 +57,35 @@ static bool isDualSenseEdgeController(SDL_GameController* controller)
            SDL_GameControllerGetProduct(controller) == DUALSENSE_EDGE_PRODUCT_ID;
 }
 
+static int dualSenseEdgeJoystickButtonCount(SDL_GameController* controller)
+{
+    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(controller);
+    return joystick != nullptr ? SDL_JoystickNumButtons(joystick) : -1;
+}
+
 static bool dualSenseEdgeExposesPaddleButtons(SDL_GameController* controller)
 {
     if (!isDualSenseEdgeController(controller)) {
         return false;
     }
 
-    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(controller);
-    return joystick != nullptr && SDL_JoystickNumButtons(joystick) >= DUALSENSE_EDGE_MIN_BUTTONS;
+    return dualSenseEdgeJoystickButtonCount(controller) >= DUALSENSE_EDGE_MIN_BUTTONS;
+}
+
+static const char* dualSenseEdgePaddleButtonName(Uint8 button)
+{
+    switch (button) {
+    case DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1:
+        return "PADDLE1";
+    case DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2:
+        return "PADDLE2";
+    case DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3:
+        return "PADDLE3";
+    case DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4:
+        return "PADDLE4";
+    default:
+        return nullptr;
+    }
 }
 
 static QString missingDualSenseEdgePaddleMappings(const char* mapping)
@@ -85,19 +113,31 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         return;
     }
 
+    int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "DualSense Edge detected with %d SDL joystick buttons",
+                buttonCount);
+
     if (!dualSenseEdgeExposesPaddleButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "DualSense Edge detected, but SDL does not expose the Edge-specific buttons");
+                    "DualSense Edge detected, but SDL exposes %d buttons; need at least %d for Edge-specific buttons",
+                    buttonCount,
+                    DUALSENSE_EDGE_MIN_BUTTONS);
         return;
     }
 
     char* mapping = SDL_GameControllerMapping(controller);
     if (mapping == nullptr) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Unable to query DualSense Edge controller mapping: %s",
+                    SDL_GetError());
         return;
     }
 
     QString missingMappings = missingDualSenseEdgePaddleMappings(mapping);
     if (missingMappings.isEmpty()) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "DualSense Edge paddle mappings already present");
         SDL_free(mapping);
         return;
     }
@@ -124,7 +164,9 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     }
     else {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                    "Added DualSense Edge paddle mappings");
+                    "Applied DualSense Edge paddle mappings (%s): %s",
+                    ret > 0 ? "added" : "updated",
+                    qPrintable(missingMappings));
     }
 }
 
@@ -457,6 +499,15 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
         }
     }
 
+    const char* edgeButtonName = dualSenseEdgePaddleButtonName(event->button);
+    if (edgeButtonName != nullptr && isDualSenseEdgeController(state->controller)) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "DualSense Edge %s %s (paddle/Fn flags: 0x%08x)",
+                    edgeButtonName,
+                    event->state == SDL_PRESSED ? "pressed" : "released",
+                    (unsigned int)(state->buttons & DUALSENSE_EDGE_PADDLE_FLAGS));
+    }
+
     // Handle Start+Select+L1+R1 as a gamepad quit combo
     if (state->buttons == (PLAY_FLAG | BACK_FLAG | LB_FLAG | RB_FLAG) && qgetenv("NO_GAMEPAD_QUIT") != "1") {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -745,8 +796,10 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
                 supportedButtonFlags |= k_ButtonMap[i];
             }
         }
-        if (dualSenseEdgeExposesPaddleButtons(state->controller)) {
-            supportedButtonFlags |= PADDLE1_FLAG | PADDLE2_FLAG | PADDLE3_FLAG | PADDLE4_FLAG;
+        bool isDualSenseEdge = isDualSenseEdgeController(state->controller);
+        int dualSenseEdgeButtonCount = isDualSenseEdge ? dualSenseEdgeJoystickButtonCount(state->controller) : 0;
+        if (isDualSenseEdge && dualSenseEdgeButtonCount >= DUALSENSE_EDGE_MIN_BUTTONS) {
+            supportedButtonFlags |= DUALSENSE_EDGE_PADDLE_FLAGS;
         }
 
         uint32_t capabilities = 0;
@@ -811,6 +864,15 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
             SDL_GameControllerGetBindForButton(state->controller, SDL_CONTROLLER_BUTTON_TOUCHPAD).bindType == SDL_CONTROLLER_BINDTYPE_NONE &&
 #endif
             type == LI_CTYPE_PS;
+
+        if (isDualSenseEdge) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "DualSense Edge arrival support: buttons=%d supportedButtonFlags=0x%08x paddle/Fn=0x%08x capabilities=0x%08x",
+                        dualSenseEdgeButtonCount,
+                        (unsigned int)supportedButtonFlags,
+                        (unsigned int)(supportedButtonFlags & DUALSENSE_EDGE_PADDLE_FLAGS),
+                        (unsigned int)capabilities);
+        }
 
         LiSendControllerArrivalEvent(state->index, m_GamepadMask, type, supportedButtonFlags, capabilities);
 #else

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -4,6 +4,8 @@
 #include "SDL_compat.h"
 #include "settings/mappingmanager.h"
 
+#include <cstring>
+
 #include <QtMath>
 
 // How long the Start button must be pressed to toggle mouse emulation
@@ -23,6 +25,15 @@
 #define ML_HAPTIC_SIMPLE_RUMBLE     (1U << 17)
 #define ML_HAPTIC_GC_TRIGGER_RUMBLE (1U << 18)
 
+#define SONY_VENDOR_ID 0x054c
+#define DUALSENSE_EDGE_PRODUCT_ID 0x0df2
+
+// SDL 2's DualSense Edge HIDAPI driver exposes the left/right Fn buttons and
+// left/right rear paddles as joystick buttons 17-20. Older controller DB
+// entries identify the Edge as a generic PS5 controller and omit these bindings.
+#define DUALSENSE_EDGE_MIN_BUTTONS 21
+#define DUALSENSE_EDGE_PADDLE_MAPPINGS "paddle1:b20,paddle2:b19,paddle3:b18,paddle4:b17,"
+
 const int SdlInputHandler::k_ButtonMap[] = {
     A_FLAG, B_FLAG, X_FLAG, Y_FLAG,
     BACK_FLAG, SPECIAL_FLAG, PLAY_FLAG,
@@ -33,6 +44,69 @@ const int SdlInputHandler::k_ButtonMap[] = {
     PADDLE1_FLAG, PADDLE2_FLAG, PADDLE3_FLAG, PADDLE4_FLAG,
     TOUCHPAD_FLAG,
 };
+
+static bool isDualSenseEdgeController(SDL_GameController* controller)
+{
+    return SDL_GameControllerGetVendor(controller) == SONY_VENDOR_ID &&
+           SDL_GameControllerGetProduct(controller) == DUALSENSE_EDGE_PRODUCT_ID;
+}
+
+static bool mappingHasPaddles(const char* mapping)
+{
+    return std::strstr(mapping, "paddle1:") != nullptr ||
+           std::strstr(mapping, "paddle2:") != nullptr ||
+           std::strstr(mapping, "paddle3:") != nullptr ||
+           std::strstr(mapping, "paddle4:") != nullptr;
+}
+
+static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
+{
+    if (!isDualSenseEdgeController(controller)) {
+        return;
+    }
+
+    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(controller);
+    if (joystick == nullptr || SDL_JoystickNumButtons(joystick) < DUALSENSE_EDGE_MIN_BUTTONS) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "DualSense Edge detected, but SDL does not expose the Edge-specific buttons");
+        return;
+    }
+
+    char* mapping = SDL_GameControllerMapping(controller);
+    if (mapping == nullptr) {
+        return;
+    }
+
+    if (mappingHasPaddles(mapping)) {
+        SDL_free(mapping);
+        return;
+    }
+
+    QString updatedMapping = QString::fromUtf8(mapping);
+    SDL_free(mapping);
+
+    int platformIndex = updatedMapping.indexOf(",platform:");
+    if (platformIndex >= 0) {
+        updatedMapping.insert(platformIndex + 1, DUALSENSE_EDGE_PADDLE_MAPPINGS);
+    }
+    else {
+        if (!updatedMapping.endsWith(",")) {
+            updatedMapping.append(",");
+        }
+        updatedMapping.append(DUALSENSE_EDGE_PADDLE_MAPPINGS);
+    }
+
+    int ret = SDL_GameControllerAddMapping(qPrintable(updatedMapping));
+    if (ret < 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Failed to add DualSense Edge paddle mappings: %s",
+                    SDL_GetError());
+    }
+    else {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Added DualSense Edge paddle mappings");
+    }
+}
 
 GamepadState*
 SdlInputHandler::findStateForGamepad(SDL_JoystickID id)
@@ -607,6 +681,8 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
             hapticCaps = 0;
         }
 #endif
+
+        addDualSenseEdgePaddleMapping(state->controller);
 
         mapping = SDL_GameControllerMapping(state->controller);
         name = SDL_GameControllerName(state->controller);

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -42,6 +42,17 @@
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 19
 #define DUALSENSE_EDGE_PADDLE_MAPPING_COUNT 4
 
+static_assert(PADDLE1_FLAG == 0x010000,
+              "DualSense Edge PADDLE1 must stay in the Sunshine buttonFlags2 high word");
+static_assert(PADDLE2_FLAG == 0x020000,
+              "DualSense Edge PADDLE2 must stay in the Sunshine buttonFlags2 high word");
+static_assert(PADDLE3_FLAG == 0x040000,
+              "DualSense Edge PADDLE3 must stay in the Sunshine buttonFlags2 high word");
+static_assert(PADDLE4_FLAG == 0x080000,
+              "DualSense Edge PADDLE4 must stay in the Sunshine buttonFlags2 high word");
+static_assert(DUALSENSE_EDGE_PADDLE_FLAGS == 0x0f0000,
+              "DualSense Edge paddle/Fn mask must preserve all four high-word bits");
+
 #if SDL_VERSION_ATLEAST(2, 0, 14)
 static_assert(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 == SDL_CONTROLLER_BUTTON_PADDLE1,
               "DualSense Edge PADDLE1 mapping must match SDL2's controller button order");
@@ -375,9 +386,14 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     }
 
     int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
+    SDL_version version;
+    SDL_GetVersion(&version);
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "DualSense Edge detected with %d SDL joystick buttons",
-                buttonCount);
+                "DualSense Edge detected with %d SDL joystick buttons (SDL %d.%d.%d)",
+                buttonCount,
+                version.major,
+                version.minor,
+                version.patch);
 
     if (!dualSenseEdgeExposesPaddleButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -569,7 +569,11 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
     if (isDualSenseEdgeController(state->controller) &&
         isDualSenseEdgePaddleControllerButton(event->button) &&
         !dualSenseEdgeHasPaddleControllerButtons(state->controller)) {
+        int previousButtons = state->buttons;
         state->buttons &= ~k_ButtonMap[event->button];
+        if (previousButtons != state->buttons && state->mouseEmulationTimer == 0) {
+            sendGamepadState(state);
+        }
         SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
                      "Ignoring DualSense Edge %s event without verified paddle bindings",
                      dualSenseEdgePaddleButtonName(event->button));

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -268,6 +268,9 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
                     SDL_GetError());
         return false;
     }
+    // SDL refreshes open controllers when an existing mapping is updated and
+    // returns 0 for that path. A new mapping returns >0, so reopen below to
+    // bind this controller to it before sending arrival capabilities.
     else if (ret == 0 && !dualSenseEdgeHasPaddleControllerButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                     "DualSense Edge paddle mapping update did not expose the paddle controller buttons");

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -159,14 +159,19 @@ static void addDualSenseEdgePaddleMappingChange(QString* changedMappings, int ma
 
 static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString* changedMappings)
 {
-    QStringList entries = QString::fromUtf8(mapping).split(',');
+    QString originalMapping = QString::fromUtf8(mapping);
+    QStringList entries = originalMapping.split(',');
     QStringList updatedEntries;
     bool foundMappings[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {};
+    bool changedMappingEntries[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {};
+    bool hasChangedMappingEntries = false;
 
     changedMappings->clear();
 
     // Normalize existing paddle entries too, because a stale mapping can expose
-    // paddle buttons while assigning the wrong raw DualSense Edge buttons.
+    // paddle buttons while assigning the wrong raw DualSense Edge buttons. Pull
+    // them out and reinsert the canonical block below so they never sit behind
+    // SDL metadata entries like platform: or crc:.
     for (int i = 0; i < entries.size(); i++) {
         const QString& entry = entries.at(i);
         int mappingIndex = dualSenseEdgePaddleMappingIndex(entry);
@@ -177,16 +182,17 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
         }
 
         if (foundMappings[mappingIndex]) {
-            addDualSenseEdgePaddleMappingChange(changedMappings, mappingIndex);
+            changedMappingEntries[mappingIndex] = true;
+            hasChangedMappingEntries = true;
             continue;
         }
 
         QString expectedEntry = dualSenseEdgePaddleMappingEntry(mappingIndex);
-        updatedEntries.append(expectedEntry);
         foundMappings[mappingIndex] = true;
 
         if (entry != expectedEntry) {
-            addDualSenseEdgePaddleMappingChange(changedMappings, mappingIndex);
+            changedMappingEntries[mappingIndex] = true;
+            hasChangedMappingEntries = true;
         }
     }
 
@@ -206,12 +212,26 @@ static QString normalizeDualSenseEdgePaddleMappings(const char* mapping, QString
 
     for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
         if (!foundMappings[i]) {
-            updatedEntries.insert(insertionIndex++, dualSenseEdgePaddleMappingEntry(i));
+            changedMappingEntries[i] = true;
+            hasChangedMappingEntries = true;
+        }
+        updatedEntries.insert(insertionIndex++, dualSenseEdgePaddleMappingEntry(i));
+    }
+
+    QString updatedMapping = updatedEntries.join(",");
+    if (updatedMapping != originalMapping && !hasChangedMappingEntries) {
+        for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+            changedMappingEntries[i] = true;
+        }
+    }
+
+    for (int i = 0; i < DUALSENSE_EDGE_PADDLE_MAPPING_COUNT; i++) {
+        if (changedMappingEntries[i]) {
             addDualSenseEdgePaddleMappingChange(changedMappings, i);
         }
     }
 
-    return updatedEntries.join(",");
+    return updatedMapping;
 }
 
 static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -109,6 +109,8 @@ static const char* dualSenseEdgePaddleButtonName(Uint8 button)
 static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controller)
 {
 #if SDL_VERSION_ATLEAST(2, 0, 14)
+    // Raw joystick button count only proves SDL can see the physical controls.
+    // The controller-button layer is what Moonlight can transmit as paddles.
     return SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1) &&
            SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2) &&
            SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3) &&

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -389,8 +389,10 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     SDL_version version;
     SDL_GetVersion(&version);
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "DualSense Edge detected with %d SDL joystick buttons (SDL %d.%d.%d)",
+                "DualSense Edge detected with %d SDL joystick buttons (VID/PID: 0x%.4x/0x%.4x) (SDL %d.%d.%d)",
                 buttonCount,
+                (unsigned int)SDL_GameControllerGetVendor(controller),
+                (unsigned int)SDL_GameControllerGetProduct(controller),
                 version.major,
                 version.minor,
                 version.patch);

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -863,6 +863,10 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
 
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                         "Reopened DualSense Edge after adding paddle mappings");
+            if (!dualSenseEdgeHasPaddleControllerButtons(controller)) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "DualSense Edge paddle mapping add did not expose the expected paddle controller bindings");
+            }
         }
 
         state = &m_GamepadState[i];

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -42,6 +42,17 @@
 #define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 19
 #define DUALSENSE_EDGE_PADDLE_MAPPING_COUNT 4
 
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+static_assert(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 == SDL_CONTROLLER_BUTTON_PADDLE1,
+              "DualSense Edge PADDLE1 mapping must match SDL2's controller button order");
+static_assert(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2 == SDL_CONTROLLER_BUTTON_PADDLE2,
+              "DualSense Edge PADDLE2 mapping must match SDL2's controller button order");
+static_assert(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3 == SDL_CONTROLLER_BUTTON_PADDLE3,
+              "DualSense Edge PADDLE3 mapping must match SDL2's controller button order");
+static_assert(DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 == SDL_CONTROLLER_BUTTON_PADDLE4,
+              "DualSense Edge PADDLE4 mapping must match SDL2's controller button order");
+#endif
+
 static const char* const DUALSENSE_EDGE_PADDLE_MAPPING_KEYS[DUALSENSE_EDGE_PADDLE_MAPPING_COUNT] = {
     "paddle1",
     "paddle2",

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -92,6 +92,18 @@ static const char* dualSenseEdgePaddleButtonName(Uint8 button)
     }
 }
 
+static bool dualSenseEdgeHasPaddleControllerButtons(SDL_GameController* controller)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    return SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1) &&
+           SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE2) &&
+           SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE3) &&
+           SDL_GameControllerHasButton(controller, (SDL_GameControllerButton)DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4);
+#else
+    return false;
+#endif
+}
+
 static QString missingDualSenseEdgePaddleMappings(const char* mapping)
 {
     QString missingMappings;
@@ -113,6 +125,10 @@ static QString missingDualSenseEdgePaddleMappings(const char* mapping)
 
 static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
 {
+#if !SDL_VERSION_ATLEAST(2, 0, 14)
+    Q_UNUSED(controller);
+    return false;
+#else
     if (!isDualSenseEdgeController(controller)) {
         return false;
     }
@@ -140,8 +156,14 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
 
     QString missingMappings = missingDualSenseEdgePaddleMappings(mapping);
     if (missingMappings.isEmpty()) {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                    "DualSense Edge paddle mappings already present");
+        if (dualSenseEdgeHasPaddleControllerButtons(controller)) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "DualSense Edge paddle mappings already present");
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "DualSense Edge paddle mappings are present, but SDL did not expose the paddle controller buttons");
+        }
         SDL_free(mapping);
         return false;
     }
@@ -167,6 +189,11 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
                     SDL_GetError());
         return false;
     }
+    else if (ret == 0 && !dualSenseEdgeHasPaddleControllerButtons(controller)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "DualSense Edge paddle mapping update did not expose the paddle controller buttons");
+        return false;
+    }
     else {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "Applied DualSense Edge paddle mappings (%s): %s",
@@ -174,6 +201,7 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
                     qPrintable(missingMappings));
         return ret > 0;
     }
+#endif
 }
 
 GamepadState*
@@ -820,7 +848,8 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
         }
         bool isDualSenseEdge = isDualSenseEdgeController(state->controller);
         int dualSenseEdgeButtonCount = isDualSenseEdge ? dualSenseEdgeJoystickButtonCount(state->controller) : 0;
-        if (isDualSenseEdge && dualSenseEdgeButtonCount >= DUALSENSE_EDGE_MIN_BUTTONS) {
+        bool hasDualSenseEdgePaddleButtons = isDualSenseEdge && dualSenseEdgeHasPaddleControllerButtons(state->controller);
+        if (hasDualSenseEdgePaddleButtons) {
             supportedButtonFlags |= DUALSENSE_EDGE_PADDLE_FLAGS;
         }
 

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -53,8 +53,12 @@ const int SdlInputHandler::k_ButtonMap[] = {
 
 static bool isDualSenseEdgeController(SDL_GameController* controller)
 {
+#if SDL_VERSION_ATLEAST(2, 0, 6)
     return SDL_GameControllerGetVendor(controller) == SONY_VENDOR_ID &&
            SDL_GameControllerGetProduct(controller) == DUALSENSE_EDGE_PRODUCT_ID;
+#else
+    return false;
+#endif
 }
 
 static int dualSenseEdgeJoystickButtonCount(SDL_GameController* controller)
@@ -107,10 +111,10 @@ static QString missingDualSenseEdgePaddleMappings(const char* mapping)
     return missingMappings;
 }
 
-static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
+static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
 {
     if (!isDualSenseEdgeController(controller)) {
-        return;
+        return false;
     }
 
     int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
@@ -123,7 +127,7 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
                     "DualSense Edge detected, but SDL exposes %d buttons; need at least %d for Edge-specific buttons",
                     buttonCount,
                     DUALSENSE_EDGE_MIN_BUTTONS);
-        return;
+        return false;
     }
 
     char* mapping = SDL_GameControllerMapping(controller);
@@ -131,7 +135,7 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                     "Unable to query DualSense Edge controller mapping: %s",
                     SDL_GetError());
-        return;
+        return false;
     }
 
     QString missingMappings = missingDualSenseEdgePaddleMappings(mapping);
@@ -139,7 +143,7 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "DualSense Edge paddle mappings already present");
         SDL_free(mapping);
-        return;
+        return false;
     }
 
     QString updatedMapping = QString::fromUtf8(mapping);
@@ -161,12 +165,14 @@ static void addDualSenseEdgePaddleMapping(SDL_GameController* controller)
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                     "Failed to add DualSense Edge paddle mappings: %s",
                     SDL_GetError());
+        return false;
     }
     else {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "Applied DualSense Edge paddle mappings (%s): %s",
                     ret > 0 ? "added" : "updated",
                     qPrintable(missingMappings));
+        return ret > 0;
     }
 }
 
@@ -693,6 +699,20 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
             return;
         }
 
+        if (addDualSenseEdgePaddleMapping(controller)) {
+            SDL_GameControllerClose(controller);
+            controller = SDL_GameControllerOpen(event->which);
+            if (controller == NULL) {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                             "Failed to reopen DualSense Edge after applying paddle mappings: %s",
+                             SDL_GetError());
+                return;
+            }
+
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Reopened DualSense Edge after adding paddle mappings");
+        }
+
         state = &m_GamepadState[i];
         if (m_MultiController) {
             state->index = i;
@@ -753,13 +773,15 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
         }
 #endif
 
-        addDualSenseEdgePaddleMapping(state->controller);
-
         mapping = SDL_GameControllerMapping(state->controller);
         name = SDL_GameControllerName(state->controller);
 
-        uint16_t vendorId = SDL_GameControllerGetVendor(state->controller);
-        uint16_t productId = SDL_GameControllerGetProduct(state->controller);
+        uint16_t vendorId = 0;
+        uint16_t productId = 0;
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+        vendorId = SDL_GameControllerGetVendor(state->controller);
+        productId = SDL_GameControllerGetProduct(state->controller);
+#endif
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "Gamepad %d (player %d) is: %s (VID/PID: 0x%.4x/0x%.4x) (haptic capabilities: 0x%x) (mapping: %s -> %s)",
                     i,

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -127,14 +127,25 @@ static bool dualSenseEdgeHasSdl3VersionHint()
     return sdl3Version != nullptr && sdl3Version[0] != '\0';
 }
 
+static bool dualSenseEdgeRuntimeLooksLikeSdl2Compat()
+{
+    SDL_version version;
+    SDL_GetVersion(&version);
+
+    // Some older sdl2-compat builds do not set SDL3_VERSION. Moonlight already
+    // treats high-patch SDL2 compatibility versions as sdl2-compat in main.cpp;
+    // use that runtime signal instead of trusting an ambiguous 17-button shape.
+    return version.major == 2 && version.patch >= 50;
+}
+
 static bool dualSenseEdgeUsesSdl3CompatMappings(SDL_GameController* controller)
 {
     if (dualSenseEdgeHasSdl3VersionHint()) {
         return true;
     }
 
-    int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
-    return buttonCount == DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS;
+    Q_UNUSED(controller);
+    return dualSenseEdgeRuntimeLooksLikeSdl2Compat();
 }
 
 static const char* dualSenseEdgeRawMappingName(SDL_GameController* controller)

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -507,11 +507,11 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
 
     const char* edgeButtonName = dualSenseEdgePaddleButtonName(event->button);
     if (edgeButtonName != nullptr && isDualSenseEdgeController(state->controller)) {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                    "DualSense Edge %s %s (paddle/Fn flags: 0x%08x)",
-                    edgeButtonName,
-                    event->state == SDL_PRESSED ? "pressed" : "released",
-                    (unsigned int)(state->buttons & DUALSENSE_EDGE_PADDLE_FLAGS));
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                     "DualSense Edge %s %s (paddle/Fn flags: 0x%08x)",
+                     edgeButtonName,
+                     event->state == SDL_PRESSED ? "pressed" : "released",
+                     (unsigned int)(state->buttons & DUALSENSE_EDGE_PADDLE_FLAGS));
     }
 
     // Handle Start+Select+L1+R1 as a gamepad quit combo

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -153,6 +153,17 @@ static const char* dualSenseEdgeRawMappingName(SDL_GameController* controller)
     return dualSenseEdgeUsesSdl3CompatMappings(controller) ? "SDL3/sdl2-compat" : "SDL2";
 }
 
+static const char* dualSenseEdgeRawMappingSignal()
+{
+    if (dualSenseEdgeHasSdl3VersionHint()) {
+        return "SDL3_VERSION";
+    }
+    if (dualSenseEdgeRuntimeLooksLikeSdl2Compat()) {
+        return "sdl2-compat runtime version";
+    }
+    return "native SDL2 runtime";
+}
+
 static QString dualSenseEdgeRuntimeSdlSummary()
 {
     SDL_version version;
@@ -470,13 +481,14 @@ static bool addDualSenseEdgePaddleMapping(SDL_GameController* controller)
     int buttonCount = dualSenseEdgeJoystickButtonCount(controller);
     QString runtimeSdlSummary = dualSenseEdgeRuntimeSdlSummary();
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "DualSense Edge detected with %d SDL joystick buttons (need %d for %s Edge raw mapping) (VID/PID: 0x%.4x/0x%.4x) (%s)",
+                "DualSense Edge detected with %d SDL joystick buttons (need %d for %s Edge raw mapping) (VID/PID: 0x%.4x/0x%.4x) (%s) (raw mapping signal: %s)",
                 buttonCount,
                 dualSenseEdgeMinimumButtonCount(controller),
                 dualSenseEdgeRawMappingName(controller),
                 (unsigned int)SDL_GameControllerGetVendor(controller),
                 (unsigned int)SDL_GameControllerGetProduct(controller),
-                qPrintable(runtimeSdlSummary));
+                qPrintable(runtimeSdlSummary),
+                dualSenseEdgeRawMappingSignal());
 
     if (!dualSenseEdgeExposesPaddleButtons(controller)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -664,9 +664,14 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
         return;
     }
 
-    if (isDualSenseEdgeController(state->controller) &&
-        isDualSenseEdgePaddleControllerButton(event->button) &&
-        !dualSenseEdgeHasPaddleControllerButtons(state->controller)) {
+    const bool isDualSenseEdge = isDualSenseEdgeController(state->controller);
+    const bool isDualSenseEdgePaddleButton = isDualSenseEdgePaddleControllerButton(event->button);
+    const bool hasDualSenseEdgePaddleButtons =
+            isDualSenseEdge && dualSenseEdgeHasPaddleControllerButtons(state->controller);
+
+    if (isDualSenseEdge &&
+        isDualSenseEdgePaddleButton &&
+        !hasDualSenseEdgePaddleButtons) {
         int previousButtons = state->buttons;
         state->buttons &= ~k_ButtonMap[event->button];
         if (previousButtons != state->buttons && state->mouseEmulationTimer == 0) {
@@ -677,8 +682,7 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
                      dualSenseEdgePaddleButtonName(event->button));
         return;
     }
-    if (isDualSenseEdgeController(state->controller) &&
-        !dualSenseEdgeHasPaddleControllerButtons(state->controller)) {
+    if (isDualSenseEdge && !isDualSenseEdgePaddleButton) {
         int rawPaddleIndex = dualSenseEdgeControllerButtonRawPaddleIndex(state->controller, event->button);
         if (rawPaddleIndex >= 0) {
             int previousButtons = state->buttons;
@@ -688,7 +692,7 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
                 sendGamepadState(state);
             }
             SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "Ignoring DualSense Edge controller button %s bound to raw %s without verified paddle bindings",
+                         "Ignoring DualSense Edge controller button %s bound to raw %s as stale Edge raw alias",
                          buttonName != nullptr ? buttonName : "<unknown>",
                          qPrintable(dualSenseEdgePaddleMappingEntry(rawPaddleIndex)));
             return;

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -9,7 +9,13 @@ const path = require('path');
 
 const repoRoot = path.resolve(__dirname, '..');
 const gamepadPath = path.join(repoRoot, 'app', 'streaming', 'input', 'gamepad.cpp');
+const limelightPath = path.join(repoRoot, 'moonlight-common-c', 'moonlight-common-c', 'src', 'Limelight.h');
+const inputHeaderPath = path.join(repoRoot, 'moonlight-common-c', 'moonlight-common-c', 'src', 'Input.h');
+const inputStreamPath = path.join(repoRoot, 'moonlight-common-c', 'moonlight-common-c', 'src', 'InputStream.c');
 const source = fs.readFileSync(gamepadPath, 'utf8');
+const limelightSource = fs.readFileSync(limelightPath, 'utf8');
+const inputHeaderSource = fs.readFileSync(inputHeaderPath, 'utf8');
+const inputStreamSource = fs.readFileSync(inputStreamPath, 'utf8');
 
 const paddleKeys = ['paddle1', 'paddle2', 'paddle3', 'paddle4'];
 const sdl2PaddleButtons = [20, 19, 18, 17];
@@ -28,8 +34,12 @@ function assert(condition, message) {
   }
 }
 
+function assertInSource(sourceText, pattern, message) {
+  assert(pattern.test(sourceText), message);
+}
+
 function assertSource(pattern, message) {
-  assert(pattern.test(source), message);
+  assertInSource(source, pattern, message);
 }
 
 function usesSdl3CompatMappings(hasSdl3VersionHint, buttonCount) {
@@ -48,6 +58,10 @@ function minimumButtonCount(hasSdl3VersionHint, buttonCount) {
 
 function exposesPaddleButtons(hasSdl3VersionHint, buttonCount) {
   return buttonCount >= minimumButtonCount(hasSdl3VersionHint, buttonCount);
+}
+
+function sunshineButtonFlags2(buttonFlags) {
+  return (buttonFlags >>> 16) & 0xffff;
 }
 
 function assertRuntimeSelection(hasSdl3VersionHint, buttonCount, expectedUsesSdl3Compat, expectedExposesPaddles, message) {
@@ -209,6 +223,14 @@ assertSource(/DualSense Edge arrival support: buttons=%d sdlType=%d arrivalType=
 assertSource(/DualSense Edge %s %s \(paddle\/Fn flags: 0x%08x\)/, 'DualSense Edge per-button evidence log format changed');
 assertSource(/as stale Edge raw alias/, 'DualSense Edge stale raw-alias diagnostic missing');
 assertSource(/not advertising it as a normal button/, 'DualSense Edge capability alias diagnostic missing');
+assertInSource(limelightSource, /#define PADDLE1_FLAG\s+0x010000\b/, 'Moonlight common PADDLE1 flag must stay in the Sunshine high word');
+assertInSource(limelightSource, /#define PADDLE2_FLAG\s+0x020000\b/, 'Moonlight common PADDLE2 flag must stay in the Sunshine high word');
+assertInSource(limelightSource, /#define PADDLE3_FLAG\s+0x040000\b/, 'Moonlight common PADDLE3 flag must stay in the Sunshine high word');
+assertInSource(limelightSource, /#define PADDLE4_FLAG\s+0x080000\b/, 'Moonlight common PADDLE4 flag must stay in the Sunshine high word');
+assertInSource(inputHeaderSource, /short buttonFlags2; \/\/ Sunshine protocol extension \(always 0 for GFE\)/, 'multi-controller packet must retain the Sunshine buttonFlags2 extension');
+assertInSource(inputStreamSource, /buttonFlags2 != \(IS_SUNSHINE\(\) \? LE16\(\(short\)\(buttonFlags >> 16\)\) : 0\)/, 'batched controller comparison must include Sunshine high-word buttonFlags2');
+assertInSource(inputStreamSource, /buttonFlags2 = IS_SUNSHINE\(\) \? LE16\(\(short\)\(buttonFlags >> 16\)\) : 0;/, 'controller packets must carry high-word Edge buttons in Sunshine buttonFlags2');
+assertInSource(inputStreamSource, /controllerArrival\.supportedButtonFlags = LE32\(supportedButtonFlags\);/, 'arrival packets must advertise the full 32-bit supported button mask');
 
 assertRuntimeSelection(false, 21, false, true, 'native SDL2 exposes the 21-button Edge shape');
 assertRuntimeSelection(false, 20, false, false, 'unknown 20-button Edge shape fails closed without an SDL3 hint');
@@ -217,6 +239,24 @@ assertRuntimeSelection(false, 17, true, true, 'exact 17-button Edge shape select
 assertRuntimeSelection(true, 21, true, true, 'SDL3 hint selects sdl2-compat mapping even if future SDL3 exposes more raw buttons');
 assertRuntimeSelection(true, 17, true, true, 'SDL3 hint accepts current sdl2-compat Edge shape');
 assertRuntimeSelection(true, 16, true, false, 'SDL3 hint still requires enough raw buttons');
+
+[
+  [0x010000, 0x0001, 'PADDLE1'],
+  [0x020000, 0x0002, 'PADDLE2'],
+  [0x040000, 0x0004, 'PADDLE3'],
+  [0x080000, 0x0008, 'PADDLE4'],
+].forEach(([buttonFlag, expectedButtonFlags2, name]) => {
+  assert(
+    sunshineButtonFlags2(buttonFlag) === expectedButtonFlags2,
+    `${name} must serialize to Sunshine buttonFlags2 bit 0x${expectedButtonFlags2.toString(16).padStart(4, '0')}`
+  );
+  assert(
+    (buttonFlag & 0xffff) === 0,
+    `${name} must not collide with the legacy 16-bit buttonFlags field`
+  );
+});
+assert(sunshineButtonFlags2(0x0f0000) === 0x000f, 'all Edge paddle/Fn buttons must serialize as buttonFlags2 mask 0x000f');
+assert(sunshineButtonFlags2(0x2f0000) === 0x002f, 'Edge paddle/Fn, touchpad, and misc buttons must all survive in Sunshine buttonFlags2');
 
 function allPaddles(paddleButtons) {
   return paddleKeys.map((_, index) => paddleMappingEntry(index, paddleButtons)).join(',');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -14,6 +14,8 @@ const source = fs.readFileSync(gamepadPath, 'utf8');
 const paddleKeys = ['paddle1', 'paddle2', 'paddle3', 'paddle4'];
 const sdl2PaddleButtons = [20, 19, 18, 17];
 const sdl3CompatPaddleButtons = [16, 15, 14, 13];
+const sdl2MinButtons = 21;
+const sdl3CompatMinButtons = 17;
 
 function fail(message) {
   console.error(`DualSense Edge mapping verification failed: ${message}`);
@@ -28,6 +30,38 @@ function assert(condition, message) {
 
 function assertSource(pattern, message) {
   assert(pattern.test(source), message);
+}
+
+function usesSdl3CompatMappings(hasSdl3VersionHint, buttonCount) {
+  if (hasSdl3VersionHint) {
+    return true;
+  }
+
+  return buttonCount === sdl3CompatMinButtons;
+}
+
+function minimumButtonCount(hasSdl3VersionHint, buttonCount) {
+  return usesSdl3CompatMappings(hasSdl3VersionHint, buttonCount) ?
+    sdl3CompatMinButtons :
+    sdl2MinButtons;
+}
+
+function exposesPaddleButtons(hasSdl3VersionHint, buttonCount) {
+  return buttonCount >= minimumButtonCount(hasSdl3VersionHint, buttonCount);
+}
+
+function assertRuntimeSelection(hasSdl3VersionHint, buttonCount, expectedUsesSdl3Compat, expectedExposesPaddles, message) {
+  const actualUsesSdl3Compat = usesSdl3CompatMappings(hasSdl3VersionHint, buttonCount);
+  const actualExposesPaddles = exposesPaddleButtons(hasSdl3VersionHint, buttonCount);
+
+  assert(
+    actualUsesSdl3Compat === expectedUsesSdl3Compat,
+    `${message}: raw mapping selection expected ${expectedUsesSdl3Compat ? 'SDL3/sdl2-compat' : 'SDL2'} but got ${actualUsesSdl3Compat ? 'SDL3/sdl2-compat' : 'SDL2'}`
+  );
+  assert(
+    actualExposesPaddles === expectedExposesPaddles,
+    `${message}: paddle exposure expected ${expectedExposesPaddles} but got ${actualExposesPaddles}`
+  );
 }
 
 function paddleMappingEntry(index, paddleButtons) {
@@ -169,6 +203,14 @@ assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge mini
 assertSource(/SDL3.*QString::fromUtf8\(sdl3Version\)/s, 'Edge detection log must include underlying SDL3 runtime version when available');
 assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');
 assertSource(/mappingEntry\.startsWith\("face:"\)/, 'SDL3 face metadata must stay treated as non-binding metadata');
+
+assertRuntimeSelection(false, 21, false, true, 'native SDL2 exposes the 21-button Edge shape');
+assertRuntimeSelection(false, 20, false, false, 'unknown 20-button Edge shape fails closed without an SDL3 hint');
+assertRuntimeSelection(false, 18, false, false, 'unknown 18-button Edge shape fails closed without an SDL3 hint');
+assertRuntimeSelection(false, 17, true, true, 'exact 17-button Edge shape selects sdl2-compat/SDL3 fallback');
+assertRuntimeSelection(true, 21, true, true, 'SDL3 hint selects sdl2-compat mapping even if future SDL3 exposes more raw buttons');
+assertRuntimeSelection(true, 17, true, true, 'SDL3 hint accepts current sdl2-compat Edge shape');
+assertRuntimeSelection(true, 16, true, false, 'SDL3 hint still requires enough raw buttons');
 
 function allPaddles(paddleButtons) {
   return paddleKeys.map((_, index) => paddleMappingEntry(index, paddleButtons)).join(',');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -250,10 +250,9 @@ function hasDetectionEvidence(log, variant) {
   return false;
 }
 
-function hasMappingEvidence(log, variant) {
+function hasMappingEvidence(log) {
   return log.includes('DualSense Edge paddle mappings already present') ||
-         log.includes(`Applied DualSense Edge paddle mappings (updated): ${variant.logMappings}`) ||
-         log.includes(`Applied DualSense Edge paddle mappings (added): ${variant.logMappings}`);
+         /Applied DualSense Edge paddle mappings \((added|updated)\): /.test(log);
 }
 
 function hasArrivalEvidence(log, variant) {
@@ -430,6 +429,15 @@ assertMoonlightLogEvidence(
   moonlightEvidenceVariants.sdl2,
   true,
   'already-present mapping line satisfies Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.replace(
+    `Applied DualSense Edge paddle mappings (updated): ${moonlightEvidenceVariants.sdl2.logMappings}`,
+    'Applied DualSense Edge paddle mappings (updated): paddle2:b19,paddle4:b17'
+  ),
+  moonlightEvidenceVariants.sdl2,
+  true,
+  'partial mapping-change line can satisfy Moonlight log evidence when arrival bindings are complete'
 );
 assertMoonlightLogEvidence(
   withoutLogLine(completeSdl2MoonlightLog, 'DualSense Edge PADDLE4 released (paddle/Fn flags: 0x00000000)'),

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Verifies the DualSense Edge SDL2 mapping assumptions used by
+ * Verifies the DualSense Edge SDL controller mapping assumptions used by
  * app/streaming/input/gamepad.cpp without requiring physical hardware.
  */
 
@@ -203,6 +203,12 @@ assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge mini
 assertSource(/SDL3.*QString::fromUtf8\(sdl3Version\)/s, 'Edge detection log must include underlying SDL3 runtime version when available');
 assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');
 assertSource(/mappingEntry\.startsWith\("face:"\)/, 'SDL3 face metadata must stay treated as non-binding metadata');
+assertSource(/isDualSenseEdge && type != LI_CTYPE_PS[\s\S]*type = LI_CTYPE_PS;/, 'DualSense Edge must advertise PlayStation arrival type by VID/PID even if SDL type is generic');
+assertSource(/supportedButtonFlags &= ~DUALSENSE_EDGE_PADDLE_FLAGS[\s\S]*supportedButtonFlags \|= DUALSENSE_EDGE_PADDLE_FLAGS/, 'DualSense Edge paddle/Fn support must only be advertised after verified controller-button bindings');
+assertSource(/DualSense Edge arrival support: buttons=%d sdlType=%d arrivalType=0x%02x supportedButtonFlags=0x%08x paddle\/Fn=0x%08x capabilities=0x%08x bindings=%s/, 'DualSense Edge arrival evidence log format changed');
+assertSource(/DualSense Edge %s %s \(paddle\/Fn flags: 0x%08x\)/, 'DualSense Edge per-button evidence log format changed');
+assertSource(/as stale Edge raw alias/, 'DualSense Edge stale raw-alias diagnostic missing');
+assertSource(/not advertising it as a normal button/, 'DualSense Edge capability alias diagnostic missing');
 
 assertRuntimeSelection(false, 21, false, true, 'native SDL2 exposes the 21-button Edge shape');
 assertRuntimeSelection(false, 20, false, false, 'unknown 20-button Edge shape fails closed without an SDL3 hint');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -164,7 +164,7 @@ assertSource(/static_assert\(PADDLE4_FLAG == 0x080000/, 'PADDLE4 high-word asser
 assertSource(/SDL_CONTROLLER_BUTTON_MISC1 == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 - 1/, 'MISC/PADDLE adjacency assertion missing');
 assertSource(/SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 \+ 1/, 'PADDLE/TOUCHPAD adjacency assertion missing');
 assertSource(/SDL_GetHint\("SDL3_VERSION"\)/, 'sdl2-compat/SDL3 runtime detection missing');
-assertSource(/buttonCount >= DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS &&\s*buttonCount < DUALSENSE_EDGE_SDL2_MIN_BUTTONS/, 'sdl2-compat/SDL3 raw count fallback missing');
+assertSource(/buttonCount == DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS/, 'sdl2-compat/SDL3 exact raw count fallback missing');
 assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge minimum raw button count selection missing');
 assertSource(/SDL3.*QString::fromUtf8\(sdl3Version\)/s, 'Edge detection log must include underlying SDL3 runtime version when available');
 assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -217,6 +217,7 @@ const moonlightEvidenceVariants = {
     minButtons: sdl2MinButtons,
     rawMappingName: 'SDL2',
     runtimeVersionPattern: /SDL \d+\.\d+\.\d+\)/,
+    rawMappingSignalPattern: /^native SDL2 runtime$/,
     bindings: bindingSummary(sdl2PaddleButtons),
     logMappings: logMappingSummary(sdl2PaddleButtons),
   },
@@ -224,14 +225,15 @@ const moonlightEvidenceVariants = {
     label: 'sdl2-compat/SDL3',
     minButtons: sdl3CompatMinButtons,
     rawMappingName: 'SDL3/sdl2-compat',
-    runtimeVersionPattern: /SDL \d+\.\d+\.\d+, SDL3 \d+\.\d+\.\d+\)/,
+    runtimeVersionPattern: /^(?:SDL \d+\.\d+\.\d+, SDL3 \d+\.\d+\.\d+\)|SDL 2\.\d+\.(?:[5-9]\d|[1-9]\d{2,})\))$/,
+    rawMappingSignalPattern: /^(SDL3_VERSION|sdl2-compat runtime version)$/,
     bindings: bindingSummary(sdl3CompatPaddleButtons),
     logMappings: logMappingSummary(sdl3CompatPaddleButtons),
   },
 };
 
 function hasDetectionEvidence(log, variant) {
-  const detectionPattern = /DualSense Edge detected with (\d+) SDL joystick buttons \(need (\d+) for (SDL2|SDL3\/sdl2-compat) Edge raw mapping\) \(VID\/PID: 0x054c\/0x0df2\) \((SDL \d+\.\d+\.\d+(?:, SDL3 \d+\.\d+\.\d+)?)\)/g;
+  const detectionPattern = /DualSense Edge detected with (\d+) SDL joystick buttons \(need (\d+) for (SDL2|SDL3\/sdl2-compat) Edge raw mapping\) \(VID\/PID: 0x054c\/0x0df2\) \((SDL \d+\.\d+\.\d+(?:, SDL3 \d+\.\d+\.\d+)?)\) \(raw mapping signal: ([^)]+)\)/g;
   let match;
 
   while ((match = detectionPattern.exec(log)) !== null) {
@@ -239,10 +241,12 @@ function hasDetectionEvidence(log, variant) {
     const requiredButtons = Number(match[2]);
     const rawMappingName = match[3];
     const runtimeVersion = `${match[4]})`;
+    const rawMappingSignal = match[5];
     if (buttonCount >= variant.minButtons &&
         requiredButtons === variant.minButtons &&
         rawMappingName === variant.rawMappingName &&
-        variant.runtimeVersionPattern.test(runtimeVersion)) {
+        variant.runtimeVersionPattern.test(runtimeVersion) &&
+        variant.rawMappingSignalPattern.test(rawMappingSignal)) {
       return true;
     }
   }
@@ -335,8 +339,11 @@ function hasCompleteMoonlightLogEvidence(log, variant) {
 }
 
 function makeCompleteMoonlightLog(variant) {
+  const runtimeSummary = variant.rawMappingName === 'SDL2' ? 'SDL 2.30.9' : 'SDL 2.32.70, SDL3 3.4.11';
+  const rawMappingSignal = variant.rawMappingName === 'SDL2' ? 'native SDL2 runtime' : 'SDL3_VERSION';
+
   return [
-    `DualSense Edge detected with ${variant.minButtons} SDL joystick buttons (need ${variant.minButtons} for ${variant.rawMappingName} Edge raw mapping) (VID/PID: 0x054c/0x0df2) (${variant.rawMappingName === 'SDL2' ? 'SDL 2.30.9' : 'SDL 2.32.70, SDL3 3.4.11'})`,
+    `DualSense Edge detected with ${variant.minButtons} SDL joystick buttons (need ${variant.minButtons} for ${variant.rawMappingName} Edge raw mapping) (VID/PID: 0x054c/0x0df2) (${runtimeSummary}) (raw mapping signal: ${rawMappingSignal})`,
     `Applied DualSense Edge paddle mappings (updated): ${variant.logMappings}`,
     `DualSense Edge arrival support: buttons=${variant.minButtons} sdlType=4 arrivalType=0x02 supportedButtonFlags=0x000f0000 paddle/Fn=0x000f0000 capabilities=0x00000000 bindings=${variant.bindings}`,
     'DualSense Edge PADDLE1 pressed (paddle/Fn flags: 0x00010000)',
@@ -374,6 +381,7 @@ assertSource(/SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON
 assertSource(/SDL_GetHint\("SDL3_VERSION"\)/, 'sdl2-compat/SDL3 runtime detection missing');
 assertSource(/version\.major == 2 && version\.patch >= 50/, 'sdl2-compat/SDL3 runtime-version fallback missing');
 assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge minimum raw button count selection missing');
+assertSource(/raw mapping signal: %s/, 'Edge detection log must include raw mapping selection signal');
 assertSource(/SDL3.*QString::fromUtf8\(sdl3Version\)/s, 'Edge detection log must include underlying SDL3 runtime version when available');
 assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');
 assertSource(/mappingEntry\.startsWith\("face:"\)/, 'SDL3 face metadata must stay treated as non-binding metadata');
@@ -425,6 +433,27 @@ const completeSdl2MoonlightLog = makeCompleteMoonlightLog(moonlightEvidenceVaria
 const completeSdl3MoonlightLog = makeCompleteMoonlightLog(moonlightEvidenceVariants.sdl3Compat);
 assertMoonlightLogEvidence(completeSdl2MoonlightLog, moonlightEvidenceVariants.sdl2, true, 'native SDL2 same-log evidence passes');
 assertMoonlightLogEvidence(completeSdl3MoonlightLog, moonlightEvidenceVariants.sdl3Compat, true, 'sdl2-compat/SDL3 same-log evidence passes');
+assertMoonlightLogEvidence(
+  completeSdl3MoonlightLog.replace(
+    '(SDL 2.32.70, SDL3 3.4.11) (raw mapping signal: SDL3_VERSION)',
+    '(SDL 2.32.70) (raw mapping signal: sdl2-compat runtime version)'
+  ),
+  moonlightEvidenceVariants.sdl3Compat,
+  true,
+  'sdl2-compat runtime-version signal satisfies SDL3-compatible log evidence without SDL3_VERSION'
+);
+assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.replace(' (raw mapping signal: native SDL2 runtime)', ''),
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'missing raw mapping signal fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl3MoonlightLog.replace('raw mapping signal: SDL3_VERSION', 'raw mapping signal: native SDL2 runtime'),
+  moonlightEvidenceVariants.sdl3Compat,
+  false,
+  'wrong raw mapping signal fails sdl2-compat/SDL3 log evidence'
+);
 assertMoonlightLogEvidence(
   completeSdl2MoonlightLog.replace(
     `Applied DualSense Edge paddle mappings (updated): ${moonlightEvidenceVariants.sdl2.logMappings}`,

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -12,7 +12,8 @@ const gamepadPath = path.join(repoRoot, 'app', 'streaming', 'input', 'gamepad.cp
 const source = fs.readFileSync(gamepadPath, 'utf8');
 
 const paddleKeys = ['paddle1', 'paddle2', 'paddle3', 'paddle4'];
-const paddleButtons = [20, 19, 18, 17];
+const sdl2PaddleButtons = [20, 19, 18, 17];
+const sdl3CompatPaddleButtons = [16, 15, 14, 13];
 
 function fail(message) {
   console.error(`DualSense Edge mapping verification failed: ${message}`);
@@ -29,7 +30,7 @@ function assertSource(pattern, message) {
   assert(pattern.test(source), message);
 }
 
-function paddleMappingEntry(index) {
+function paddleMappingEntry(index, paddleButtons) {
   return `${paddleKeys[index]}:b${paddleButtons[index]}`;
 }
 
@@ -43,7 +44,7 @@ function paddleMappingIndex(mappingEntry) {
   return -1;
 }
 
-function paddleRawButtonMappingIndex(mappingEntry) {
+function paddleRawButtonMappingIndex(mappingEntry, paddleButtons) {
   const separatorIndex = mappingEntry.indexOf(':');
   if (separatorIndex < 0) {
     return -1;
@@ -69,11 +70,11 @@ function isMappingMetadataEntry(mappingEntry) {
          mappingEntry.startsWith('type:');
 }
 
-function addPaddleMappingChange(changedMappings, mappingIndex) {
-  changedMappings.push(paddleMappingEntry(mappingIndex));
+function addPaddleMappingChange(changedMappings, mappingIndex, paddleButtons) {
+  changedMappings.push(paddleMappingEntry(mappingIndex, paddleButtons));
 }
 
-function normalizePaddleMappings(mapping) {
+function normalizePaddleMappings(mapping, paddleButtons) {
   const entries = mapping.split(',');
   const updatedEntries = [];
   const foundMappings = new Array(paddleKeys.length).fill(false);
@@ -84,7 +85,7 @@ function normalizePaddleMappings(mapping) {
     let mappingIndex = paddleMappingIndex(entry);
 
     if (mappingIndex < 0) {
-      mappingIndex = paddleRawButtonMappingIndex(entry);
+      mappingIndex = paddleRawButtonMappingIndex(entry, paddleButtons);
       if (mappingIndex >= 0) {
         changedMappingEntries[mappingIndex] = true;
         hasChangedMappingEntries = true;
@@ -102,7 +103,7 @@ function normalizePaddleMappings(mapping) {
     }
 
     foundMappings[mappingIndex] = true;
-    if (entry !== paddleMappingEntry(mappingIndex)) {
+    if (entry !== paddleMappingEntry(mappingIndex, paddleButtons)) {
       changedMappingEntries[mappingIndex] = true;
       hasChangedMappingEntries = true;
     }
@@ -121,7 +122,7 @@ function normalizePaddleMappings(mapping) {
       changedMappingEntries[i] = true;
       hasChangedMappingEntries = true;
     }
-    updatedEntries.splice(insertionIndex++, 0, paddleMappingEntry(i));
+    updatedEntries.splice(insertionIndex++, 0, paddleMappingEntry(i, paddleButtons));
   }
 
   const updatedMapping = updatedEntries.join(',');
@@ -134,7 +135,7 @@ function normalizePaddleMappings(mapping) {
   const changedMappings = [];
   for (let i = 0; i < paddleKeys.length; i++) {
     if (changedMappingEntries[i]) {
-      addPaddleMappingChange(changedMappings, i);
+      addPaddleMappingChange(changedMappings, i, paddleButtons);
     }
   }
 
@@ -144,54 +145,72 @@ function normalizePaddleMappings(mapping) {
   };
 }
 
-function assertNormalize(input, expectedMapping, expectedChangedMappings, message) {
-  const actual = normalizePaddleMappings(input);
+function assertNormalize(input, expectedMapping, expectedChangedMappings, paddleButtons, message) {
+  const actual = normalizePaddleMappings(input, paddleButtons);
   assert(actual.mapping === expectedMapping, `${message}: mapping\nexpected: ${expectedMapping}\nactual:   ${actual.mapping}`);
   assert(actual.changedMappings === expectedChangedMappings, `${message}: changed mappings\nexpected: ${expectedChangedMappings}\nactual:   ${actual.changedMappings}`);
 }
 
-assertSource(/#define DUALSENSE_EDGE_MIN_BUTTONS 21\b/, 'minimum Edge raw button count must stay at 21');
+assertSource(/#define DUALSENSE_EDGE_SDL2_MIN_BUTTONS 21\b/, 'native SDL2 minimum Edge raw button count must stay at 21');
+assertSource(/#define DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS 17\b/, 'sdl2-compat/SDL3 minimum Edge raw button count must stay at 17');
 assertSource(/#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 16\b/, 'PADDLE1 controller button index must stay at 16');
 assertSource(/#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 19\b/, 'PADDLE4 controller button index must stay at 19');
 assertSource(/"paddle1",\s*"paddle2",\s*"paddle3",\s*"paddle4"/, 'paddle mapping key order changed');
-assertSource(/20,\s*19,\s*18,\s*17/, 'paddle raw button order changed');
+assertSource(/20,\s*19,\s*18,\s*17/, 'native SDL2 paddle raw button order changed');
+assertSource(/16,\s*15,\s*14,\s*13/, 'sdl2-compat/SDL3 paddle raw button order changed');
 assertSource(/MISC_FLAG,\s*PADDLE1_FLAG,\s*PADDLE2_FLAG,\s*PADDLE3_FLAG,\s*PADDLE4_FLAG,\s*TOUCHPAD_FLAG/, 'button map no longer keeps MISC, Edge paddles, and TOUCHPAD adjacent');
 assertSource(/static_assert\(PADDLE1_FLAG == 0x010000/, 'PADDLE1 high-word assertion missing');
 assertSource(/static_assert\(PADDLE4_FLAG == 0x080000/, 'PADDLE4 high-word assertion missing');
 assertSource(/SDL_CONTROLLER_BUTTON_MISC1 == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 - 1/, 'MISC/PADDLE adjacency assertion missing');
 assertSource(/SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 \+ 1/, 'PADDLE/TOUCHPAD adjacency assertion missing');
+assertSource(/SDL_GetHint\("SDL3_VERSION"\)/, 'sdl2-compat/SDL3 runtime detection missing');
+assertSource(/buttonCount >= DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS &&\s*buttonCount < DUALSENSE_EDGE_SDL2_MIN_BUTTONS/, 'sdl2-compat/SDL3 raw count fallback missing');
+assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge minimum raw button count selection missing');
 assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');
 assertSource(/mappingEntry\.startsWith\("face:"\)/, 'SDL3 face metadata must stay treated as non-binding metadata');
 
-const allPaddles = 'paddle1:b20,paddle2:b19,paddle3:b18,paddle4:b17';
-const allChanged = allPaddles;
+function allPaddles(paddleButtons) {
+  return paddleKeys.map((_, index) => paddleMappingEntry(index, paddleButtons)).join(',');
+}
 
-assertNormalize(
-  '030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,type:ps5,platform:Mac OS X,',
-  `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${allPaddles},type:ps5,platform:Mac OS X,`,
-  allChanged,
-  'missing Edge paddle bindings are inserted before SDL metadata'
-);
+function verifyMappingSet(paddleButtons, label) {
+  const canonicalPaddles = allPaddles(paddleButtons);
+  const allChanged = canonicalPaddles;
 
-assertNormalize(
-  `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${allPaddles},type:ps5,platform:Mac OS X,`,
-  `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${allPaddles},type:ps5,platform:Mac OS X,`,
-  '',
-  'already canonical Edge paddle block is unchanged'
-);
+  assertNormalize(
+    '030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,type:ps5,platform:Mac OS X,',
+    `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${canonicalPaddles},type:ps5,platform:Mac OS X,`,
+    allChanged,
+    paddleButtons,
+    `${label}: missing Edge paddle bindings are inserted before SDL metadata`
+  );
 
-assertNormalize(
-  '030000004c050000f20d000000000000,DualSense Edge,a:b20,paddle1:b17,paddle1:b20,paddle2:b18,paddle3:b19,paddle4:b20,type:ps5,',
-  `030000004c050000f20d000000000000,DualSense Edge,${allPaddles},type:ps5,`,
-  allChanged,
-  'stale paddle mappings and duplicate raw aliases are canonicalized'
-);
+  assertNormalize(
+    `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${canonicalPaddles},type:ps5,platform:Mac OS X,`,
+    `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${canonicalPaddles},type:ps5,platform:Mac OS X,`,
+    '',
+    paddleButtons,
+    `${label}: already canonical Edge paddle block is unchanged`
+  );
 
-assertNormalize(
-  '030000004c050000f20d000000000000,DualSense Edge,x:b17,y:b18,a:b20,b:b19,crc:1234,face:ABXY,hint:foo,sdk>=:0,sdk<=:999,type:ps5,',
-  `030000004c050000f20d000000000000,DualSense Edge,${allPaddles},crc:1234,face:ABXY,hint:foo,sdk>=:0,sdk<=:999,type:ps5,`,
-  allChanged,
-  'normal buttons bound to Edge-only raw buttons are removed before metadata'
-);
+  assertNormalize(
+    `030000004c050000f20d000000000000,DualSense Edge,a:b${paddleButtons[0]},paddle1:b${paddleButtons[3]},paddle1:b${paddleButtons[0]},paddle2:b${paddleButtons[2]},paddle3:b${paddleButtons[1]},paddle4:b${paddleButtons[0]},type:ps5,`,
+    `030000004c050000f20d000000000000,DualSense Edge,${canonicalPaddles},type:ps5,`,
+    allChanged,
+    paddleButtons,
+    `${label}: stale paddle mappings and duplicate raw aliases are canonicalized`
+  );
+
+  assertNormalize(
+    `030000004c050000f20d000000000000,DualSense Edge,x:b${paddleButtons[3]},y:b${paddleButtons[2]},a:b${paddleButtons[0]},b:b${paddleButtons[1]},crc:1234,face:ABXY,hint:foo,sdk>=:0,sdk<=:999,type:ps5,`,
+    `030000004c050000f20d000000000000,DualSense Edge,${canonicalPaddles},crc:1234,face:ABXY,hint:foo,sdk>=:0,sdk<=:999,type:ps5,`,
+    allChanged,
+    paddleButtons,
+    `${label}: normal buttons bound to Edge-only raw buttons are removed before metadata`
+  );
+}
+
+verifyMappingSet(sdl2PaddleButtons, 'native SDL2');
+verifyMappingSet(sdl3CompatPaddleButtons, 'sdl2-compat/SDL3');
 
 console.log('DualSense Edge mapping verification passed.');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -321,6 +321,7 @@ function hasNoMoonlightStopEvidence(log) {
   return !/DualSense Edge paddle mappings are present, but SDL did not expose/.test(log) &&
          !/DualSense Edge paddle mapping update did not expose/.test(log) &&
          !/DualSense Edge paddle mapping add did not expose/.test(log) &&
+         !/Ignoring DualSense Edge PADDLE[1-4] event without verified paddle bindings/.test(log) &&
          !/Ignoring DualSense Edge controller button .* as stale Edge raw alias/.test(log) &&
          !/DualSense Edge controller button .* not advertising it as a normal button/.test(log);
 }
@@ -380,6 +381,7 @@ assertSource(/isDualSenseEdge && type != LI_CTYPE_PS[\s\S]*type = LI_CTYPE_PS;/,
 assertSource(/supportedButtonFlags &= ~DUALSENSE_EDGE_PADDLE_FLAGS[\s\S]*supportedButtonFlags \|= DUALSENSE_EDGE_PADDLE_FLAGS/, 'DualSense Edge paddle/Fn support must only be advertised after verified controller-button bindings');
 assertSource(/DualSense Edge arrival support: buttons=%d sdlType=%d arrivalType=0x%02x supportedButtonFlags=0x%08x paddle\/Fn=0x%08x capabilities=0x%08x bindings=%s/, 'DualSense Edge arrival evidence log format changed');
 assertSource(/DualSense Edge %s %s \(paddle\/Fn flags: 0x%08x\)/, 'DualSense Edge per-button evidence log format changed');
+assertSource(/without verified paddle bindings/, 'DualSense Edge unverified paddle-event diagnostic missing');
 assertSource(/as stale Edge raw alias/, 'DualSense Edge stale raw-alias diagnostic missing');
 assertSource(/not advertising it as a normal button/, 'DualSense Edge capability alias diagnostic missing');
 assertInSource(limelightSource, /#define PADDLE1_FLAG\s+0x010000\b/, 'Moonlight common PADDLE1 flag must stay in the Sunshine high word');
@@ -467,6 +469,7 @@ assertMoonlightLogEvidence(
   'DualSense Edge paddle mappings are present, but SDL did not expose the expected paddle controller bindings (actual: paddle1=b20,paddle2=b19,paddle3=b18,paddle4=b17)',
   'DualSense Edge paddle mapping update did not expose the expected paddle controller bindings (actual: paddle1=b20,paddle2=b19,paddle3=b18,paddle4=b17)',
   'DualSense Edge paddle mapping add did not expose the expected paddle controller bindings (actual: paddle1=b20,paddle2=b19,paddle3=b18,paddle4=b17)',
+  'Ignoring DualSense Edge PADDLE1 event without verified paddle bindings',
   'Ignoring DualSense Edge controller button a bound to raw paddle1:b20 as stale Edge raw alias',
   'DualSense Edge controller button a is bound to raw paddle1:b20; not advertising it as a normal button',
 ].forEach((stopLine) => {

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -380,6 +380,8 @@ assertSource(/SDL_CONTROLLER_BUTTON_MISC1 == DUALSENSE_EDGE_CONTROLLER_BUTTON_PA
 assertSource(/SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 \+ 1/, 'PADDLE/TOUCHPAD adjacency assertion missing');
 assertSource(/SDL_GetHint\("SDL3_VERSION"\)/, 'sdl2-compat/SDL3 runtime detection missing');
 assertSource(/version\.major == 2 && version\.patch >= 50/, 'sdl2-compat/SDL3 runtime-version fallback missing');
+assertSource(/SDL_GameControllerHasButton\(controller, button\)/, 'Edge paddle support must probe the SDL controller-button layer');
+assertSource(/SDL_GameControllerGetBindForButton\(controller, button\)/, 'Edge paddle support must verify SDL controller-button bindings');
 assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge minimum raw button count selection missing');
 assertSource(/raw mapping signal: %s/, 'Edge detection log must include raw mapping selection signal');
 assertSource(/SDL3.*QString::fromUtf8\(sdl3Version\)/s, 'Edge detection log must include underlying SDL3 runtime version when available');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -199,6 +199,166 @@ function assertNormalize(input, expectedMapping, expectedChangedMappings, paddle
   assert(actual.changedMappings === expectedChangedMappings, `${message}: changed mappings\nexpected: ${expectedChangedMappings}\nactual:   ${actual.changedMappings}`);
 }
 
+function escapeRegex(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function bindingSummary(paddleButtons) {
+  return paddleKeys.map((_, index) => `${paddleKeys[index]}=b${paddleButtons[index]}`).join(',');
+}
+
+function logMappingSummary(paddleButtons) {
+  return paddleKeys.map((_, index) => paddleMappingEntry(index, paddleButtons)).join(',');
+}
+
+const moonlightEvidenceVariants = {
+  sdl2: {
+    label: 'native SDL2',
+    minButtons: sdl2MinButtons,
+    rawMappingName: 'SDL2',
+    runtimeVersionPattern: /SDL \d+\.\d+\.\d+\)/,
+    bindings: bindingSummary(sdl2PaddleButtons),
+    logMappings: logMappingSummary(sdl2PaddleButtons),
+  },
+  sdl3Compat: {
+    label: 'sdl2-compat/SDL3',
+    minButtons: sdl3CompatMinButtons,
+    rawMappingName: 'SDL3/sdl2-compat',
+    runtimeVersionPattern: /SDL \d+\.\d+\.\d+, SDL3 \d+\.\d+\.\d+\)/,
+    bindings: bindingSummary(sdl3CompatPaddleButtons),
+    logMappings: logMappingSummary(sdl3CompatPaddleButtons),
+  },
+};
+
+function hasDetectionEvidence(log, variant) {
+  const detectionPattern = /DualSense Edge detected with (\d+) SDL joystick buttons \(need (\d+) for (SDL2|SDL3\/sdl2-compat) Edge raw mapping\) \(VID\/PID: 0x054c\/0x0df2\) \((SDL \d+\.\d+\.\d+(?:, SDL3 \d+\.\d+\.\d+)?)\)/g;
+  let match;
+
+  while ((match = detectionPattern.exec(log)) !== null) {
+    const buttonCount = Number(match[1]);
+    const requiredButtons = Number(match[2]);
+    const rawMappingName = match[3];
+    const runtimeVersion = `${match[4]})`;
+    if (buttonCount >= variant.minButtons &&
+        requiredButtons === variant.minButtons &&
+        rawMappingName === variant.rawMappingName &&
+        variant.runtimeVersionPattern.test(runtimeVersion)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasMappingEvidence(log, variant) {
+  return log.includes('DualSense Edge paddle mappings already present') ||
+         log.includes(`Applied DualSense Edge paddle mappings (updated): ${variant.logMappings}`) ||
+         log.includes(`Applied DualSense Edge paddle mappings (added): ${variant.logMappings}`);
+}
+
+function hasArrivalEvidence(log, variant) {
+  const arrivalPattern = /DualSense Edge arrival support: buttons=(\d+) sdlType=\d+ arrivalType=0x([0-9a-fA-F]{2}) supportedButtonFlags=0x([0-9a-fA-F]{8}) paddle\/Fn=0x([0-9a-fA-F]{8}) capabilities=0x([0-9a-fA-F]{8}) bindings=([^\r\n]+)/g;
+  let match;
+
+  while ((match = arrivalPattern.exec(log)) !== null) {
+    const buttonCount = Number(match[1]);
+    const arrivalType = Number.parseInt(match[2], 16);
+    const paddleFn = Number.parseInt(match[4], 16);
+    const bindings = match[6];
+    if (buttonCount >= variant.minButtons &&
+        arrivalType === 0x02 &&
+        paddleFn === 0x000f0000 &&
+        bindings === variant.bindings) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasPerButtonEvidence(log) {
+  const expectedMasks = {
+    PADDLE1: '00010000',
+    PADDLE2: '00020000',
+    PADDLE3: '00040000',
+    PADDLE4: '00080000',
+  };
+  const singleMasks = new Set(['00010000', '00020000', '00040000', '00080000']);
+  const eventPattern = /DualSense Edge (PADDLE[1-4]) (pressed|released) \(paddle\/Fn flags: 0x([0-9a-fA-F]{8})\)/g;
+  const seen = {};
+  let match;
+
+  for (const name of Object.keys(expectedMasks)) {
+    seen[`${name}:pressed`] = false;
+    seen[`${name}:released`] = false;
+  }
+
+  while ((match = eventPattern.exec(log)) !== null) {
+    const name = match[1];
+    const action = match[2];
+    const mask = match[3].toLowerCase();
+    if (action === 'pressed') {
+      if (mask !== expectedMasks[name]) {
+        return false;
+      }
+      seen[`${name}:pressed`] = true;
+    }
+    else {
+      if (mask !== '00000000') {
+        return false;
+      }
+      seen[`${name}:released`] = true;
+    }
+
+    if (mask !== '00000000' && !singleMasks.has(mask)) {
+      return false;
+    }
+  }
+
+  return Object.values(seen).every(Boolean);
+}
+
+function hasNoMoonlightStopEvidence(log) {
+  return !/DualSense Edge paddle mappings are present, but SDL did not expose/.test(log) &&
+         !/DualSense Edge paddle mapping update did not expose/.test(log) &&
+         !/DualSense Edge paddle mapping add did not expose/.test(log) &&
+         !/Ignoring DualSense Edge controller button .* as stale Edge raw alias/.test(log) &&
+         !/DualSense Edge controller button .* not advertising it as a normal button/.test(log);
+}
+
+function hasCompleteMoonlightLogEvidence(log, variant) {
+  return hasDetectionEvidence(log, variant) &&
+         hasMappingEvidence(log, variant) &&
+         hasArrivalEvidence(log, variant) &&
+         hasPerButtonEvidence(log) &&
+         hasNoMoonlightStopEvidence(log);
+}
+
+function makeCompleteMoonlightLog(variant) {
+  return [
+    `DualSense Edge detected with ${variant.minButtons} SDL joystick buttons (need ${variant.minButtons} for ${variant.rawMappingName} Edge raw mapping) (VID/PID: 0x054c/0x0df2) (${variant.rawMappingName === 'SDL2' ? 'SDL 2.30.9' : 'SDL 2.32.70, SDL3 3.4.11'})`,
+    `Applied DualSense Edge paddle mappings (updated): ${variant.logMappings}`,
+    `DualSense Edge arrival support: buttons=${variant.minButtons} sdlType=4 arrivalType=0x02 supportedButtonFlags=0x000f0000 paddle/Fn=0x000f0000 capabilities=0x00000000 bindings=${variant.bindings}`,
+    'DualSense Edge PADDLE1 pressed (paddle/Fn flags: 0x00010000)',
+    'DualSense Edge PADDLE1 released (paddle/Fn flags: 0x00000000)',
+    'DualSense Edge PADDLE2 pressed (paddle/Fn flags: 0x00020000)',
+    'DualSense Edge PADDLE2 released (paddle/Fn flags: 0x00000000)',
+    'DualSense Edge PADDLE3 pressed (paddle/Fn flags: 0x00040000)',
+    'DualSense Edge PADDLE3 released (paddle/Fn flags: 0x00000000)',
+    'DualSense Edge PADDLE4 pressed (paddle/Fn flags: 0x00080000)',
+    'DualSense Edge PADDLE4 released (paddle/Fn flags: 0x00000000)',
+  ].join('\n');
+}
+
+function assertMoonlightLogEvidence(log, variant, expected, message) {
+  const actual = hasCompleteMoonlightLogEvidence(log, variant);
+  assert(actual === expected, `${message}: expected ${expected ? 'complete' : 'incomplete'} Moonlight log evidence`);
+}
+
+function withoutLogLine(log, line) {
+  return log.replace(new RegExp(`^${escapeRegex(line)}\\n?`, 'm'), '');
+}
+
 assertSource(/#define DUALSENSE_EDGE_SDL2_MIN_BUTTONS 21\b/, 'native SDL2 minimum Edge raw button count must stay at 21');
 assertSource(/#define DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS 17\b/, 'sdl2-compat/SDL3 minimum Edge raw button count must stay at 17');
 assertSource(/#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 16\b/, 'PADDLE1 controller button index must stay at 16');
@@ -257,6 +417,47 @@ assertRuntimeSelection(true, 16, true, false, 'SDL3 hint still requires enough r
 });
 assert(sunshineButtonFlags2(0x0f0000) === 0x000f, 'all Edge paddle/Fn buttons must serialize as buttonFlags2 mask 0x000f');
 assert(sunshineButtonFlags2(0x2f0000) === 0x002f, 'Edge paddle/Fn, touchpad, and misc buttons must all survive in Sunshine buttonFlags2');
+
+const completeSdl2MoonlightLog = makeCompleteMoonlightLog(moonlightEvidenceVariants.sdl2);
+const completeSdl3MoonlightLog = makeCompleteMoonlightLog(moonlightEvidenceVariants.sdl3Compat);
+assertMoonlightLogEvidence(completeSdl2MoonlightLog, moonlightEvidenceVariants.sdl2, true, 'native SDL2 same-log evidence passes');
+assertMoonlightLogEvidence(completeSdl3MoonlightLog, moonlightEvidenceVariants.sdl3Compat, true, 'sdl2-compat/SDL3 same-log evidence passes');
+assertMoonlightLogEvidence(
+  withoutLogLine(completeSdl2MoonlightLog, 'DualSense Edge PADDLE4 released (paddle/Fn flags: 0x00000000)'),
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'missing release-to-neutral line fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.replace(
+    `bindings=${moonlightEvidenceVariants.sdl2.bindings}`,
+    `bindings=${moonlightEvidenceVariants.sdl3Compat.bindings}`
+  ),
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'mismatched SDL binding variant fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.replace(
+    'DualSense Edge PADDLE2 pressed (paddle/Fn flags: 0x00020000)',
+    'DualSense Edge PADDLE2 pressed (paddle/Fn flags: 0x00030000)'
+  ),
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'combined one-at-a-time paddle/Fn mask fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  `${completeSdl2MoonlightLog}\nIgnoring DualSense Edge controller button a bound to raw paddle1:b20 as stale Edge raw alias`,
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'stale raw-alias diagnostic fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.split('\n').slice(0, 2).join('\n'),
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'partial copied Moonlight log cannot satisfy complete evidence'
+);
 
 function allPaddles(paddleButtons) {
   return paddleKeys.map((_, index) => paddleMappingEntry(index, paddleButtons)).join(',');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -443,6 +443,39 @@ assertMoonlightLogEvidence(
   'sdl2-compat runtime-version signal satisfies SDL3-compatible log evidence without SDL3_VERSION'
 );
 assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.replace(
+    'DualSense Edge detected with 21 SDL joystick buttons',
+    'DualSense Edge detected with 20 SDL joystick buttons'
+  ),
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'native SDL2 raw-button undercount fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl3MoonlightLog.replace(
+    'DualSense Edge detected with 17 SDL joystick buttons',
+    'DualSense Edge detected with 16 SDL joystick buttons'
+  ),
+  moonlightEvidenceVariants.sdl3Compat,
+  false,
+  'sdl2-compat/SDL3 raw-button undercount fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl3MoonlightLog.replace(
+    '(SDL 2.32.70, SDL3 3.4.11) (raw mapping signal: SDL3_VERSION)',
+    '(SDL 2.32.10) (raw mapping signal: sdl2-compat runtime version)'
+  ),
+  moonlightEvidenceVariants.sdl3Compat,
+  false,
+  'ambiguous low-patch sdl2-compat claim fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.replace('VID/PID: 0x054c/0x0df2', 'VID/PID: 0x054c/0x0ce6'),
+  moonlightEvidenceVariants.sdl2,
+  false,
+  'wrong Edge VID/PID fails Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
   completeSdl2MoonlightLog.replace(' (raw mapping signal: native SDL2 runtime)', ''),
   moonlightEvidenceVariants.sdl2,
   false,

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -42,31 +42,31 @@ function assertSource(pattern, message) {
   assertInSource(source, pattern, message);
 }
 
-function usesSdl3CompatMappings(hasSdl3VersionHint, buttonCount) {
+function usesSdl3CompatMappings(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat) {
   if (hasSdl3VersionHint) {
     return true;
   }
 
-  return buttonCount === sdl3CompatMinButtons;
+  return runtimeLooksLikeSdl2Compat;
 }
 
-function minimumButtonCount(hasSdl3VersionHint, buttonCount) {
-  return usesSdl3CompatMappings(hasSdl3VersionHint, buttonCount) ?
+function minimumButtonCount(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat) {
+  return usesSdl3CompatMappings(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat) ?
     sdl3CompatMinButtons :
     sdl2MinButtons;
 }
 
-function exposesPaddleButtons(hasSdl3VersionHint, buttonCount) {
-  return buttonCount >= minimumButtonCount(hasSdl3VersionHint, buttonCount);
+function exposesPaddleButtons(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat, buttonCount) {
+  return buttonCount >= minimumButtonCount(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat);
 }
 
 function sunshineButtonFlags2(buttonFlags) {
   return (buttonFlags >>> 16) & 0xffff;
 }
 
-function assertRuntimeSelection(hasSdl3VersionHint, buttonCount, expectedUsesSdl3Compat, expectedExposesPaddles, message) {
-  const actualUsesSdl3Compat = usesSdl3CompatMappings(hasSdl3VersionHint, buttonCount);
-  const actualExposesPaddles = exposesPaddleButtons(hasSdl3VersionHint, buttonCount);
+function assertRuntimeSelection(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat, buttonCount, expectedUsesSdl3Compat, expectedExposesPaddles, message) {
+  const actualUsesSdl3Compat = usesSdl3CompatMappings(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat);
+  const actualExposesPaddles = exposesPaddleButtons(hasSdl3VersionHint, runtimeLooksLikeSdl2Compat, buttonCount);
 
   assert(
     actualUsesSdl3Compat === expectedUsesSdl3Compat,
@@ -372,7 +372,7 @@ assertSource(/static_assert\(PADDLE4_FLAG == 0x080000/, 'PADDLE4 high-word asser
 assertSource(/SDL_CONTROLLER_BUTTON_MISC1 == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 - 1/, 'MISC/PADDLE adjacency assertion missing');
 assertSource(/SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 \+ 1/, 'PADDLE/TOUCHPAD adjacency assertion missing');
 assertSource(/SDL_GetHint\("SDL3_VERSION"\)/, 'sdl2-compat/SDL3 runtime detection missing');
-assertSource(/buttonCount == DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS/, 'sdl2-compat/SDL3 exact raw count fallback missing');
+assertSource(/version\.major == 2 && version\.patch >= 50/, 'sdl2-compat/SDL3 runtime-version fallback missing');
 assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge minimum raw button count selection missing');
 assertSource(/SDL3.*QString::fromUtf8\(sdl3Version\)/s, 'Edge detection log must include underlying SDL3 runtime version when available');
 assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');
@@ -393,13 +393,15 @@ assertInSource(inputStreamSource, /buttonFlags2 != \(IS_SUNSHINE\(\) \? LE16\(\(
 assertInSource(inputStreamSource, /buttonFlags2 = IS_SUNSHINE\(\) \? LE16\(\(short\)\(buttonFlags >> 16\)\) : 0;/, 'controller packets must carry high-word Edge buttons in Sunshine buttonFlags2');
 assertInSource(inputStreamSource, /controllerArrival\.supportedButtonFlags = LE32\(supportedButtonFlags\);/, 'arrival packets must advertise the full 32-bit supported button mask');
 
-assertRuntimeSelection(false, 21, false, true, 'native SDL2 exposes the 21-button Edge shape');
-assertRuntimeSelection(false, 20, false, false, 'unknown 20-button Edge shape fails closed without an SDL3 hint');
-assertRuntimeSelection(false, 18, false, false, 'unknown 18-button Edge shape fails closed without an SDL3 hint');
-assertRuntimeSelection(false, 17, true, true, 'exact 17-button Edge shape selects sdl2-compat/SDL3 fallback');
-assertRuntimeSelection(true, 21, true, true, 'SDL3 hint selects sdl2-compat mapping even if future SDL3 exposes more raw buttons');
-assertRuntimeSelection(true, 17, true, true, 'SDL3 hint accepts current sdl2-compat Edge shape');
-assertRuntimeSelection(true, 16, true, false, 'SDL3 hint still requires enough raw buttons');
+assertRuntimeSelection(false, false, 21, false, true, 'native SDL2 exposes the 21-button Edge shape');
+assertRuntimeSelection(false, false, 20, false, false, 'unknown 20-button Edge shape fails closed without an SDL3 hint');
+assertRuntimeSelection(false, false, 18, false, false, 'unknown 18-button Edge shape fails closed without an SDL3 hint');
+assertRuntimeSelection(false, false, 17, false, false, 'ambiguous 17-button Edge shape fails closed without an SDL3/sdl2-compat runtime signal');
+assertRuntimeSelection(false, true, 17, true, true, 'sdl2-compat runtime fallback accepts current 17-button Edge shape');
+assertRuntimeSelection(false, true, 16, true, false, 'sdl2-compat runtime fallback still requires enough raw buttons');
+assertRuntimeSelection(true, false, 21, true, true, 'SDL3 hint selects sdl2-compat mapping even if future SDL3 exposes more raw buttons');
+assertRuntimeSelection(true, false, 17, true, true, 'SDL3 hint accepts current sdl2-compat Edge shape');
+assertRuntimeSelection(true, false, 16, true, false, 'SDL3 hint still requires enough raw buttons');
 
 [
   [0x010000, 0x0001, 'PADDLE1'],

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/*
+ * Verifies the DualSense Edge SDL2 mapping assumptions used by
+ * app/streaming/input/gamepad.cpp without requiring physical hardware.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const gamepadPath = path.join(repoRoot, 'app', 'streaming', 'input', 'gamepad.cpp');
+const source = fs.readFileSync(gamepadPath, 'utf8');
+
+const paddleKeys = ['paddle1', 'paddle2', 'paddle3', 'paddle4'];
+const paddleButtons = [20, 19, 18, 17];
+
+function fail(message) {
+  console.error(`DualSense Edge mapping verification failed: ${message}`);
+  process.exit(1);
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    fail(message);
+  }
+}
+
+function assertSource(pattern, message) {
+  assert(pattern.test(source), message);
+}
+
+function paddleMappingEntry(index) {
+  return `${paddleKeys[index]}:b${paddleButtons[index]}`;
+}
+
+function paddleMappingIndex(mappingEntry) {
+  for (let i = 0; i < paddleKeys.length; i++) {
+    if (mappingEntry.startsWith(`${paddleKeys[i]}:`)) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function paddleRawButtonMappingIndex(mappingEntry) {
+  const separatorIndex = mappingEntry.indexOf(':');
+  if (separatorIndex < 0) {
+    return -1;
+  }
+
+  const binding = mappingEntry.slice(separatorIndex + 1);
+  for (let i = 0; i < paddleButtons.length; i++) {
+    if (binding === `b${paddleButtons[i]}`) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function isMappingMetadataEntry(mappingEntry) {
+  return mappingEntry.startsWith('crc:') ||
+         mappingEntry.startsWith('face:') ||
+         mappingEntry.startsWith('hint:') ||
+         mappingEntry.startsWith('platform:') ||
+         mappingEntry.startsWith('sdk>=:') ||
+         mappingEntry.startsWith('sdk<=:') ||
+         mappingEntry.startsWith('type:');
+}
+
+function addPaddleMappingChange(changedMappings, mappingIndex) {
+  changedMappings.push(paddleMappingEntry(mappingIndex));
+}
+
+function normalizePaddleMappings(mapping) {
+  const entries = mapping.split(',');
+  const updatedEntries = [];
+  const foundMappings = new Array(paddleKeys.length).fill(false);
+  const changedMappingEntries = new Array(paddleKeys.length).fill(false);
+  let hasChangedMappingEntries = false;
+
+  for (const entry of entries) {
+    let mappingIndex = paddleMappingIndex(entry);
+
+    if (mappingIndex < 0) {
+      mappingIndex = paddleRawButtonMappingIndex(entry);
+      if (mappingIndex >= 0) {
+        changedMappingEntries[mappingIndex] = true;
+        hasChangedMappingEntries = true;
+        continue;
+      }
+
+      updatedEntries.push(entry);
+      continue;
+    }
+
+    if (foundMappings[mappingIndex]) {
+      changedMappingEntries[mappingIndex] = true;
+      hasChangedMappingEntries = true;
+      continue;
+    }
+
+    foundMappings[mappingIndex] = true;
+    if (entry !== paddleMappingEntry(mappingIndex)) {
+      changedMappingEntries[mappingIndex] = true;
+      hasChangedMappingEntries = true;
+    }
+  }
+
+  let insertionIndex = updatedEntries.findIndex(isMappingMetadataEntry);
+  if (insertionIndex < 0) {
+    insertionIndex = updatedEntries.length;
+    if (updatedEntries.length > 0 && updatedEntries[updatedEntries.length - 1] === '') {
+      insertionIndex--;
+    }
+  }
+
+  for (let i = 0; i < paddleKeys.length; i++) {
+    if (!foundMappings[i]) {
+      changedMappingEntries[i] = true;
+      hasChangedMappingEntries = true;
+    }
+    updatedEntries.splice(insertionIndex++, 0, paddleMappingEntry(i));
+  }
+
+  const updatedMapping = updatedEntries.join(',');
+  if (updatedMapping !== mapping && !hasChangedMappingEntries) {
+    for (let i = 0; i < paddleKeys.length; i++) {
+      changedMappingEntries[i] = true;
+    }
+  }
+
+  const changedMappings = [];
+  for (let i = 0; i < paddleKeys.length; i++) {
+    if (changedMappingEntries[i]) {
+      addPaddleMappingChange(changedMappings, i);
+    }
+  }
+
+  return {
+    mapping: updatedMapping,
+    changedMappings: changedMappings.join(','),
+  };
+}
+
+function assertNormalize(input, expectedMapping, expectedChangedMappings, message) {
+  const actual = normalizePaddleMappings(input);
+  assert(actual.mapping === expectedMapping, `${message}: mapping\nexpected: ${expectedMapping}\nactual:   ${actual.mapping}`);
+  assert(actual.changedMappings === expectedChangedMappings, `${message}: changed mappings\nexpected: ${expectedChangedMappings}\nactual:   ${actual.changedMappings}`);
+}
+
+assertSource(/#define DUALSENSE_EDGE_MIN_BUTTONS 21\b/, 'minimum Edge raw button count must stay at 21');
+assertSource(/#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 16\b/, 'PADDLE1 controller button index must stay at 16');
+assertSource(/#define DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 19\b/, 'PADDLE4 controller button index must stay at 19');
+assertSource(/"paddle1",\s*"paddle2",\s*"paddle3",\s*"paddle4"/, 'paddle mapping key order changed');
+assertSource(/20,\s*19,\s*18,\s*17/, 'paddle raw button order changed');
+assertSource(/MISC_FLAG,\s*PADDLE1_FLAG,\s*PADDLE2_FLAG,\s*PADDLE3_FLAG,\s*PADDLE4_FLAG,\s*TOUCHPAD_FLAG/, 'button map no longer keeps MISC, Edge paddles, and TOUCHPAD adjacent');
+assertSource(/static_assert\(PADDLE1_FLAG == 0x010000/, 'PADDLE1 high-word assertion missing');
+assertSource(/static_assert\(PADDLE4_FLAG == 0x080000/, 'PADDLE4 high-word assertion missing');
+assertSource(/SDL_CONTROLLER_BUTTON_MISC1 == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE1 - 1/, 'MISC/PADDLE adjacency assertion missing');
+assertSource(/SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON_PADDLE4 \+ 1/, 'PADDLE/TOUCHPAD adjacency assertion missing');
+assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');
+assertSource(/mappingEntry\.startsWith\("face:"\)/, 'SDL3 face metadata must stay treated as non-binding metadata');
+
+const allPaddles = 'paddle1:b20,paddle2:b19,paddle3:b18,paddle4:b17';
+const allChanged = allPaddles;
+
+assertNormalize(
+  '030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,type:ps5,platform:Mac OS X,',
+  `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${allPaddles},type:ps5,platform:Mac OS X,`,
+  allChanged,
+  'missing Edge paddle bindings are inserted before SDL metadata'
+);
+
+assertNormalize(
+  `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${allPaddles},type:ps5,platform:Mac OS X,`,
+  `030000004c050000f20d000000000000,DualSense Edge,a:b0,b:b1,${allPaddles},type:ps5,platform:Mac OS X,`,
+  '',
+  'already canonical Edge paddle block is unchanged'
+);
+
+assertNormalize(
+  '030000004c050000f20d000000000000,DualSense Edge,a:b20,paddle1:b17,paddle1:b20,paddle2:b18,paddle3:b19,paddle4:b20,type:ps5,',
+  `030000004c050000f20d000000000000,DualSense Edge,${allPaddles},type:ps5,`,
+  allChanged,
+  'stale paddle mappings and duplicate raw aliases are canonicalized'
+);
+
+assertNormalize(
+  '030000004c050000f20d000000000000,DualSense Edge,x:b17,y:b18,a:b20,b:b19,crc:1234,face:ABXY,hint:foo,sdk>=:0,sdk<=:999,type:ps5,',
+  `030000004c050000f20d000000000000,DualSense Edge,${allPaddles},crc:1234,face:ABXY,hint:foo,sdk>=:0,sdk<=:999,type:ps5,`,
+  allChanged,
+  'normal buttons bound to Edge-only raw buttons are removed before metadata'
+);
+
+console.log('DualSense Edge mapping verification passed.');

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -423,6 +423,15 @@ const completeSdl3MoonlightLog = makeCompleteMoonlightLog(moonlightEvidenceVaria
 assertMoonlightLogEvidence(completeSdl2MoonlightLog, moonlightEvidenceVariants.sdl2, true, 'native SDL2 same-log evidence passes');
 assertMoonlightLogEvidence(completeSdl3MoonlightLog, moonlightEvidenceVariants.sdl3Compat, true, 'sdl2-compat/SDL3 same-log evidence passes');
 assertMoonlightLogEvidence(
+  completeSdl2MoonlightLog.replace(
+    `Applied DualSense Edge paddle mappings (updated): ${moonlightEvidenceVariants.sdl2.logMappings}`,
+    'DualSense Edge paddle mappings already present'
+  ),
+  moonlightEvidenceVariants.sdl2,
+  true,
+  'already-present mapping line satisfies Moonlight log evidence'
+);
+assertMoonlightLogEvidence(
   withoutLogLine(completeSdl2MoonlightLog, 'DualSense Edge PADDLE4 released (paddle/Fn flags: 0x00000000)'),
   moonlightEvidenceVariants.sdl2,
   false,
@@ -446,12 +455,20 @@ assertMoonlightLogEvidence(
   false,
   'combined one-at-a-time paddle/Fn mask fails Moonlight log evidence'
 );
-assertMoonlightLogEvidence(
-  `${completeSdl2MoonlightLog}\nIgnoring DualSense Edge controller button a bound to raw paddle1:b20 as stale Edge raw alias`,
-  moonlightEvidenceVariants.sdl2,
-  false,
-  'stale raw-alias diagnostic fails Moonlight log evidence'
-);
+[
+  'DualSense Edge paddle mappings are present, but SDL did not expose the expected paddle controller bindings (actual: paddle1=b20,paddle2=b19,paddle3=b18,paddle4=b17)',
+  'DualSense Edge paddle mapping update did not expose the expected paddle controller bindings (actual: paddle1=b20,paddle2=b19,paddle3=b18,paddle4=b17)',
+  'DualSense Edge paddle mapping add did not expose the expected paddle controller bindings (actual: paddle1=b20,paddle2=b19,paddle3=b18,paddle4=b17)',
+  'Ignoring DualSense Edge controller button a bound to raw paddle1:b20 as stale Edge raw alias',
+  'DualSense Edge controller button a is bound to raw paddle1:b20; not advertising it as a normal button',
+].forEach((stopLine) => {
+  assertMoonlightLogEvidence(
+    `${completeSdl2MoonlightLog}\n${stopLine}`,
+    moonlightEvidenceVariants.sdl2,
+    false,
+    `${stopLine} fails Moonlight log evidence`
+  );
+});
 assertMoonlightLogEvidence(
   completeSdl2MoonlightLog.split('\n').slice(0, 2).join('\n'),
   moonlightEvidenceVariants.sdl2,

--- a/scripts/verify-dualsense-edge-mapping.js
+++ b/scripts/verify-dualsense-edge-mapping.js
@@ -166,6 +166,7 @@ assertSource(/SDL_CONTROLLER_BUTTON_TOUCHPAD == DUALSENSE_EDGE_CONTROLLER_BUTTON
 assertSource(/SDL_GetHint\("SDL3_VERSION"\)/, 'sdl2-compat/SDL3 runtime detection missing');
 assertSource(/buttonCount >= DUALSENSE_EDGE_SDL3_COMPAT_MIN_BUTTONS &&\s*buttonCount < DUALSENSE_EDGE_SDL2_MIN_BUTTONS/, 'sdl2-compat/SDL3 raw count fallback missing');
 assertSource(/dualSenseEdgeMinimumButtonCount\(controller\)/, 'runtime Edge minimum raw button count selection missing');
+assertSource(/SDL3.*QString::fromUtf8\(sdl3Version\)/s, 'Edge detection log must include underlying SDL3 runtime version when available');
 assertSource(/mappingEntry\.startsWith\("type:"\)/, 'SDL2 type metadata must stay treated as non-binding metadata');
 assertSource(/mappingEntry\.startsWith\("face:"\)/, 'SDL3 face metadata must stay treated as non-binding metadata');
 


### PR DESCRIPTION
## Summary
- Detect Sony DualSense Edge controllers by VID/PID.
- Normalize missing or stale SDL2 controller mappings for the Edge rear paddles and Fn buttons, including native SDL2 and `sdl2-compat`/SDL3 raw button layouts.
- Canonicalize the Edge paddle block by removing existing paddle entries first, then reinserting one correct `paddle1..4` block before SDL mapping metadata.
- Remove stale non-paddle aliases to the active Edge-only raw buttons so one physical Edge control cannot transmit both a normal button and a paddle/Fn flag, while keeping transmission gated on verified raw SDL bindings.
- Assert at compile time that Moonlight's transmitted Edge paddle flags remain Sunshine high-word bits `0x010000` through `0x080000`.
- Assert at compile time that Moonlight's Edge paddle constants match SDL2's `SDL_CONTROLLER_BUTTON_PADDLE1..4` order.
- Insert Edge paddle bindings before SDL mapping metadata fields (`crc:`, `face:`, `hint:`, `platform:`, `sdk>=:`, `sdk<=:`, `type:`) so updated mappings stay in SDL's expected shape.
- Advertise and transmit the existing Moonlight/Sunshine paddle flags only when SDL exposes the controller-button layer with the canonical Edge raw button bindings.
- Add diagnostics for the Edge detection/arrival path, VID/PID, runtime SDL version, raw-mapping selection signal, and per-button debug logging.
- Force confirmed DualSense Edge VID/PID devices to PlayStation arrival type `0x02` and log both SDL type and protocol arrival type.
- Log the actual Edge paddle controller binding summary for arrival and SDL mapping-failure diagnostics.
- Suppress controller-button aliases that still point at the active raw Edge-only buttons, even if canonical paddle bindings are also present, so stale SDL mappings cannot leak paddles/Fn as face buttons or normal-button arrival capabilities.
- Select native SDL2 raw bindings `paddle1:b20,paddle2:b19,paddle3:b18,paddle4:b17` or `sdl2-compat`/SDL3 raw bindings `paddle1:b16,paddle2:b15,paddle3:b14,paddle4:b13` at runtime.
- Select the `sdl2-compat`/SDL3 raw layout only from an SDL3 runtime hint or Moonlight's existing high-patch sdl2-compat runtime-version signal, so an ambiguous 17-button Edge shape fails closed instead of guessing.
- Log that raw-mapping selection signal as `native SDL2 runtime`, `SDL3_VERSION`, or `sdl2-compat runtime version` so physical evidence does not rely on reviewer inference from version numbers alone.
- Add a local verifier script that checks both Edge mapping layouts, button-map adjacency, metadata insertion point, stale raw-alias normalization cases, Sunshine high-word protocol transport, and negative evidence cases without physical hardware.

## Context
This is a client-side companion for preserving DualSense Edge rear paddles/Fn buttons through Apollo/Sunshine-compatible streaming. The protocol already has paddle flags; this PR makes Moonlight expose the Edge-specific SDL buttons as those flags instead of losing them as a generic PS5/DS4-style controller.

Relevant upstream context considered:
- moonlight-stream/moonlight-qt#1621: SDL3 HIDAPI drivers can fix device-specific controller capabilities, but this PR keeps the workaround Edge-specific and SDL2-compatible.
- moonlight-stream/moonlight-qt#1881: maintainers note that the current protocol supports basic buttons, paddles, sticks, triggers, motion, battery, and touchpads; full HID passthrough is a separate larger feature.
- moonlight-stream/moonlight-qt#1329: full PlayStation feature parity is larger than this button-preservation path; sound/adaptive triggers remain separate SDL/protocol work.
- libsdl-org/SDL#13835: SDL maintainers recommend probing specific supported buttons with SDL_GameControllerHasButton().
- libsdl-org/SDL#14544: a reported Edge additional-button mapping issue was traced to the app mapping layer, so this PR normalizes stale paddle mappings before trusting them.
- Steam Input reports show that collapsing Edge expanded buttons into face-button behavior is a real user-facing problem, so this PR preserves distinct paddle/Fn flags instead of remapping them to A/B/X/Y.
- SDL2's DualSense Edge HIDAPI path sets the Edge to 21 raw joystick buttons and its generated mapping is exactly `paddle1:b20,paddle2:b19,paddle3:b18,paddle4:b17`.
- Rechecked that SDL2 evidence against `libsdl-org/SDL` branch `SDL2` at `b8b3f5ef2001cbe7c11f62d41a9bf47d4a2d8b07`; Moonlight's bundled macOS SDL2 compatibility library reports version `2.32.70` and loads SDL3 `3.4.11` through `sdl2-compat`. Later SDL #14544 comments still point at mapping-layer behavior and newer SDL releases rather than a protocol change.
- SDL2's controller-button enum order places `SDL_CONTROLLER_BUTTON_PADDLE1..4` at 16-19; this branch asserts that order where those enum constants are available.
- SDL2's controller mapping metadata fields are `crc:`, `hint:`, `platform:`, `sdk>=:`, `sdk<=:`, and `type:`. SDL3's gamepad mapping code also has `face:`, so this branch treats it as metadata too when normalizing the Edge paddle block.
- SDL3 uses different raw button numbers (`paddle1:b16,paddle2:b15,paddle3:b14,paddle4:b13`) and explicit right/left paddle labels, so this branch deliberately targets Moonlight's current SDL2 `SDL_GameController` API while selecting the correct runtime raw binding set and preserving the same semantic order: right rear, left rear, right Fn, left Fn.
- Rechecked that SDL3 evidence against `libsdl-org/SDL` main at `f0e99e7c7f9aa90d5ce2e3b8a69f72c23faf257e`.
- Electronicks/JoyShockMapper#155 reports right-side Edge extra buttons also firing their left-side counterparts in another mapping layer, so physical validation needs one-at-a-time Edge presses with no combined paddle/Fn masks.
- Electronicks/JoyShockMapper#90 and JibbSmart/JoyShockMapper#169 report earlier Edge support problems such as duplicate mic-mute mapping, a missed left Fn input, and swapped left-side labels, so physical validation must cross-check third-party labels against the actual physical press order and Moonlight/Apollo masks.

## Companion host PR
Apollo draft PR: https://github.com/ClassicOldSong/Apollo/pull/1530

## Validation
- Rebased onto upstream `origin/master` commit `b2d77f48` and force-pushed with lease; current head is `236d121f`, and the branch is `44` commits ahead and `0` behind upstream.
- Fresh qmake configure passed on macOS at runtime-code head `1c046153` in `/tmp/moonlight-qt-build-edge`: `qmake /Users/georgeleonardo/Developer/moonlight-qt/moonlight-qt.pro CONFIG+=debug CONFIG+=sdk_no_version_check`.
- Fresh debug build passed on macOS at runtime-code head `1c046153`: `make -C /tmp/moonlight-qt-build-edge -j$(sysctl -n hw.ncpu)`.
- Incremental debug build passed on macOS at runtime-code head `1bfc3e31`: `make -C /tmp/moonlight-qt-build-edge -j$(sysctl -n hw.ncpu)`.
- Fresh qmake configure passed on macOS at runtime-code head `1c046153` in `/tmp/moonlight-qt-build-edge-release`: `qmake /Users/georgeleonardo/Developer/moonlight-qt/moonlight-qt.pro CONFIG+=release CONFIG+=sdk_no_version_check`.
- Fresh release build passed on macOS at runtime-code head `1c046153`: `make -C /tmp/moonlight-qt-build-edge-release -j$(sysctl -n hw.ncpu)`.
- Incremental release build passed on macOS at runtime-code head `1bfc3e31`: `make -C /tmp/moonlight-qt-build-edge-release -j$(sysctl -n hw.ncpu)`.
- Hardened synthetic evidence rejection after commit `6958aa29`; the verifier now rejects native SDL2 and `sdl2-compat`/SDL3 raw-button undercounts, wrong Edge VID/PID, and ambiguous low-patch `sdl2-compat` evidence.
- Hardened source verifier coverage after commit `236d121f`; the verifier now fails if Edge paddle support stops probing SDL's controller-button layer with `SDL_GameControllerHasButton()` or stops verifying concrete bindings with `SDL_GameControllerGetBindForButton()`.
- Re-ran the local Edge mapping verifier at current head `236d121f`: `node /Users/georgeleonardo/Developer/moonlight-qt/scripts/verify-dualsense-edge-mapping.js`.
- `git diff --check origin/master...HEAD`, `git diff --check`, and `git diff --cached --check` passed at current head `236d121f`.
- Rechecked upstream issue context on 2026-06-28 across Moonlight #1881/#1329, Apollo #805/#851/#957/#1060/#1237, Sunshine #3468/#3600/#3527/#4948, and SDL #13835/#14544/#14581/#13339; newer comments still support a scoped Edge button-preservation path over the existing controller protocol rather than full raw USB passthrough or DS4/X360 remapping, and newer Moonlight nightlies still use the SDL2 API through `sdl2-compat`.
- Runtime mapping support covers SDL2 metadata (`type:`), SDL3 metadata (`face:`), canonical paddle insertion before non-binding metadata, stale paddle-entry canonicalization, and stale non-paddle aliases such as `a:b20`.
- Verified Edge transmission remains fail-closed: Moonlight only advertises or transmits `PADDLE1..4` when SDL exposes the canonical controller-button bindings for native SDL2 (`b20,b19,b18,b17`) or `sdl2-compat`/SDL3 (`b16,b15,b14,b13`), and unknown 17-20 button Edge shapes without an SDL3/sdl2-compat runtime signal do not guess a mapping.
- Verified diagnostics cover the required physical evidence lines: confirmed Sony `054c:0df2`, runtime `SDL x.y.z` or `SDL x.y.z, SDL3 x.y.z`, raw mapping signal, mapping success or already-present status, `arrivalType=0x02`, `paddle/Fn=0x000f0000`, active binding summary, and per-button press/release logs.
- Verified stale Edge alias safeguards cover normal-button transmission, arrival capability filtering, duplicate raw aliases, and stale state flushing so unverified Edge input cannot leak as face buttons or leave a host-visible stuck paddle/Fn flag.
- Verifier coverage pins `moonlight-common-c` `PADDLE1..4` values, Sunshine `buttonFlags2` serialization, 32-bit arrival `supportedButtonFlags`, SDL controller-button adjacency around `MISC1`, `PADDLE1..4`, and `TOUCHPAD`, and complete same-log evidence for native SDL2 and `sdl2-compat`/SDL3.
- Verifier coverage accepts explicit `SDL3_VERSION` and high-patch `sdl2-compat runtime version` evidence, and rejects missing/wrong raw-mapping signals, raw-button undercounts, wrong Edge VID/PID, ambiguous low-patch `sdl2-compat` evidence, missing release-to-neutral lines, binding-variant mismatches, combined one-at-a-time masks, mapping-binding failure diagnostics, unverified paddle-event diagnostics, stale raw-alias diagnostics, capability-alias diagnostics, and partial copied logs.
- Companion Apollo validation now requires Moonlight debug logs to show a press and matching release-to-neutral line for each Edge-specific control, plus at least four Apollo neutral-state observations in the same evidence bundle.
- Companion Apollo head `96900d74` adds usbip-win2 WPP trace bundling, Windows device-event capture, DeviceClasses HID-interface validation, GameInput/Gaming Services service and registry context capture, and SISR/PadForge/HIDMaestro/W3C research notes; those are host-side evidence aids and do not change Moonlight mapping.
- Companion Apollo documentation now calls out JoyShockMapper label swaps and duplicate mic-mute history, so host-input evidence should not treat `LSL`/`LSR`/`RSL`/`RSR` labels alone as proof of physical Edge button correctness.
- Only observed build warnings were existing local linker warnings: duplicate `@executable_path/../Frameworks` rpath and Homebrew Qt dylibs built for newer macOS 26.0 while this build targets macOS 14.0.

## Draft status
Draft until one physical end-to-end run with the companion Apollo PR confirms:
- Moonlight detects the DualSense Edge VID/PID with `VID/PID: 0x054c/0x0df2` in the Edge detection log, records `SDL x.y.z` or `SDL x.y.z, SDL3 x.y.z`, records `raw mapping signal: native SDL2 runtime`, `raw mapping signal: SDL3_VERSION`, or `raw mapping signal: sdl2-compat runtime version`, and SDL exposes at least `21` joystick buttons for native SDL2 or at least `17` joystick buttons when an SDL3 hint or sdl2-compat runtime-version signal selects the `sdl2-compat`/SDL3 layout.
- Moonlight is launched with SDL application debug logging enabled, for example `SDL_LOGGING=application=debug`, so the per-button Edge press/release evidence is captured.
- Moonlight reports either `Applied DualSense Edge paddle mappings (...)` or `DualSense Edge paddle mappings already present`.
- Moonlight does not report that SDL failed to expose the expected paddle controller bindings after mapping and does not log `Ignoring DualSense Edge controller button ... bound to raw ... as stale Edge raw alias` while pressing Edge-specific controls.
- Moonlight does not log `Ignoring DualSense Edge PADDLE... event without verified paddle bindings` while pressing Edge-specific controls.
- Moonlight sends arrival support with `arrivalType=0x02`, `paddle/Fn=0x000f0000` and either `bindings=paddle1=b20,paddle2=b19,paddle3=b18,paddle4=b17` or `bindings=paddle1=b16,paddle2=b15,paddle3=b14,paddle4=b13`, without warning that a normal controller button was bound to raw Edge-only input.
- Each physical Edge control changes a distinct Moonlight paddle flag and logs a matching release back to `0x00000000` when tested one at a time:
  - PADDLE1/right rear: `0x00010000`
  - PADDLE2/left rear: `0x00020000`
  - PADDLE3/right Fn: `0x00040000`
  - PADDLE4/left Fn: `0x00080000`
- Moonlight does not log combined paddle/Fn masks such as `0x00030000`, `0x00050000`, or `0x00090000` while testing one Edge-specific control at a time.
- Apollo receives the same arrival mask, observes at least four returns to `[00000000]`, and the host-side virtual Edge device exposes those four controls separately instead of remapping them to face buttons.
