### PR TITLE
Fix ABNT2 keyboard mappings for C1 and C2 keys

### DIFF
--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -6,6 +6,14 @@
 #define VK_0 0x30
 #define VK_A 0x41
 
+#ifndef VK_ABNT_C1
+#define VK_ABNT_C1 0xC1
+#endif
+
+#ifndef VK_ABNT_C2
+#define VK_ABNT_C2 0xC2
+#endif
+
 // These are real Windows VK_* codes
 #ifndef VK_F1
 #define VK_F1 0x70
@@ -337,7 +345,8 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 keyCode = 0x6B;
                 break;
             case SDL_SCANCODE_KP_COMMA:
-                keyCode = 0x6C;
+                shouldNotConvertToScanCodeOnServer = true;
+                keyCode = VK_ABNT_C2;
                 break;
             case SDL_SCANCODE_KP_MINUS:
                 keyCode = 0x6D;
@@ -446,7 +455,8 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 break;
             case SDL_SCANCODE_INTERNATIONAL1:
                 shouldNotConvertToScanCodeOnServer = true;
-                Q_FALLTHROUGH();
+                keyCode = VK_ABNT_C1;
+                break;
             case SDL_SCANCODE_NONUSBACKSLASH:
                 keyCode = 0xE2;
                 break;


### PR DESCRIPTION
## Summary

This PR fixes Brazilian ABNT2 keyboard handling by sending the ABNT-specific Windows virtual key codes for both affected SDL scancodes:

- `SDL_SCANCODE_INTERNATIONAL1` now maps to `VK_ABNT_C1`.
- `SDL_SCANCODE_KP_COMMA` now maps to `VK_ABNT_C2`.
- Both keys are sent with `SS_KBE_FLAG_NON_NORMALIZED` so the server does not convert them back through a generic scancode path.
- Fallback definitions are added for `VK_ABNT_C1` and `VK_ABNT_C2` when the build SDK headers do not define them.

## Why

On ABNT2 PT-BR keyboards, these keys are layout-specific and should be sent as their ABNT virtual key codes. Previously, `SDL_SCANCODE_INTERNATIONAL1` fell through to `SDL_SCANCODE_NONUSBACKSLASH` and used `0xE2`, while `SDL_SCANCODE_KP_COMMA` used `0x6C` instead of `VK_ABNT_C2`.

This is important because fixes that only handle `VK_ABNT_C1` leave the ABNT2 keypad comma key unresolved. This PR covers both `VK_ABNT_C1` and `VK_ABNT_C2`.

## Testing

- Tested locally with an ABNT2 PT-BR keyboard in the original commit this change was split from.
- Verified this PR diff only changes `app/streaming/input/keyboard.cpp`.