### PR TITLE
Fix crash when skipping oversized displays

### DIFF
--- a/app/backend/systemproperties.cpp
+++ b/app/backend/systemproperties.cpp
@@ -141,21 +141,18 @@ void SystemProperties::updateDecoderProperties(bool hasHardwareAcceleration, boo
 QRect SystemProperties::getNativeResolution(int displayIndex)
 {
     // Returns default constructed QRect if out of bounds
-    Q_ASSERT(!monitorNativeResolutions.isEmpty());
     return monitorNativeResolutions.value(displayIndex);
 }
 
 QRect SystemProperties::getSafeAreaResolution(int displayIndex)
 {
     // Returns default constructed QRect if out of bounds
-    Q_ASSERT(!monitorSafeAreaResolutions.isEmpty());
     return monitorSafeAreaResolutions.value(displayIndex);
 }
 
 int SystemProperties::getRefreshRate(int displayIndex)
 {
     // Returns 0 if out of bounds
-    Q_ASSERT(!monitorRefreshRates.isEmpty());
     return monitorRefreshRates.value(displayIndex);
 }
 
@@ -221,6 +218,8 @@ void SystemProperties::refreshDisplays()
     }
 
     monitorNativeResolutions.clear();
+    monitorSafeAreaResolutions.clear();
+    monitorRefreshRates.clear();
 
     SDL_DisplayMode bestMode;
     for (int displayIndex = 0; displayIndex < SDL_GetNumVideoDisplays(); displayIndex++) {
@@ -229,8 +228,11 @@ void SystemProperties::refreshDisplays()
 
         if (StreamUtils::getNativeDesktopMode(displayIndex, &desktopMode, &safeArea)) {
             if (desktopMode.w <= 8192 && desktopMode.h <= 8192) {
-                monitorNativeResolutions.insert(displayIndex, QRect(0, 0, desktopMode.w, desktopMode.h));
-                monitorSafeAreaResolutions.insert(displayIndex, QRect(0, 0, safeArea.w, safeArea.h));
+                // Keep these lists compact because their QML consumers iterate until
+                // the first empty entry. Inserting by SDL display index is invalid if
+                // an earlier display was skipped (for example, a >8K virtual display).
+                monitorNativeResolutions.append(QRect(0, 0, desktopMode.w, desktopMode.h));
+                monitorSafeAreaResolutions.append(QRect(0, 0, safeArea.w, safeArea.h));
             }
             else {
                 SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,


### PR DESCRIPTION
## Problem

Moonlight excludes detected native resolutions above 8192 pixels from the settings list. However, it inserted each accepted resolution into a QList using the SDL display index. If an oversized display was skipped and a later display was accepted, the insertion index was greater than the list size. Qt then attempted an invalid memmove and Moonlight crashed during display enumeration.

This was reproduced on macOS with a BetterDisplay virtual HiDPI 1440p display mirrored to an Odyssey G95NC. The mirrored display was reported as 10240x2880, which triggered the skip and exposed the sparse-index bug.

## Fix

- Append accepted native and safe-area resolutions so the QML-facing lists remain compact after skipped displays.
- Clear all display-related caches when refreshing them.
- Allow empty cache lookups to return the documented default values instead of asserting.

## Testing

- Built the release target on Apple Silicon with Qt 6.11.1.
- Launched Moonlight with the BetterDisplay configuration enabled and confirmed that 10240x2880 was skipped without a crash.
- Successfully started a 3840x2160 at 120 FPS stream on the 5120x1440 HiDPI desktop.