### PR TITLE
Add Fedora rpm build via packit

### DIFF
--- a/.distro/moonlight-qt.spec
+++ b/.distro/moonlight-qt.spec
@@ -1,0 +1,119 @@
+%global         forgeurl0 https://github.com/moonlight-stream/moonlight-qt
+
+# TODO: Debundle these once the build-system can do that
+%global         forgeurl1 https://github.com/moonlight-stream/moonlight-common-c
+%global         forgeurl2 https://github.com/cgutman/qmdnsengine
+%global         forgeurl3 https://github.com/gabomdq/SDL_GameControllerDB
+%global         forgeurl4 https://github.com/aizvorski/h264bitstream
+%global         forgeurl5 https://github.com/cgutman/enet
+%global         forgeurl6 https://github.com/sleepybishop/nanors
+
+%global         version0  0.0.0
+
+%global         commit1   PLACEHOLDER
+%global         commit2   PLACEHOLDER
+%global         commit3   PLACEHOLDER
+%global         commit4   PLACEHOLDER
+%global         commit5   PLACEHOLDER
+%global         commit6   PLACEHOLDER
+
+Provides:       bundled(moonlight-common-c) = 0~git%{commit1}
+Provides:       bundled(qmdnsengine) = 0.1.0^git%{commit2}
+Provides:       bundled(SDL_GameControllerDB) = 0~git%{commit3}
+Provides:       bundled(h264bitstream) = 0.2.0^git%{commit4}
+Provides:       bundled(enet) = 1.3.17^git%{commit5}
+Provides:       bundled(nanors-common-c) = 0~git%{commit6}
+
+Name:           moonlight-qt
+Release:        %autorelease
+%forgemeta -a
+Version:        %forgeversion
+Summary:        GameStream client for PCs
+
+License:        GPL-3.0-or-later
+URL:            %forgeurl0
+Source0:        %forgesource0
+Source1:        %forgesource1
+Source2:        %forgesource2
+Source3:        %forgesource3
+Source4:        %forgesource4
+Source5:        %forgesource5
+Source6:        %forgesource6
+
+BuildRequires:  appstream
+BuildRequires:  desktop-file-utils
+BuildRequires:  gcc-c++
+BuildRequires:  make
+BuildRequires:  qt6-qtbase-devel
+BuildRequires:  qt6-qtdeclarative-devel
+BuildRequires:  qt6-qtsvg-devel
+BuildRequires:  pkgconfig(egl)
+BuildRequires:  pkgconfig(gl)
+BuildRequires:  pkgconfig(libavcodec) >= 60
+BuildRequires:  pkgconfig(libavformat)
+BuildRequires:  pkgconfig(libavutil)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libplacebo) >= 7.349.0
+BuildRequires:  pkgconfig(libswscale)
+BuildRequires:  pkgconfig(libva)
+BuildRequires:  pkgconfig(libva-drm)
+BuildRequires:  pkgconfig(libva-wayland)
+BuildRequires:  pkgconfig(libva-x11)
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(opus)
+BuildRequires:  pkgconfig(sdl2)
+BuildRequires:  pkgconfig(SDL2_ttf)
+BuildRequires:  pkgconfig(vdpau)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(x11)
+
+# Directory ownership
+Requires: hicolor-icon-theme
+
+%description
+Moonlight is an open-source game-streaming client for Sunshine and NVIDIA
+GameStream hosts. This package tracks the upstream master branch and is built
+entirely from source, including its pinned Git submodules.
+
+
+%prep
+%autosetup -p1 -n moonlight-qt-%{version}
+tar -xf %{SOURCE1} --strip-components=1 -C moonlight-common-c/moonlight-common-c
+tar -xf %{SOURCE2} --strip-components=1 -C qmdnsengine/qmdnsengine
+tar -xf %{SOURCE3} --strip-components=1 -C app/SDL_GameControllerDB
+tar -xf %{SOURCE4} --strip-components=1 -C h264bitstream/h264bitstream
+tar -xf %{SOURCE5} --strip-components=1 -C moonlight-common-c/moonlight-common-c/enet
+tar -xf %{SOURCE6} --strip-components=1 -C moonlight-common-c/moonlight-common-c/nanors
+
+
+%conf
+%qmake_qt6 \
+  "PREFIX=%{_prefix}"
+
+
+%build
+%make_build
+
+
+%install
+%make_install INSTALL_ROOT=%{buildroot}
+
+
+%check
+desktop-file-validate \
+    %{buildroot}%{_datadir}/applications/com.moonlight_stream.Moonlight.desktop
+appstreamcli validate --no-net \
+    %{buildroot}%{_datadir}/metainfo/com.moonlight_stream.Moonlight.appdata.xml
+
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/moonlight
+%{_datadir}/applications/com.moonlight_stream.Moonlight.desktop
+%{_datadir}/icons/hicolor/scalable/apps/moonlight.svg
+%{_datadir}/metainfo/com.moonlight_stream.Moonlight.appdata.xml
+
+
+%changelog
+%autochangelog

--- a/.distro/post-upstream-clone.py
+++ b/.distro/post-upstream-clone.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# /// script
+# ///
+
+import re
+import subprocess
+from pathlib import Path
+
+submodule_macro = {
+    "moonlight-common-c/moonlight-common-c": "commit1",
+    "qmdnsengine/qmdnsengine": "commit2",
+    "app/SDL_GameControllerDB": "commit3",
+    "h264bitstream/h264bitstream": "commit4",
+    "moonlight-common-c/moonlight-common-c/enet": "commit5",
+    "moonlight-common-c/moonlight-common-c/nanors": "commit6",
+}
+spec_file = Path(__file__).parent / "moonlight-qt.spec"
+
+
+def get_submodules() -> dict[str, str]:
+    submodule_status_lines = subprocess.run(
+        [
+            "git",
+            "submodule",
+            "status",
+            "--recursive",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+    if any(line.startswith("-") for line in submodule_status_lines):
+        subprocess.check_call(
+            [
+                "git",
+                "submodule",
+                "update",
+                "--recursive",
+            ]
+        )
+        results = get_submodules()
+        subprocess.check_call(
+            [
+                "git",
+                "submodule",
+                "deinit",
+                "--all",
+            ]
+        )
+        return results
+    results = {}
+    for line in submodule_status_lines:
+        sha, path, ref = line.strip().split(" ")
+        results[path] = sha
+    return results
+
+
+def patch_specfile(submodules: dict[str, str]) -> None:
+    spec = spec_file.read_text()
+    for path, sha in submodules.items():
+        commit_tag = submodule_macro[path]
+        spec = re.sub(rf"(%global\s*{commit_tag}\s*)\w+", rf"\g<1>{sha}", spec)
+    spec_file.write_text(spec)
+
+
+if __name__ == "__main__":
+    submodules = get_submodules()
+    if set(submodules.keys()) != set(submodule_macro.keys()):
+        print("submodule lists do not match")
+        exit(1)
+    patch_specfile(submodules)

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ build/
 libs/
 config.tests/*/.qmake.stash
 config.tests/*/Makefile
+
+### Fedora packaging
+*.rpm
+*.tar.gz
+*.log

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,6 +9,11 @@ actions:
   post-upstream-clone:
     - ./.distro/post-upstream-clone.py
 
+notifications:
+  failure_comment:
+    message: |
+      Packit build failed @LecrisUT please check
+
 targets:
   - fedora-all
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+specfile_path: .distro/moonlight-qt.spec
+upstream_package_name: moonlight-qt
+downstream_package_name: moonlight-qt
+
+version_suffix: "^{PACKIT_PROJECT_SNAPSHOTID}"
+update_release: false
+
+actions:
+  post-upstream-clone:
+    - ./.distro/post-upstream-clone.py
+
+targets:
+  - fedora-all
+
+jobs:
+  - job: copr_build
+    trigger: pull_request


### PR DESCRIPTION
It would be quite helpful if you could add the rpm build automation with [packit](https://packit.dev/docs/guide) which would track the build status as this project and the Fedora dependencies evolve. The setup that is setup here is:
- Build a copr build for each PR
- If a build fails notify me to see the logs and try and help (would not mind having manual pings though :slightly_smiling_face:)
- `.distro/post-upstream-clone.py` fixes the `commitN` references so that it points to the git submodule shas

In order to enable this you would need to install the [github app](https://github.com/marketplace/packit-as-a-service).

A few other things that can be setup with this integration:
- Build nightly and releases into specific copr projects
- Add complex tests even some that would need setting up sunshine server and such