### PR TITLE
Close imported GEM handles after creating the FB

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/drm.cpp
+++ b/app/streaming/video/ffmpeg-renderers/drm.cpp
@@ -1791,6 +1791,30 @@ bool DrmRenderer::addFbForFrame(AVFrame *frame, uint32_t* newFbId, bool testMode
         return false;
     }
 
+    // The FB holds its own reference to the underlying buffer objects, so the GEM
+    // handles imported above can (and should) be released now. Leaving them open
+    // leaks a handle for every distinct buffer imported. That is normally invisible
+    // because the decoder reuses a fixed DMA-BUF pool (same fd -> same handle), but
+    // when the pool is reallocated — a colorspace or HDR transition, a resolution
+    // change — the old pool's handles are never freed. They accumulate until the
+    // GEM handle table is exhausted, at which point drmPrimeFDToHandle() starts
+    // failing with ENOMEM: new frames can no longer be imported, the last frame
+    // stays stuck on the plane, and the video freezes.
+    for (int i = 0; i < layer.nb_planes; i++) {
+        // Planes can share a buffer object (e.g. NV12/P010), in which case
+        // drmPrimeFDToHandle() returned the same handle for each. Close once.
+        bool alreadyClosed = false;
+        for (int j = 0; j < i; j++) {
+            if (handles[j] == handles[i]) {
+                alreadyClosed = true;
+                break;
+            }
+        }
+        if (!alreadyClosed) {
+            drmCloseBufferHandle(m_DrmFd, handles[i]);
+        }
+    }
+
     // For atomic drivers, we'll use a test-only commit to confirm this plane+FB works
     if (testMode && m_PropSetter.isAtomic()) {
         SDL_Rect src, dst;


### PR DESCRIPTION
### Problem

In `DrmRenderer::addFbForFrame()`, each plane is imported with `drmPrimeFDToHandle()`, but the
resulting GEM handles are never closed. `drmModeAddFB2WithModifiers()` takes its own reference to
the underlying buffer objects, so holding the handles open afterwards serves no purpose.

While the decoder reuses a fixed DMA-BUF pool this is invisible: the same fd maps to the same
handle, so no new handle is allocated. It becomes a problem when the pool is **reallocated** — a
colorspace or HDR transition, a resolution change. The previous pool's handles are never freed and
accumulate, until the GEM handle table is exhausted and `drmPrimeFDToHandle()` starts returning
`ENOMEM`.

The failure mode is not a clean error: no new frame can be imported, so the last successfully
imported frame stays on the plane. The picture ghosts and the video freezes, while audio and input
keep working.

### Reproduction

Raspberry Pi 5 (vc4), 4K60 HDR stream, host alternating SDR and HDR content so the decoder pool is
reallocated repeatedly. Without the fix the stream ghosts then freezes after enough transitions;
with it, it runs indefinitely.

### Fix

Close each imported handle after the FB is created. Planes can share a buffer object (NV12/P010
return the same handle for every plane), so each distinct handle is closed once.

### Notes for the maintainer

Two things you may want to weigh in on:

- **`drmCloseBufferHandle()` is a first use in this project** and needs a reasonably recent libdrm
  (it was added around 2.4.112). If moonlight-qt targets older libdrm, the portable equivalent is
  a `struct drm_gem_close` passed to `drmIoctl(fd, DRM_IOCTL_GEM_CLOSE, &close)`. Happy to switch.
- **The early-return paths leak too** — `drmPrimeFDToHandle()` failing partway through the plane
  loop, and `drmModeAddFB2WithModifiers()` failing, both leave the handles imported so far open.
  Left untouched here since it is a rarer path and not what was exercised in testing; happy to fold
  it in if you prefer.