### PR TITLE
Add adaptive frame pacing for VRR displays

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -203,6 +203,7 @@ SOURCES += \
     settings/mappingmanager.cpp \
     gui/sdlgamepadkeynavigation.cpp \
     streaming/video/overlaymanager.cpp \
+    streaming/vrrratepolicy.cpp \
     backend/systemproperties.cpp \
     wm.cpp
 
@@ -234,6 +235,7 @@ HEADERS += \
     gui/computermodel.h \
     gui/appmodel.h \
     streaming/video/decoder.h \
+    streaming/vrrratepolicy.h \
     streaming/bandwidth.h \
     streaming/streamutils.h \
     backend/autoupdatechecker.h \
@@ -253,7 +255,10 @@ ffmpeg {
         streaming/video/ffmpeg-renderers/genhwaccel.cpp \
         streaming/video/ffmpeg-renderers/sdlvid.cpp \
         streaming/video/ffmpeg-renderers/swframemapper.cpp \
-        streaming/video/ffmpeg-renderers/pacer/pacer.cpp
+        streaming/video/ffmpeg-renderers/pacer/pacer.cpp \
+        streaming/video/ffmpeg-renderers/pacer/vrrpacingworker.cpp \
+        streaming/video/ffmpeg-renderers/pacer/vrr/vrrtimingcontroller.cpp \
+        streaming/video/ffmpeg-renderers/pacer/vrr/vrrtargetwaiter.cpp
 
     HEADERS += \
         streaming/video/ffmpeg.h \
@@ -261,7 +266,12 @@ ffmpeg {
         streaming/video/ffmpeg-renderers/genhwaccel.h \
         streaming/video/ffmpeg-renderers/sdlvid.h \
         streaming/video/ffmpeg-renderers/swframemapper.h \
-        streaming/video/ffmpeg-renderers/pacer/pacer.h
+        streaming/video/ffmpeg-renderers/pacer/pacer.h \
+        streaming/video/ffmpeg-renderers/pacer/vrrpacingworker.h \
+        streaming/video/ffmpeg-renderers/ivrrframepresenter.h \
+        streaming/video/ffmpeg-renderers/pacer/vrr/vrrtypes.h \
+        streaming/video/ffmpeg-renderers/pacer/vrr/vrrtimingcontroller.h \
+        streaming/video/ffmpeg-renderers/pacer/vrr/vrrtargetwaiter.h
 }
 libva {
     message(VAAPI renderer selected)

--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -347,6 +347,7 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.addFlagOption("4K", "3840x2160 resolution");
     parser.addValueOption("resolution", "custom <width>x<height> resolution");
     parser.addToggleOption("vsync", "V-Sync");
+    parser.addToggleOption("vrr", "VRR");
     parser.addValueOption("fps", "FPS");
     parser.addValueOption("bitrate", "bitrate in Kbps");
     parser.addValueOption("packet-size", "video packet size");
@@ -437,6 +438,9 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
 
     // Resolve --vsync and --no-vsync options
     preferences->enableVsync = parser.getToggleOptionValue("vsync", preferences->enableVsync);
+
+    // Resolve --vrr and --no-vrr options
+    preferences->enableVrr = parser.getToggleOptionValue("vrr", preferences->enableVrr);
 
     // Resolve --audio-config option
     if (parser.isSet("audio-config")) {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -556,52 +556,46 @@ Flickable {
                             }
                         }
 
-                        function addRefreshRateOrdered(fpsListModel, refreshRate, description, custom) {
-                            var indexToAdd = 0
-                            for (var j = 0; j < fpsListModel.count; j++) {
-                                var existing_fps = parseInt(fpsListModel.get(j).video_fps);
-
-                                if (refreshRate === existing_fps || (custom && fpsListModel.get(j).is_custom)) {
-                                    // Duplicate entry, skip
-                                    indexToAdd = -1
+                        function getRefreshRates() {
+                            var refreshRates = []
+                            for (var displayIndex = 0; ; displayIndex++) {
+                                var refreshRate = SystemProperties.getRefreshRate(displayIndex)
+                                if (refreshRate === 0) {
                                     break
                                 }
-                                else if (refreshRate > existing_fps) {
-                                    // Candidate entrypoint after this entry
-                                    indexToAdd = j + 1
-                                }
+
+                                refreshRates.push(refreshRate)
                             }
 
-                            // Insert this frame rate if it's not a duplicate
-                            if (indexToAdd >= 0) {
-                                // Custom values always go at the end of the list
-                                if (custom) {
-                                    indexToAdd = fpsListModel.count
-                                }
+                            return refreshRates
+                        }
 
-                                fpsListModel.insert(indexToAdd,
-                                                    {
-                                                        "text": description,
-                                                        "video_fps": ""+refreshRate,
-                                                        "is_custom": custom
-                                                    })
+                        function choiceText(choice) {
+                            switch (choice.kind) {
+                            case "vrr":
+                                return qsTr("VRR (%1 FPS)").arg(choice.video_fps)
+                            case "low-latency-vrr":
+                                return qsTr("Low-latency VRR (%1 FPS)").arg(choice.video_fps)
+                            case "custom":
+                                return qsTr("Custom (%1 FPS)").arg(choice.video_fps)
+                            default:
+                                return qsTr("%1 FPS").arg(choice.video_fps)
                             }
-
-                            return indexToAdd
                         }
 
                         function reinitialize() {
-                            // Add native refresh rate for all attached displays
-                            var done = false
-                            for (var displayIndex = 0; !done; displayIndex++) {
-                                var refreshRate = SystemProperties.getRefreshRate(displayIndex);
-                                if (refreshRate === 0) {
-                                    // Exceeded max count of displays
-                                    done = true
-                                    break
-                                }
+                            var choices = StreamingPreferences.getFpsChoices(getRefreshRates())
+                            model.clear()
+                            var hasCustomChoice = false
 
-                                addRefreshRateOrdered(fpsListModel, refreshRate, qsTr("%1 FPS").arg(refreshRate), false)
+                            for (var i = 0; i < choices.length; i++) {
+                                var choice = choices[i]
+                                hasCustomChoice = hasCustomChoice || choice.is_custom
+                                model.append({
+                                                 "text": choiceText(choice),
+                                                 "video_fps": choice.video_fps,
+                                                 "is_custom": choice.is_custom
+                                             })
                             }
 
                             var saved_fps = StreamingPreferences.fps
@@ -617,12 +611,18 @@ Flickable {
                                 }
                             }
 
-                            // If we didn't find one, add a custom frame rate for the current value
+                            // VRR mode omits exact native refresh rates, so a saved
+                            // native value may have no entry to select.
                             if (!found) {
-                                currentIndex = addRefreshRateOrdered(model, saved_fps, qsTr("Custom (%1 FPS)").arg(saved_fps), true)
+                                currentIndex = model.count > 0 ? 0 : -1
                             }
-                            else {
-                                addRefreshRateOrdered(model, "", qsTr("Custom"), true)
+
+                            if (!hasCustomChoice) {
+                                model.append({
+                                                 "text": qsTr("Custom"),
+                                                 "video_fps": "",
+                                                 "is_custom": true
+                                             })
                             }
 
                             recalculateWidth()
@@ -634,21 +634,12 @@ Flickable {
                         Component.onCompleted: {
                             reinitialize()
                             languageChanged.connect(reinitialize)
+                            StreamingPreferences.enableVsyncChanged.connect(reinitialize)
+                            StreamingPreferences.enableVrrChanged.connect(reinitialize)
                         }
 
                         model: ListModel {
                             id: fpsListModel
-                            // Other elements may be added at runtime
-                            ListElement {
-                                text: qsTr("30 FPS")
-                                video_fps: "30"
-                                is_custom: false
-                            }
-                            ListElement {
-                                text: qsTr("60 FPS")
-                                video_fps: "60"
-                                is_custom: false
-                            }
                         }
 
                         id: fpsComboBox
@@ -799,7 +790,10 @@ Flickable {
 
                     id: windowModeComboBox
                     visible: SystemProperties.hasDesktopEnvironment
-                    enabled: !SystemProperties.rendererAlwaysFullScreen
+                    // An active VRR session always uses borderless fullscreen,
+                    // so the saved preference cannot take effect while it is on.
+                    enabled: !SystemProperties.rendererAlwaysFullScreen &&
+                             !(StreamingPreferences.enableVsync && StreamingPreferences.enableVrr)
                     hoverEnabled: true
                     textRole: "text"
                     onActivated: {
@@ -846,6 +840,23 @@ Flickable {
                         ToolTip.timeout: 5000
                         ToolTip.visible: hovered
                         ToolTip.text: qsTr("Frame pacing reduces micro-stutter by delaying frames that come in too early")
+                    }
+
+                    CheckBox {
+                        hoverEnabled: true
+                        text: qsTr("Enable VRR")
+                        font.pointSize: 12
+                        enabled: StreamingPreferences.enableVsync
+                        checked: StreamingPreferences.enableVrr
+                        onCheckedChanged: {
+                            StreamingPreferences.enableVrr = checked
+                        }
+
+                        ToolTip.delay: 1000
+                        ToolTip.timeout: 5000
+                        ToolTip.visible: hovered
+                        ToolTip.text: enabled ? qsTr("VRR uses paced adaptive presentation with best-effort tear avoidance. Sessions without enough refresh-rate headroom use fixed V-Sync. Borderless fullscreen is used while VRR is active.")
+                                              : qsTr("VRR requires V-Sync. Enable V-Sync to change this setting.")
                     }
                 }
 

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -1,14 +1,20 @@
 #include "streamingpreferences.h"
 #include "utils.h"
+#include "streaming/vrrratepolicy.h"
 
 #include <QSettings>
 #include <QTranslator>
 #include <QCoreApplication>
 #include <QLocale>
 #include <QReadWriteLock>
+#include <QVariantMap>
 #include <QtMath>
 
 #include <QtDebug>
+
+#include <algorithm>
+#include <map>
+#include <vector>
 
 #define SER_STREAMSETTINGS "streamsettings"
 #define SER_WIDTH "width"
@@ -19,6 +25,7 @@
 #define SER_AUTOADJUSTBITRATE "autoadjustbitrate"
 #define SER_FULLSCREEN "fullscreen"
 #define SER_VSYNC "vsync"
+#define SER_ENABLEVRR "enablevrr"
 #define SER_GAMEOPTS "gameopts"
 #define SER_HOSTAUDIO "hostaudio"
 #define SER_MULTICONT "multicontroller"
@@ -130,6 +137,7 @@ void StreamingPreferences::reload()
     unlockBitrate = settings.value(SER_UNLOCK_BITRATE, false).toBool();
     autoAdjustBitrate = settings.value(SER_AUTOADJUSTBITRATE, true).toBool();
     enableVsync = settings.value(SER_VSYNC, true).toBool();
+    enableVrr = settings.value(SER_ENABLEVRR, false).toBool();
     gameOptimizations = settings.value(SER_GAMEOPTS, true).toBool();
     playAudioOnHost = settings.value(SER_HOSTAUDIO, false).toBool();
     multiController = settings.value(SER_MULTICONT, true).toBool();
@@ -330,6 +338,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_UNLOCK_BITRATE, unlockBitrate);
     settings.setValue(SER_AUTOADJUSTBITRATE, autoAdjustBitrate);
     settings.setValue(SER_VSYNC, enableVsync);
+    settings.setValue(SER_ENABLEVRR, enableVrr);
     settings.setValue(SER_GAMEOPTS, gameOptimizations);
     settings.setValue(SER_HOSTAUDIO, playAudioOnHost);
     settings.setValue(SER_MULTICONT, multiController);
@@ -362,6 +371,64 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+}
+
+QVariantList StreamingPreferences::getFpsChoices(const QVariantList& refreshRates) const
+{
+    const bool vrrEnabled = enableVsync && enableVrr;
+
+    std::vector<int> rates;
+    rates.reserve(refreshRates.size());
+    for (const QVariant& value : refreshRates) {
+        bool ok = false;
+        const int refreshHz = value.toInt(&ok);
+        if (ok && refreshHz > 1) {
+            rates.push_back(refreshHz);
+        }
+    }
+
+    // Sorted by rate, and the first semantic role for a duplicate rate wins so
+    // a baseline choice is never relabeled by a coincident calculated rate.
+    std::map<int, QString> choices;
+    auto addChoice = [&choices](int rate, const char* kind) {
+        if (rate > 0) {
+            choices.emplace(rate, QLatin1String(kind));
+        }
+    };
+
+    // Always useful streaming rates, including on a 60 Hz display.
+    addChoice(30, "fixed");
+    addChoice(60, "fixed");
+
+    for (const int refreshHz : rates) {
+        if (vrrEnabled) {
+            // Exact native rates are deliberately omitted while VRR is on:
+            // they leave no adaptive-refresh headroom.
+            addChoice(VrrRatePolicy::vrrRateForRefresh(refreshHz), "vrr");
+            addChoice(VrrRatePolicy::lowLatencyRateForRefresh(refreshHz), "low-latency-vrr");
+        }
+        else {
+            addChoice(refreshHz, "fixed");
+        }
+    }
+
+    // A manually saved value must remain selectable, but a native rate is not
+    // reintroduced that way while VRR is enabled.
+    if (fps > 0 && (!vrrEnabled ||
+                    std::find(rates.cbegin(), rates.cend(), fps) == rates.cend())) {
+        addChoice(fps, "custom");
+    }
+
+    QVariantList result;
+    for (const auto& choice : choices) {
+        QVariantMap item;
+        item.insert("video_fps", QString::number(choice.first));
+        item.insert("is_custom", choice.second == QLatin1String("custom"));
+        item.insert("kind", choice.second);
+        result.append(item);
+    }
+
+    return result;
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QRect>
 #include <QQmlEngine>
+#include <QVariantList>
 
 class StreamingPreferences : public QObject
 {
@@ -126,6 +127,7 @@ public:
     Q_PROPERTY(bool unlockBitrate MEMBER unlockBitrate NOTIFY unlockBitrateChanged)
     Q_PROPERTY(bool autoAdjustBitrate MEMBER autoAdjustBitrate NOTIFY autoAdjustBitrateChanged)
     Q_PROPERTY(bool enableVsync MEMBER enableVsync NOTIFY enableVsyncChanged)
+    Q_PROPERTY(bool enableVrr MEMBER enableVrr NOTIFY enableVrrChanged)
     Q_PROPERTY(bool gameOptimizations MEMBER gameOptimizations NOTIFY gameOptimizationsChanged)
     Q_PROPERTY(bool playAudioOnHost MEMBER playAudioOnHost NOTIFY playAudioOnHostChanged)
     Q_PROPERTY(bool multiController MEMBER multiController NOTIFY multiControllerChanged)
@@ -160,6 +162,10 @@ public:
 
     Q_INVOKABLE bool retranslate();
 
+    // Rate choices are advisory; toggling VRR never rewrites the saved FPS
+    // preference.
+    Q_INVOKABLE QVariantList getFpsChoices(const QVariantList& refreshRates) const;
+
     // Directly accessible members for preferences
     int width;
     int height;
@@ -168,6 +174,7 @@ public:
     bool unlockBitrate;
     bool autoAdjustBitrate;
     bool enableVsync;
+    bool enableVrr;
     bool gameOptimizations;
     bool playAudioOnHost;
     bool multiController;
@@ -207,6 +214,7 @@ signals:
     void unlockBitrateChanged();
     void autoAdjustBitrateChanged();
     void enableVsyncChanged();
+    void enableVrrChanged();
     void gameOptimizationsChanged();
     void playAudioOnHostChanged();
     void multiControllerChanged();

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1,6 +1,7 @@
 #include "session.h"
 #include "settings/streamingpreferences.h"
 #include "streaming/streamutils.h"
+#include "streaming/vrrratepolicy.h"
 #include "backend/richpresencemanager.h"
 
 #include <Limelight.h>
@@ -278,7 +279,10 @@ void Session::clSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlag
 bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
                             StreamingPreferences::RendererSelection renderer,
                             SDL_Window* window, int videoFormat, int width, int height,
-                            int frameRate, bool enableVsync, bool enableFramePacing, bool testOnly, IVideoDecoder*& chosenDecoder)
+                            int frameRate, bool enableVsync, bool enableFramePacing,
+                            bool testOnly, IVideoDecoder*& chosenDecoder,
+                            bool enableVrr, int vrrDisplayRefreshHz,
+                            [[maybe_unused]] bool* effectiveVrr)
 {
     DECODER_PARAMETERS params;
 
@@ -294,6 +298,8 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
     params.window = window;
     params.enableVsync = enableVsync;
     params.enableFramePacing = enableFramePacing;
+    params.enableVrr = enableVrr;
+    params.vrrDisplayRefreshHz = vrrDisplayRefreshHz;
     params.testOnly = testOnly;
     params.vds = vds;
     params.renderer = renderer;
@@ -303,8 +309,18 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
                 enableVsync ? "enabled" : "disabled");
 
 #ifdef HAVE_SLVIDEO
+    // SLVideo has no VRR backend, so don't hand it an active VRR request. If
+    // it fails below, FFmpeg still receives the original parameters.
+    DECODER_PARAMETERS slVideoParams = params;
+    slVideoParams.enableVrr = false;
+    slVideoParams.vrrDisplayRefreshHz = 0;
     chosenDecoder = new SLVideoDecoder(testOnly);
-    if (chosenDecoder->initialize(&params)) {
+    if (chosenDecoder->initialize(&slVideoParams)) {
+        // Keep the session snapshot aligned with the decoder that was
+        // actually selected without changing the stored preference.
+        if (effectiveVrr != nullptr) {
+            *effectiveVrr = false;
+        }
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "SLVideo video decoder chosen");
         return true;
@@ -596,6 +612,39 @@ Session::~Session()
     SDL_DestroyMutex(m_DecoderLock);
 }
 
+void Session::snapshotPresentationSettings(SDL_Window* window)
+{
+    if (!m_Preferences->enableVrr) {
+        return;
+    }
+
+    // VRR must never qualify against an invented refresh rate, so this uses
+    // the strict query rather than getDisplayRefreshRate()'s 60 Hz guess.
+    // Requiring adaptive headroom also implies the stream rate stays below the
+    // refresh rate, which is the condition that would force V-sync off later.
+    int refreshRate = 0;
+    if (!m_Preferences->enableVsync ||
+            !StreamUtils::tryGetDisplayRefreshRate(window, refreshRate) ||
+            !VrrRatePolicy::hasAdaptiveHeadroom(m_StreamConfig.fps, refreshRate)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "VRR disabled: V-sync %s, %d FPS at %d Hz",
+                    m_Preferences->enableVsync ? "enabled" : "disabled",
+                    m_StreamConfig.fps, refreshRate);
+        return;
+    }
+
+    m_PresentationSettings.enableVrr = true;
+    m_PresentationSettings.refreshRate = refreshRate;
+
+    // Adaptive presentation requires borderless (non-exclusive) fullscreen.
+    // This is session-local state: the stored window-mode preference is never
+    // rewritten, so a later non-VRR session returns to that choice.
+    m_IsFullScreen = true;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "VRR enabled at %d Hz; forcing borderless fullscreen for this session",
+                refreshRate);
+}
+
 bool Session::initialize(QQuickWindow* qtWindow)
 {
     m_QtWindow = qtWindow;
@@ -672,6 +721,12 @@ bool Session::initialize(QQuickWindow* qtWindow)
         return false;
     }
 
+    // createTestWindow() normally starts on display zero.  Move it to the
+    // display selected for the real streaming window before snapshotting the
+    // refresh rate, otherwise a multi-monitor session could qualify VRR using
+    // the wrong panel's refresh.
+    SDL_SetWindowPosition(testWindow, x, y);
+
     qInfo() << "Server GPU:" << m_Computer->gpuModel;
     qInfo() << "Server GFE version:" << m_Computer->gfeVersion;
 
@@ -679,6 +734,7 @@ bool Session::initialize(QQuickWindow* qtWindow)
     m_VideoCallbacks.setup = drSetup;
 
     m_StreamConfig.fps = m_Preferences->fps;
+    snapshotPresentationSettings(testWindow);
     m_StreamConfig.bitrate = m_Preferences->bitrateKbps;
 
 #ifndef STEAM_LINK
@@ -924,6 +980,12 @@ bool Session::initialize(QQuickWindow* qtWindow)
         m_FullScreenFlag = SDL_WINDOW_FULLSCREEN;
 #endif
         break;
+    }
+
+    if (m_PresentationSettings.enableVrr) {
+        // Adaptive presentation requires borderless fullscreen. The saved
+        // window-mode preference is intentionally left untouched.
+        m_FullScreenFlag = SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
 
 #if !SDL_VERSION_ATLEAST(2, 0, 11)
@@ -1963,6 +2025,20 @@ void Session::exec()
     // Hijack this thread to be the SDL main thread. We have to do this
     // because we want to suspend all Qt processing until the stream is over.
     SDL_Event event;
+    auto notifyDecoderWindowState = [this](uint32_t stateChangeFlags) {
+        if (m_VideoDecoder == nullptr) {
+            return;
+        }
+
+        WINDOW_STATE_CHANGE_INFO windowChangeInfo = {};
+        windowChangeInfo.window = m_Window;
+        windowChangeInfo.stateChangeFlags = stateChangeFlags;
+
+        // State-only notifications are advisory.  Legacy renderers may return
+        // false for these new flags, but they must never force a renderer reset.
+        m_VideoDecoder->notifyWindowChanged(&windowChangeInfo);
+    };
+
     for (;;) {
 #if SDL_VERSION_ATLEAST(2, 0, 18) && !defined(STEAM_LINK)
         // SDL 2.0.18 has a proper wait event implementation that uses platform
@@ -2042,6 +2118,17 @@ void Session::exec()
             break;
 
         case SDL_WINDOWEVENT:
+            switch (event.window.event) {
+            case SDL_WINDOWEVENT_MINIMIZED:
+            case SDL_WINDOWEVENT_HIDDEN:
+                notifyDecoderWindowState(WINDOW_STATE_CHANGE_MINIMIZED);
+                break;
+            case SDL_WINDOWEVENT_RESTORED:
+            case SDL_WINDOWEVENT_SHOWN:
+                notifyDecoderWindowState(WINDOW_STATE_CHANGE_RESTORED);
+                break;
+            }
+
             // Early handling of some events
             switch (event.window.event) {
             case SDL_WINDOWEVENT_FOCUS_LOST:
@@ -2124,6 +2211,24 @@ void Session::exec()
                 }
 
                 int newDisplayIndex = SDL_GetWindowDisplayIndex(m_Window);
+
+                // A VRR session's display period is snapshotted at startup and
+                // baked into the renderer's immutable presentation mode, so any
+                // refresh change (including a mode switch on the same monitor)
+                // must drop back to fixed pacing rather than pace against a
+                // stale period.
+                if (m_PresentationSettings.enableVrr) {
+                    int currentRefreshRate = 0;
+                    if (!StreamUtils::tryGetDisplayRefreshRate(m_Window,
+                                                               currentRefreshRate) ||
+                            currentRefreshRate != m_PresentationSettings.refreshRate) {
+                        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                    "VRR disabled for this session after display refresh changed or became unavailable");
+                        m_PresentationSettings.enableVrr = false;
+                        forceRecreation = true;
+                    }
+                }
+
                 if (newDisplayIndex != currentDisplayIndex) {
                     windowChangeInfo.stateChangeFlags |= WINDOW_STATE_CHANGE_DISPLAY;
 
@@ -2206,6 +2311,13 @@ void Session::exec()
                     enableVsync = false;
                 }
 
+                // A VRR request that was rejected still runs on the fixed
+                // V-sync fallback, so keep that fallback paced even if the
+                // separate frame pacing option is off.
+                bool enableFramePacing = enableVsync &&
+                        (m_Preferences->framePacing ||
+                         (m_Preferences->enableVrr && !m_PresentationSettings.enableVrr));
+
                 // Choose a new decoder (hopefully the same one, but possibly
                 // not if a GPU was removed or something).
                 if (!chooseDecoder(m_Preferences->videoDecoderSelection,
@@ -2213,9 +2325,12 @@ void Session::exec()
                                    m_Window, m_ActiveVideoFormat, m_ActiveVideoWidth,
                                    m_ActiveVideoHeight, m_ActiveVideoFrameRate,
                                    enableVsync,
-                                   enableVsync && m_Preferences->framePacing,
+                                   enableFramePacing,
                                    false,
-                                   s_ActiveSession->m_VideoDecoder)) {
+                                   s_ActiveSession->m_VideoDecoder,
+                                   m_PresentationSettings.enableVrr,
+                                   m_PresentationSettings.refreshRate,
+                                   &m_PresentationSettings.enableVrr)) {
                     SDL_UnlockMutex(m_DecoderLock);
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                                  "Failed to recreate decoder after reset");

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -154,6 +154,8 @@ private:
 
     bool populateDecoderProperties(SDL_Window* window);
 
+    void snapshotPresentationSettings(SDL_Window* window);
+
     IAudioRenderer* createAudioRenderer(const POPUS_MULTISTREAM_CONFIGURATION opusConfig);
 
     bool initializeAudioRenderer();
@@ -187,8 +189,9 @@ private:
                        StreamingPreferences::RendererSelection renderer,
                        SDL_Window* window, int videoFormat, int width, int height,
                        int frameRate, bool enableVsync, bool enableFramePacing,
-                       bool testOnly,
-                       IVideoDecoder*& chosenDecoder);
+                       bool testOnly, IVideoDecoder*& chosenDecoder,
+                       bool enableVrr = false, int vrrDisplayRefreshHz = 0,
+                       bool* effectiveVrr = nullptr);
 
     static
     void clStageStarting(int stage);
@@ -243,7 +246,16 @@ private:
     static
     int drSubmitDecodeUnit(PDECODE_UNIT du);
 
+    // VRR qualification is decided once at session start. The refresh rate is
+    // baked into the renderer's immutable presentation mode, so it must not be
+    // re-derived from a mutable settings object mid-stream.
+    struct PresentationSettings {
+        bool enableVrr = false;
+        int refreshRate = 0;
+    };
+
     StreamingPreferences* m_Preferences;
+    PresentationSettings m_PresentationSettings;
     bool m_IsFullScreen;
     SupportedVideoFormatList m_SupportedVideoFormats; // Sorted in order of descending priority
     STREAM_CONFIGURATION m_StreamConfig;

--- a/app/streaming/streamutils.cpp
+++ b/app/streaming/streamutils.cpp
@@ -158,6 +158,20 @@ void StreamUtils::screenSpaceToNormalizedDeviceCoords(SDL_Rect* src, SDL_FRect* 
 
 int StreamUtils::getDisplayRefreshRate(SDL_Window* window)
 {
+    int refreshHz;
+    if (tryGetDisplayRefreshRate(window, refreshHz)) {
+        return refreshHz;
+    }
+
+    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                "Refresh rate unknown; assuming 60 Hz");
+    return 60;
+}
+
+bool StreamUtils::tryGetDisplayRefreshRate(SDL_Window* window, int& outHz)
+{
+    outHz = 0;
+
     int displayIndex = SDL_GetWindowDisplayIndex(window);
     if (displayIndex < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
@@ -175,9 +189,7 @@ int StreamUtils::getDisplayRefreshRate(SDL_Window* window)
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                          "SDL_GetWindowDisplayMode() failed: %s",
                          SDL_GetError());
-
-            // Assume 60 Hz
-            return 60;
+            return false;
         }
     }
     else {
@@ -186,20 +198,18 @@ int StreamUtils::getDisplayRefreshRate(SDL_Window* window)
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                          "SDL_GetCurrentDisplayMode() failed: %s",
                          SDL_GetError());
-
-            // Assume 60 Hz
-            return 60;
+            return false;
         }
     }
 
-    // May be zero if undefined
-    if (mode.refresh_rate == 0) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Refresh rate unknown; assuming 60 Hz");
-        mode.refresh_rate = 60;
+    // SDL uses zero for an undefined refresh rate. A strict caller must be able
+    // to reject that state instead of silently qualifying VRR at 60 Hz.
+    if (mode.refresh_rate <= 0) {
+        return false;
     }
 
-    return mode.refresh_rate;
+    outHz = mode.refresh_rate;
+    return true;
 }
 
 bool StreamUtils::hasFastAes()

--- a/app/streaming/streamutils.h
+++ b/app/streaming/streamutils.h
@@ -26,6 +26,12 @@ public:
     static
     int getDisplayRefreshRate(SDL_Window* window);
 
+    // Unlike getDisplayRefreshRate(), this does not guess 60 Hz. VRR session
+    // qualification must reject an unknown refresh rate rather than pace
+    // against an invented one.
+    static
+    bool tryGetDisplayRefreshRate(SDL_Window* window, int& outHz);
+
     static
     bool hasFastAes();
 

--- a/app/streaming/video/decoder.h
+++ b/app/streaming/video/decoder.h
@@ -44,11 +44,19 @@ typedef struct _DECODER_PARAMETERS {
     int frameRate;
     bool enableVsync;
     bool enableFramePacing;
+    // VRR is an opt-in, session-snapshotted third pacing mode.
+    bool enableVrr;
+    // Strictly obtained during Session initialization. A value of zero means
+    // the session was not qualified for VRR; Pacer must not substitute a
+    // legacy 60 Hz fallback when this path is requested.
+    int vrrDisplayRefreshHz;
     bool testOnly;
 } DECODER_PARAMETERS, *PDECODER_PARAMETERS;
 
 #define WINDOW_STATE_CHANGE_SIZE 0x01
 #define WINDOW_STATE_CHANGE_DISPLAY 0x02
+#define WINDOW_STATE_CHANGE_MINIMIZED 0x04
+#define WINDOW_STATE_CHANGE_RESTORED 0x08
 
 typedef struct _WINDOW_STATE_CHANGE_INFO {
     SDL_Window* window;

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -10,6 +10,7 @@
 #include "streaming/session.h"
 
 #include <SDL_syswm.h>
+#include <Limelight.h>
 
 #include <dwmapi.h>
 
@@ -60,13 +61,23 @@ D3D11VARenderer::D3D11VARenderer(int decoderSelectionPass)
       m_DecoderSelectionPass(decoderSelectionPass),
       m_DevicesWithFL11Support(0),
       m_DevicesWithCodecSupport(0),
+      m_AdapterIndex(-1),
+      m_RenderAdapterIndex(-1),
       m_LastColorTrc(AVCOL_TRC_UNSPECIFIED),
       m_AllowTearing(false),
+      m_VrrBorderlessFlipModel(false),
+      m_VrrSwapChainAllowsTearing(false),
+      m_VrrSuspended(false),
+      m_VrrFallbackReason(VrrFallbackReason::InitializationFailed),
+      m_VrrFramePrepared(false),
+      m_VrrContextLocked(false),
+      m_VrrPresentReadyFenceValue(0),
+      m_VrrPresentReadyFenceEvent(nullptr),
+      m_VrrPresentReadyAvailable(false),
       m_OverlayLock(0),
       m_HwDeviceContext(nullptr)
 {
     m_ContextLock = SDL_CreateMutex();
-
     DwmEnableMMCSS(TRUE);
 }
 
@@ -74,6 +85,10 @@ D3D11VARenderer::~D3D11VARenderer()
 {
     DwmEnableMMCSS(FALSE);
 
+    // The VRR worker may be cancelled after preparation but before Present.
+    // Release the retained D3D context lock before destroying it or any
+    // back-buffer objects.
+    cancelFrame();
     SDL_DestroyMutex(m_ContextLock);
 
     m_VideoVertexBuffer.Reset();
@@ -110,6 +125,12 @@ D3D11VARenderer::~D3D11VARenderer()
     m_DecodeR2DFence.Reset();
     m_RenderD2RFence.Reset();
     m_RenderR2DFence.Reset();
+
+    m_VrrPresentReadyFence.Reset();
+    if (m_VrrPresentReadyFenceEvent != nullptr) {
+        CloseHandle(m_VrrPresentReadyFenceEvent);
+        m_VrrPresentReadyFenceEvent = nullptr;
+    }
 
     m_RenderTargetView.Reset();
     m_SwapChain.Reset();
@@ -432,6 +453,7 @@ bool D3D11VARenderer::createDeviceByAdapterIndex(int adapterIndex, bool* adapter
         m_DevicesWithCodecSupport++;
     }
 
+    m_RenderAdapterIndex = adapterIndex;
     success = true;
 
 Exit:
@@ -492,7 +514,6 @@ bool D3D11VARenderer::initialize(PDECODER_PARAMETERS params)
                      SDL_GetError());
         return false;
     }
-
     hr = CreateDXGIFactory2(
         m_DebugLayer ? DXGI_CREATE_FACTORY_DEBUG : 0,
         __uuidof(IDXGIFactory5),
@@ -570,39 +591,15 @@ bool D3D11VARenderer::initialize(PDECODER_PARAMETERS params)
         swapChainDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     }
 
-    // Use DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING with flip mode for non-vsync case, if possible.
-    // NOTE: This is only possible in windowed or borderless windowed mode.
-    if (!params->enableVsync) {
-        BOOL allowTearing = FALSE;
-        hr = m_Factory->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING,
-                                            &allowTearing,
-                                            sizeof(allowTearing));
-        if (SUCCEEDED(hr)) {
-            if (allowTearing) {
-                // Use flip discard with allow tearing mode if possible.
-                swapChainDesc.Flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
-                m_AllowTearing = true;
-            }
-            else {
-                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                            "OS/GPU doesn't support DXGI_FEATURE_PRESENT_ALLOW_TEARING");
-            }
-        }
-        else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                         "IDXGIFactory::CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING) failed: %x",
-                         hr);
-            // Non-fatal
-        }
+    initializeVrrPresentationState(&swapChainDesc);
 
-        // DXVA2 may let us take over for FSE V-sync off cases. However, if we don't have DXGI_FEATURE_PRESENT_ALLOW_TEARING
-        // then we should not attempt to do this unless there's no other option (HDR, DXVA2 failed in pass 1, etc).
-        if (!m_AllowTearing && m_DecoderSelectionPass == 0 && !(params->videoFormat & VIDEO_FORMAT_MASK_10BIT) &&
-                (SDL_GetWindowFlags(params->window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Defaulting to DXVA2 for FSE without DXGI_FEATURE_PRESENT_ALLOW_TEARING support");
-            return false;
-        }
+    // DXVA2 may let us take over for FSE V-sync off cases. However, if we don't have DXGI_FEATURE_PRESENT_ALLOW_TEARING
+    // then we should not attempt to do this unless there's no other option (HDR, DXVA2 failed in pass 1, etc).
+    if (!m_AllowTearing && !params->enableVsync && m_DecoderSelectionPass == 0 && !(params->videoFormat & VIDEO_FORMAT_MASK_10BIT) &&
+            (SDL_GetWindowFlags(params->window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Defaulting to DXVA2 for FSE without DXGI_FEATURE_PRESENT_ALLOW_TEARING support");
+        return false;
     }
 
     SDL_SysWMinfo info;
@@ -645,6 +642,10 @@ bool D3D11VARenderer::initialize(PDECODER_PARAMETERS params)
                      hr);
         return false;
     }
+
+    // Determine VRR eligibility from the created swapchain rather than the
+    // requested descriptor, since the runtime may normalize it.
+    refreshVrrDisplayState();
 
     {
         m_HwDeviceContext = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_D3D11VA);
@@ -747,24 +748,9 @@ void D3D11VARenderer::renderFrame(AVFrame* frame)
         lockContext(this);
     }
 
-    // Clear the back buffer
-    const float clearColor[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-    m_RenderDeviceContext->ClearRenderTargetView(m_RenderTargetView.Get(), clearColor);
-
-    // Bind the back buffer. This needs to be done each time,
-    // because the render target view will be unbound by Present().
-    m_RenderDeviceContext->OMSetRenderTargets(1, m_RenderTargetView.GetAddressOf(), nullptr);
-
-    // Render our video frame with the aspect-ratio adjusted viewport
-    renderVideo(frame);
-
-    // Render overlays on top of the video stream
-    for (int i = 0; i < Overlay::OverlayMax; i++) {
-        renderOverlay((Overlay::OverlayType)i);
-    }
-
-    UINT flags;
-
+    // Keep the existing fixed/unpaced behavior intact while sharing the same
+    // preparation and final Present helpers used by the opt-in VRR backend.
+    UINT flags = 0;
     if (m_AllowTearing) {
         SDL_assert(!m_DecoderParams.enableVsync);
 
@@ -772,40 +758,9 @@ void D3D11VARenderer::renderFrame(AVFrame* frame)
         // It is not valid to use any other syncInterval values in tearing mode.
         flags = DXGI_PRESENT_ALLOW_TEARING;
     }
-    else {
-        // Otherwise, we'll submit as fast as possible and DWM will discard excess
-        // frames for us. If frame pacing is also enabled or we're in full-screen,
-        // our Vsync source will keep us in sync with VBlank.
-        flags = 0;
-    }
 
-    HRESULT hr;
-
-    if (frame->color_trc != m_LastColorTrc) {
-        if (frame->color_trc == AVCOL_TRC_SMPTE2084) {
-            // Switch to Rec 2020 PQ (SMPTE ST 2084) colorspace for HDR10 rendering
-            hr = m_SwapChain->SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
-            if (FAILED(hr)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                             "IDXGISwapChain::SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020) failed: %x",
-                             hr);
-            }
-        }
-        else {
-            // Restore default sRGB colorspace
-            hr = m_SwapChain->SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
-            if (FAILED(hr)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                             "IDXGISwapChain::SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) failed: %x",
-                             hr);
-            }
-        }
-
-        m_LastColorTrc = frame->color_trc;
-    }
-
-    // Present according to the decoder parameters
-    hr = m_SwapChain->Present(0, flags);
+    bool prepared = prepareFrameForPresent(frame);
+    HRESULT hr = prepared ? presentPreparedFrame(flags) : E_FAIL;
 
     if (m_DecodeDevice == m_RenderDevice) {
         // Release the context lock
@@ -813,14 +768,18 @@ void D3D11VARenderer::renderFrame(AVFrame* frame)
     }
 
     if (FAILED(hr)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                     "IDXGISwapChain::Present() failed: %x",
-                     hr);
+        if (prepared) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                         "IDXGISwapChain::Present() failed: %x",
+                         hr);
+        }
+        else {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                         "D3D11 frame preparation failed");
+        }
 
         // The card may have been removed or crashed. Reset the decoder.
-        SDL_Event event;
-        event.type = SDL_RENDER_DEVICE_RESET;
-        SDL_PushEvent(&event);
+        queueRenderDeviceReset();
         return;
     }
 }
@@ -1007,11 +966,17 @@ void D3D11VARenderer::renderVideo(AVFrame* frame)
         SDL_assert(m_DecodeD2RFence);
         SDL_assert(m_RenderD2RFence);
 
-        lockContext(this);
+        bool acquiredContextLock = false;
+        if (!m_VrrContextLocked) {
+            lockContext(this);
+            acquiredContextLock = true;
+        }
         if (SUCCEEDED(m_DecodeDeviceContext->Signal(m_DecodeD2RFence.Get(), m_D2RFenceValue))) {
             m_RenderDeviceContext->Wait(m_RenderD2RFence.Get(), m_D2RFenceValue++);
         }
-        unlockContext(this);
+        if (acquiredContextLock) {
+            unlockContext(this);
+        }
     }
 
     UINT srvIndex;
@@ -1067,10 +1032,16 @@ void D3D11VARenderer::renderVideo(AVFrame* frame)
         // This means the fence should generally not cause a pipeline bubble for the decoder
         // unless rendering is taking much longer than expected.
         if (SUCCEEDED(m_RenderDeviceContext->Signal(m_RenderR2DFence.Get(), m_R2DFenceValue))) {
-            lockContext(this);
+            bool acquiredContextLock = false;
+            if (!m_VrrContextLocked) {
+                lockContext(this);
+                acquiredContextLock = true;
+            }
             SDL_assert(m_R2DFenceValue > 0);
             m_DecodeDeviceContext->Wait(m_DecodeR2DFence.Get(), m_R2DFenceValue - 1);
-            unlockContext(this);
+            if (acquiredContextLock) {
+                unlockContext(this);
+            }
             m_R2DFenceValue++;
         }
     }
@@ -1234,6 +1205,13 @@ bool D3D11VARenderer::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO stateInfo)
             return false;
         }
 
+        // A same-GPU display move keeps this renderer alive. Serialize the
+        // refreshed swapchain eligibility against the context lock the VRR
+        // worker retains from preparation through Present.
+        lockContext(this);
+        refreshVrrDisplayState();
+        unlockContext(this);
+
         // We've handled this state change
         stateInfo->stateChangeFlags &= ~WINDOW_STATE_CHANGE_DISPLAY;
     }
@@ -1284,6 +1262,10 @@ bool D3D11VARenderer::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO stateInfo)
             unlockContext(this);
             return false;
         }
+
+        // A same-monitor mode switch can arrive only as SIZE_CHANGED, so
+        // re-evaluate VRR eligibility from the resized swapchain.
+        refreshVrrDisplayState();
 
         unlockContext(this);
 
@@ -1523,6 +1505,452 @@ void D3D11VARenderer::unlockContext(void *lock_ctx)
     auto me = (D3D11VARenderer*)lock_ctx;
 
     SDL_UnlockMutex(me->m_ContextLock);
+}
+
+void D3D11VARenderer::initializeVrrPresentationState(DXGI_SWAP_CHAIN_DESC1* swapChainDesc)
+{
+    // Preserve the legacy non-VSync path while also creating an
+    // allow-tearing flip swapchain for an explicitly requested VRR session.
+    // The latter is required even though the session's effective V-Sync is
+    // true: the VRR worker always uses immediate presentation and owns the
+    // complete mathematical pacing policy.
+    if (!m_DecoderParams.enableVsync || m_DecoderParams.enableVrr) {
+        BOOL allowTearing = FALSE;
+        HRESULT hr = m_Factory->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING,
+                                                    &allowTearing,
+                                                    sizeof(allowTearing));
+        if (SUCCEEDED(hr) && allowTearing) {
+            // VRR eligibility gates on the swapchain carrying this flag, which
+            // is only requested here when the feature query succeeded.  Never
+            // set it unconditionally.
+            swapChainDesc->Flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+
+            // Do not alter legacy V-Sync semantics.  Only the existing
+            // non-VSync path uses this flag from renderFrame().
+            if (!m_DecoderParams.enableVsync) {
+                m_AllowTearing = true;
+            }
+        }
+        else if (!m_DecoderParams.enableVsync) {
+            if (SUCCEEDED(hr)) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "OS/GPU doesn't support DXGI_FEATURE_PRESENT_ALLOW_TEARING");
+            }
+            else {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                             "IDXGIFactory::CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING) failed: %x",
+                             hr);
+            }
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "D3D11 VRR unavailable: DXGI_FEATURE_PRESENT_ALLOW_TEARING is unavailable (%x)",
+                        hr);
+        }
+    }
+
+    if (!m_DecoderParams.enableVrr) {
+        return;
+    }
+
+    m_VrrPresentReadyAvailable = initializeVrrPresentReadyFence();
+    if (!m_VrrPresentReadyAvailable) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "D3D11 VRR unavailable: GPU present-ready fencing is unavailable");
+    }
+}
+
+void D3D11VARenderer::refreshVrrDisplayState()
+{
+    if (!m_DecoderParams.enableVrr) {
+        return;
+    }
+
+    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+    HRESULT swapChainDescResult = E_POINTER;
+    if (m_SwapChain != nullptr) {
+        swapChainDescResult = m_SwapChain->GetDesc1(&swapChainDesc);
+    }
+    const bool gotSwapChainDesc = swapChainDescResult == S_OK;
+
+    BOOL fullscreenExclusive = FALSE;
+    HRESULT fullscreenStateResult = E_POINTER;
+    if (m_SwapChain != nullptr) {
+        fullscreenStateResult = m_SwapChain->GetFullscreenState(
+            &fullscreenExclusive, nullptr);
+    }
+    const uint32_t windowFlags = m_DecoderParams.window != nullptr ?
+        SDL_GetWindowFlags(m_DecoderParams.window) : 0;
+    m_VrrBorderlessFlipModel = gotSwapChainDesc &&
+        fullscreenStateResult == S_OK &&
+        fullscreenExclusive == FALSE &&
+        (windowFlags & SDL_WINDOW_FULLSCREEN_DESKTOP) ==
+            SDL_WINDOW_FULLSCREEN_DESKTOP &&
+        (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD ||
+         swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL);
+    m_VrrSwapChainAllowsTearing = gotSwapChainDesc &&
+        (swapChainDesc.Flags & DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) != 0;
+
+    VrrFallbackReason previousReason = m_VrrFallbackReason;
+    m_VrrFallbackReason = evaluateVrrEligibility();
+
+    if (m_VrrFallbackReason != previousReason) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "D3D11 VRR: %s",
+                    vrrFallbackReasonName(m_VrrFallbackReason));
+    }
+}
+
+VrrFallbackReason D3D11VARenderer::evaluateVrrEligibility()
+{
+    if (!m_DecoderParams.enableVsync) {
+        return VrrFallbackReason::IneffectiveVsync;
+    }
+    // The renderer may fall back to an adapter other than the one that owns
+    // the SDL output, which cannot drive that output's flip queue.
+    if (!m_VrrBorderlessFlipModel ||
+            m_RenderAdapterIndex < 0 ||
+            m_RenderAdapterIndex != m_AdapterIndex) {
+        return VrrFallbackReason::UnsupportedRenderer;
+    }
+    if (m_DecoderParams.vrrDisplayRefreshHz <= 0) {
+        return VrrFallbackReason::InvalidRefresh;
+    }
+    if (!isRenderThreadSupported()) {
+        return VrrFallbackReason::MainThreadRenderer;
+    }
+    if (!m_VrrPresentReadyAvailable) {
+        return VrrFallbackReason::AdaptivePresentationUnavailable;
+    }
+    if (!m_VrrSwapChainAllowsTearing) {
+        return VrrFallbackReason::InitializationFailed;
+    }
+
+    return VrrFallbackReason::NoFallback;
+}
+
+void D3D11VARenderer::releasePreparedVrrFrame()
+{
+    // Present() unbinds the render target itself.  A cancellation does not,
+    // so explicitly remove the context's reference to the back buffer before
+    // a resize/device reset can tear it down.
+    if ((m_VrrFramePrepared || m_VrrContextLocked) &&
+            m_RenderDeviceContext != nullptr) {
+        m_RenderDeviceContext->OMSetRenderTargets(0, nullptr, nullptr);
+    }
+
+    m_VrrFramePrepared = false;
+
+    if (m_VrrContextLocked) {
+        unlockContext(this);
+        m_VrrContextLocked = false;
+    }
+}
+
+void D3D11VARenderer::queueRenderDeviceReset()
+{
+    SDL_Event event = {};
+    event.type = SDL_RENDER_DEVICE_RESET;
+    SDL_PushEvent(&event);
+}
+
+bool D3D11VARenderer::prepareFrameForPresent(AVFrame* frame)
+{
+    if (frame == nullptr || m_RenderDeviceContext == nullptr ||
+            m_RenderTargetView == nullptr || m_SwapChain == nullptr) {
+        return false;
+    }
+
+    // Clear the back buffer.
+    const float clearColor[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+    m_RenderDeviceContext->ClearRenderTargetView(m_RenderTargetView.Get(), clearColor);
+
+    // Bind the back buffer. This needs to be done each time because Present()
+    // unbinds the render target view.
+    m_RenderDeviceContext->OMSetRenderTargets(1, m_RenderTargetView.GetAddressOf(), nullptr);
+
+    // Render the video and overlays.  This is the complete preparation phase
+    // shared by the legacy and VRR paths; only the final Present is split out.
+    renderVideo(frame);
+    for (int i = 0; i < Overlay::OverlayMax; i++) {
+        renderOverlay((Overlay::OverlayType)i);
+    }
+
+    if (frame->color_trc != m_LastColorTrc) {
+        HRESULT hr;
+        if (frame->color_trc == AVCOL_TRC_SMPTE2084) {
+            hr = m_SwapChain->SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
+            if (FAILED(hr)) {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                             "IDXGISwapChain::SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020) failed: %x",
+                             hr);
+            }
+        }
+        else {
+            hr = m_SwapChain->SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
+            if (FAILED(hr)) {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                             "IDXGISwapChain::SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) failed: %x",
+                             hr);
+            }
+        }
+
+        m_LastColorTrc = frame->color_trc;
+    }
+
+    return true;
+}
+
+bool D3D11VARenderer::initializeVrrPresentReadyFence()
+{
+    HRESULT hr = m_RenderDevice->CreateFence(
+        0, D3D11_FENCE_FLAG_NONE,
+        IID_PPV_ARGS(&m_VrrPresentReadyFence));
+    if (SUCCEEDED(hr)) {
+        m_VrrPresentReadyFenceEvent = CreateEventW(
+            nullptr, FALSE, FALSE, nullptr);
+    }
+
+    if (FAILED(hr) || m_VrrPresentReadyFenceEvent == nullptr) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "D3D11 VRR could not create the present-ready fence: %x",
+                    hr);
+        m_VrrPresentReadyFence.Reset();
+        if (m_VrrPresentReadyFenceEvent != nullptr) {
+            CloseHandle(m_VrrPresentReadyFenceEvent);
+            m_VrrPresentReadyFenceEvent = nullptr;
+        }
+        return false;
+    }
+
+    return true;
+}
+
+bool D3D11VARenderer::waitForVrrPresentReady()
+{
+    if (!m_VrrPresentReadyAvailable ||
+            m_VrrPresentReadyFence == nullptr ||
+            m_VrrPresentReadyFenceEvent == nullptr) {
+        return false;
+    }
+
+    // A tearing Present does not become scanout-visible until all GPU work
+    // targeting its back buffer is complete (roughly 2.4 ms was measured
+    // between the CPU Present call and display without this fence). Finish
+    // the frame here so the worker's later target hold operates on an actual
+    // flip-ready boundary.
+    const UINT64 fenceValue = ++m_VrrPresentReadyFenceValue;
+    HRESULT hr = m_RenderDeviceContext->Signal(
+        m_VrrPresentReadyFence.Get(), fenceValue);
+    if (FAILED(hr)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "D3D11 VRR present-ready Signal() failed: %x", hr);
+        m_VrrPresentReadyAvailable = false;
+        return false;
+    }
+
+    m_RenderDeviceContext->Flush();
+    hr = m_VrrPresentReadyFence->SetEventOnCompletion(
+        fenceValue, m_VrrPresentReadyFenceEvent);
+    if (FAILED(hr)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "D3D11 VRR present-ready SetEventOnCompletion() failed: %x",
+                     hr);
+        m_VrrPresentReadyAvailable = false;
+        return false;
+    }
+
+    // A shared decode/render device uses this mutex in FFmpeg's device
+    // callbacks. Never wait for the GPU while retaining it: doing so stalls
+    // decode behind the render fence.
+    const bool releaseSharedContext =
+        m_DecodeDevice == m_RenderDevice && m_VrrContextLocked;
+    if (releaseSharedContext) {
+        unlockContext(this);
+        m_VrrContextLocked = false;
+    }
+
+    const DWORD waitResult = WaitForSingleObject(
+        m_VrrPresentReadyFenceEvent, 50);
+
+    if (releaseSharedContext) {
+        lockContext(this);
+        m_VrrContextLocked = true;
+    }
+
+    if (waitResult != WAIT_OBJECT_0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "D3D11 VRR present-ready fence wait failed or timed out: %lu",
+                     static_cast<unsigned long>(waitResult));
+        m_VrrPresentReadyAvailable = false;
+        return false;
+    }
+
+    return true;
+}
+
+HRESULT D3D11VARenderer::presentPreparedFrame(UINT flags)
+{
+    if (m_SwapChain == nullptr) {
+        return E_FAIL;
+    }
+
+    return m_SwapChain->Present(0, flags);
+}
+
+IVrrFramePresenter* D3D11VARenderer::getVrrFramePresenter()
+{
+    return this;
+}
+
+VrrFallbackReason D3D11VARenderer::checkSupport() const
+{
+    if (m_VrrFallbackReason != VrrFallbackReason::NoFallback) {
+        return m_VrrFallbackReason;
+    }
+
+    return m_DecoderParams.enableVrr && m_SwapChain != nullptr &&
+        m_VrrSwapChainAllowsTearing ? VrrFallbackReason::NoFallback :
+        VrrFallbackReason::InitializationFailed;
+}
+
+VrrPrepareResult D3D11VARenderer::prepareFrame(AVFrame* frame)
+{
+    VrrPrepareResult result;
+    if (m_VrrSuspended || frame == nullptr) {
+        return result;
+    }
+
+    // The contract guarantees one worker, but make an accidental second
+    // preparation recoverable instead of leaking a retained context lock.
+    if (m_VrrFramePrepared) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "D3D11 VRR discarded an unpresented prepared frame");
+        result.feedback = cancelFrame();
+        return result;
+    }
+
+    // Hold the FFmpeg/D3D context lock from rendering preparation through
+    // final Present.  renderVideo() recognizes this retained lock for the
+    // separate-device fence calls, so it never recursively locks the SDL
+    // mutex while this frame is in flight.
+    lockContext(this);
+    m_VrrContextLocked = true;
+
+    // Display-state changes share this lock with preparation through Present.
+    // Check eligibility only after taking it so a UI callback cannot replace
+    // swapchain state concurrently.
+    if (checkSupport() != VrrFallbackReason::NoFallback) {
+        releasePreparedVrrFrame();
+        return result;
+    }
+
+    if (!prepareFrameForPresent(frame)) {
+        releasePreparedVrrFrame();
+        return result;
+    }
+
+    if (!waitForVrrPresentReady()) {
+        m_VrrFallbackReason = VrrFallbackReason::AdaptivePresentationUnavailable;
+        result.feedback.cancelled = true;
+        releasePreparedVrrFrame();
+        queueRenderDeviceReset();
+        return result;
+    }
+
+    // The shared-device fence wait temporarily releases the renderer lock.
+    // Revalidate state after reacquiring it before publishing this frame as
+    // prepared for the worker's target wait.
+    if (m_VrrSuspended || checkSupport() != VrrFallbackReason::NoFallback) {
+        result.feedback.cancelled = true;
+        releasePreparedVrrFrame();
+        return result;
+    }
+
+    HRESULT deviceReason = m_RenderDevice->GetDeviceRemovedReason();
+    if (FAILED(deviceReason)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "D3D11 VRR preparation detected device loss: %x",
+                     deviceReason);
+        result.feedback.cancelled = true;
+        releasePreparedVrrFrame();
+        queueRenderDeviceReset();
+        return result;
+    }
+
+    m_VrrFramePrepared = true;
+    result.prepared = true;
+    return result;
+}
+
+VrrPresentFeedback D3D11VARenderer::presentAdaptive(
+    const VrrPresentRequest& request)
+{
+    VrrPresentFeedback feedback;
+
+    if (!m_VrrFramePrepared || m_VrrSuspended) {
+        return cancelFrame();
+    }
+
+    // A latched near-refresh request omits ALLOW_TEARING, selecting DXGI's
+    // non-tearing path. The flag is a per-present choice on this swapchain,
+    // so no swapchain recreation is involved.
+    const UINT presentFlags = request.latchedPresentation ?
+        0 : DXGI_PRESENT_ALLOW_TEARING;
+
+    // The worker anchors its display-spacing floor at this instant rather
+    // than at its own call boundary, so capture it immediately before Present.
+    const uint64_t submissionTimeUs = LiGetMicroseconds();
+    HRESULT hr = presentPreparedFrame(presentFlags);
+
+    if (FAILED(hr)) {
+        releasePreparedVrrFrame();
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "IDXGISwapChain::Present() failed on D3D11 VRR path: %x",
+                     hr);
+        queueRenderDeviceReset();
+        feedback.cancelled = true;
+        return feedback;
+    }
+    if (hr != S_OK) {
+        // In particular, DXGI_STATUS_OCCLUDED is a successful HRESULT but
+        // does not mean that the image reached a monitor.
+        releasePreparedVrrFrame();
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                     "IDXGISwapChain::Present() returned non-display status on D3D11 VRR path: %x",
+                     hr);
+        feedback.cancelled = true;
+        return feedback;
+    }
+
+    feedback.presented = true;
+    feedback.submissionTimeValid = true;
+    feedback.submissionTimeUs = submissionTimeUs;
+
+    releasePreparedVrrFrame();
+    return feedback;
+}
+
+VrrPresentFeedback D3D11VARenderer::cancelFrame()
+{
+    VrrPresentFeedback feedback;
+    releasePreparedVrrFrame();
+    feedback.cancelled = true;
+    return feedback;
+}
+
+bool D3D11VARenderer::restoreFixedPresentation(VrrFallbackReason reason)
+{
+    // This is called synchronously only if the pacing worker could not start,
+    // before it has prepared a frame.  ALLOW_TEARING is a swapchain capability,
+    // not a requirement for every Present, so the existing swapchain safely
+    // supports the legacy fixed path with Present(0, 0).  Do not recreate it.
+    cancelFrame();
+    m_VrrSuspended = false;
+    m_DecoderParams.enableVrr = false;
+    m_VrrFallbackReason = reason == VrrFallbackReason::NoFallback ?
+        VrrFallbackReason::InitializationFailed : reason;
+    return true;
 }
 
 bool D3D11VARenderer::setupRenderingResources()

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.h
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ivrrframepresenter.h"
 #include "renderer.h"
 
 #include <d3d11_4.h>
@@ -12,7 +13,7 @@ extern "C" {
 #include <wrl/client.h>
 #include <wrl/wrappers/corewrappers.h>
 
-class D3D11VARenderer : public IFFmpegRenderer
+class D3D11VARenderer : public IFFmpegRenderer, public IVrrFramePresenter
 {
 public:
     D3D11VARenderer(int decoderSelectionPass);
@@ -21,6 +22,17 @@ public:
     virtual bool prepareDecoderContext(AVCodecContext* context, AVDictionary**) override;
     virtual bool prepareDecoderContextInGetFormat(AVCodecContext* context, AVPixelFormat pixelFormat) override;
     virtual void renderFrame(AVFrame* frame) override;
+    virtual IVrrFramePresenter* getVrrFramePresenter() override;
+
+    virtual bool canLatchAdaptivePresent() const override { return true; }
+    virtual VrrFallbackReason checkSupport() const override;
+    virtual VrrPrepareResult prepareFrame(AVFrame* frame) override;
+    virtual VrrPresentFeedback presentAdaptive(
+        const VrrPresentRequest& request) override;
+    virtual VrrPresentFeedback cancelFrame() override;
+    virtual void setSuspended(bool suspended) override { m_VrrSuspended = suspended; }
+    virtual bool restoreFixedPresentation(VrrFallbackReason reason) override;
+
     virtual void notifyOverlayUpdated(Overlay::OverlayType) override;
     virtual bool notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO stateInfo) override;
     virtual int getRendererAttributes() override;
@@ -44,6 +56,15 @@ private:
     bool setupSwapchainDependentResources();
     bool setupVideoTexture(AVHWFramesContext* framesContext); // for !m_BindDecoderOutputTextures
     bool setupTexturePoolViews(AVHWFramesContext* framesContext); // for m_BindDecoderOutputTextures
+    bool prepareFrameForPresent(AVFrame* frame);
+    bool initializeVrrPresentReadyFence();
+    bool waitForVrrPresentReady();
+    HRESULT presentPreparedFrame(UINT flags);
+    void initializeVrrPresentationState(DXGI_SWAP_CHAIN_DESC1* swapChainDesc);
+    void refreshVrrDisplayState();
+    VrrFallbackReason evaluateVrrEligibility();
+    void releasePreparedVrrFrame();
+    void queueRenderDeviceReset();
     void renderOverlay(Overlay::OverlayType type);
     bool createOverlayVertexBuffer(Overlay::OverlayType type, int width, int height, Microsoft::WRL::ComPtr<ID3D11Buffer>& newVertexBuffer);
     void bindColorConversion(bool frameChanged, AVFrame* frame);
@@ -69,7 +90,11 @@ private:
 
     bool m_DebugLayer;
     Microsoft::WRL::ComPtr<IDXGIFactory5> m_Factory;
+    // m_AdapterIndex identifies the output selected by SDL.  The renderer
+    // may fall back to another adapter for decoding, so retain that index
+    // separately for the VRR same-GPU check.
     int m_AdapterIndex;
+    int m_RenderAdapterIndex;
     Microsoft::WRL::ComPtr<ID3D11Device5> m_RenderDevice, m_DecodeDevice;
     Microsoft::WRL::ComPtr<ID3D11DeviceContext4> m_RenderDeviceContext, m_DecodeDeviceContext;
     Microsoft::WRL::ComPtr<ID3D11Texture2D> m_RenderSharedTextureArray;
@@ -93,6 +118,16 @@ private:
     AVColorTransferCharacteristic m_LastColorTrc;
 
     bool m_AllowTearing;
+    bool m_VrrBorderlessFlipModel;
+    bool m_VrrSwapChainAllowsTearing;
+    bool m_VrrSuspended;
+    VrrFallbackReason m_VrrFallbackReason;
+    bool m_VrrFramePrepared;
+    bool m_VrrContextLocked;
+    Microsoft::WRL::ComPtr<ID3D11Fence> m_VrrPresentReadyFence;
+    UINT64 m_VrrPresentReadyFenceValue;
+    HANDLE m_VrrPresentReadyFenceEvent;
+    bool m_VrrPresentReadyAvailable;
 
     std::array<Microsoft::WRL::ComPtr<ID3D11PixelShader>, PixelShaders::_COUNT> m_VideoPixelShaders;
     Microsoft::WRL::ComPtr<ID3D11Buffer> m_VideoVertexBuffer;
@@ -111,4 +146,3 @@ private:
 
     AVBufferRef* m_HwDeviceContext;
 };
-

--- a/app/streaming/video/ffmpeg-renderers/ivrrframepresenter.h
+++ b/app/streaming/video/ffmpeg-renderers/ivrrframepresenter.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <cstdint>
+
+struct AVFrame;
+
+// Renderer-facing VRR contract. Pacing timestamps and sender metadata never
+// cross this boundary: the presenter only prepares, adaptively presents, or
+// abandons a decoded image.
+enum class VrrFallbackReason : uint8_t {
+    NoFallback,
+    IneffectiveVsync,
+    InvalidRefresh,
+    UnsupportedRenderer,
+    MainThreadRenderer,
+    WindowsVulkan,
+    AdaptivePresentationUnavailable,
+    InsufficientHeadroom,
+    InitializationFailed,
+};
+
+inline const char* vrrFallbackReasonName(VrrFallbackReason reason)
+{
+    switch (reason) {
+    case VrrFallbackReason::NoFallback:
+        return "none";
+    case VrrFallbackReason::IneffectiveVsync:
+        return "ineffective V-sync";
+    case VrrFallbackReason::InvalidRefresh:
+        return "invalid display refresh";
+    case VrrFallbackReason::UnsupportedRenderer:
+        return "unsupported renderer";
+    case VrrFallbackReason::MainThreadRenderer:
+        return "main-thread renderer";
+    case VrrFallbackReason::WindowsVulkan:
+        return "Windows Vulkan is not supported";
+    case VrrFallbackReason::AdaptivePresentationUnavailable:
+        return "adaptive presentation is unavailable";
+    case VrrFallbackReason::InsufficientHeadroom:
+        return "stream rate leaves insufficient adaptive-refresh headroom";
+    case VrrFallbackReason::InitializationFailed:
+        return "VRR initialization failed";
+    }
+
+    return "unknown fallback";
+}
+
+// presented means the native API accepted a display transition. cancelled
+// describes why the operation ended, not whether the platform submitted: some
+// APIs must submit an acquired image even while abandoning it.
+struct VrrPresentFeedback {
+    bool presented = false;
+    bool cancelled = false;
+    // Set when the backend knows the exact instant of its native submission.
+    // The worker anchors its display-spacing floor there instead of at its own
+    // call boundary, which may include a blocking return.
+    bool submissionTimeValid = false;
+    uint64_t submissionTimeUs = 0;
+};
+
+// Per-present request from the platform-neutral controller. When the learned
+// source cadence leaves too little adaptive-refresh headroom for safe
+// immediate flips, the controller asks for a latched (non-tearing) present:
+// at near-refresh rates the cadence cost of latching is a few repeated frames
+// per second while immediate flips tear. Backends whose presentation mode is
+// immutable after swapchain creation may ignore the preference.
+struct VrrPresentRequest {
+    bool latchedPresentation = false;
+};
+
+struct VrrPrepareResult {
+    bool prepared = false;
+    // Some acquired images (notably Vulkan swapchain frames) can only be
+    // abandoned by submitting them. The worker owns any required wait.
+    bool cancellationMaySubmit = false;
+    VrrPresentFeedback feedback;
+};
+
+class IVrrFramePresenter {
+public:
+    virtual ~IVrrFramePresenter() = default;
+
+    // Some adaptive backends can select a fixed-vsync latch for an individual
+    // present. Vulkan WSI modes are immutable for the swapchain lifetime, so
+    // cadence-following Mailbox/Immediate implementations leave this false.
+    virtual bool canLatchAdaptivePresent() const
+    {
+        return false;
+    }
+
+    // Startup eligibility only. NoFallback means the presenter supports a worker-
+    // thread split prepare/present path using its adaptive presentation mode.
+    virtual VrrFallbackReason checkSupport() const = 0;
+
+    // May acquire a swapchain image and submit rendering work, but must not
+    // intentionally pace or wait for the worker's presentation target.
+    virtual VrrPrepareResult prepareFrame(AVFrame* frame) = 0;
+
+    // Presents the prepared image using the backend's adaptive presentation
+    // path without intentionally waiting.
+    virtual VrrPresentFeedback presentAdaptive(
+        const VrrPresentRequest& request) = 0;
+
+    // Releases a prepared image. The result must report a native submission
+    // when the platform cannot abandon an acquired image without submitting.
+    virtual VrrPresentFeedback cancelFrame()
+    {
+        VrrPresentFeedback feedback;
+        feedback.cancelled = true;
+        return feedback;
+    }
+
+    virtual void setSuspended(bool)
+    {
+    }
+
+    // Called only when creating the VRR worker failed, before any frame was
+    // handed to it or a legacy render worker was started.
+    virtual bool restoreFixedPresentation(VrrFallbackReason)
+    {
+        return false;
+    }
+};

--- a/app/streaming/video/ffmpeg-renderers/pacer/pacer.cpp
+++ b/app/streaming/video/ffmpeg-renderers/pacer/pacer.cpp
@@ -1,5 +1,8 @@
 #include "pacer.h"
+#include "vrrpacingworker.h"
+#include "../ivrrframepresenter.h"
 #include "streaming/streamutils.h"
+#include "streaming/vrrratepolicy.h"
 
 #ifdef Q_OS_WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -12,6 +15,8 @@
 #endif
 
 #include <SDL_syswm.h>
+
+#include <utility>
 
 // Limit the number of queued frames to prevent excessive memory consumption
 // if the V-Sync source or renderer is blocked for a while. It's important
@@ -45,6 +50,13 @@ Pacer::Pacer(IFFmpegRenderer* renderer, PVIDEO_STATS videoStats) :
 
 Pacer::~Pacer()
 {
+    if (m_VrrWorker != nullptr) {
+        // The VRR worker owns the renderer context and releases it from its
+        // own thread after cancelling any prepared frame.
+        m_VrrWorker.reset();
+        return;
+    }
+
     m_Stopping = true;
 
     // Stop the V-sync thread
@@ -83,6 +95,10 @@ Pacer::~Pacer()
 
 void Pacer::renderOnMainThread()
 {
+    if (m_VrrWorker != nullptr) {
+        return;
+    }
+
     // Ignore this call for renderers that work on a dedicated render thread
     if (m_RenderThread != nullptr) {
         return;
@@ -259,11 +275,87 @@ void Pacer::handleVsync(int timeUntilNextVsyncMillis)
     enqueueFrameForRenderingAndUnlock(m_PacingQueue.dequeue());
 }
 
-bool Pacer::initialize(SDL_Window* window, int maxVideoFps, bool enablePacing)
+bool Pacer::initialize(SDL_Window* window, int maxVideoFps,
+                       bool enablePacing, bool enableVsync,
+                       bool enableVrr, int vrrDisplayRefreshHz)
 {
     m_MaxVideoFps = maxVideoFps;
-    m_DisplayFps = StreamUtils::getDisplayRefreshRate(window);
     m_RendererAttributes = m_VsyncRenderer->getRendererAttributes();
+
+    // VRR is deliberately a third pacing mode. It is selected once, before
+    // any legacy V-sync source or render thread can be created, and every
+    // rejection continues through the original fixed path below.
+    if (enableVrr) {
+        VrrSessionConfig config;
+        VrrFallbackReason fallbackReason = VrrFallbackReason::NoFallback;
+        config.streamRateHz = maxVideoFps;
+        config.displayRefreshHz = vrrDisplayRefreshHz;
+
+        if (!enableVsync) {
+            fallbackReason = VrrFallbackReason::IneffectiveVsync;
+        }
+        else if (config.displayRefreshHz <= 0) {
+            fallbackReason = VrrFallbackReason::InvalidRefresh;
+        }
+        else if (!VrrRatePolicy::hasAdaptiveHeadroom(config.streamRateHz,
+                                                     config.displayRefreshHz)) {
+            fallbackReason = VrrFallbackReason::InsufficientHeadroom;
+            IVrrFramePresenter* presenter =
+                m_VsyncRenderer->getVrrFramePresenter();
+            if (presenter != nullptr &&
+                    presenter->checkSupport() == VrrFallbackReason::NoFallback &&
+                    !presenter->restoreFixedPresentation(fallbackReason)) {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                             "VRR pacing lacks adaptive-refresh headroom and the presenter cannot restore fixed presentation");
+                return false;
+            }
+        }
+        else {
+            IVrrFramePresenter* presenter =
+                m_VsyncRenderer->getVrrFramePresenter();
+            if (presenter == nullptr) {
+                fallbackReason = VrrFallbackReason::UnsupportedRenderer;
+            }
+            else {
+                fallbackReason = presenter->checkSupport();
+                if (fallbackReason == VrrFallbackReason::NoFallback) {
+                    m_VrrWorker = std::make_unique<VrrPacingWorker>(
+                        presenter, config, m_VideoStats);
+                    if (m_VrrWorker->start()) {
+                        m_DisplayFps = config.displayRefreshHz;
+                        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                    "VRR pacing: target %d Hz with %d FPS stream",
+                                    m_DisplayFps, m_MaxVideoFps);
+                        return true;
+                    }
+
+                    fallbackReason = VrrFallbackReason::InitializationFailed;
+                    if (!presenter->restoreFixedPresentation(fallbackReason)) {
+                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                                     "VRR pacing worker failed to start and the presenter cannot restore fixed presentation");
+                        m_VrrWorker.reset();
+                        return false;
+                    }
+
+                    m_VrrWorker.reset();
+                }
+            }
+        }
+
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "VRR pacing unavailable: %s; falling back to fixed V-sync pacing",
+                    vrrFallbackReasonName(fallbackReason));
+
+        // VRR requires V-sync at the session boundary, so its rejection still
+        // has a valid fixed-pacing fallback even if the user did not select
+        // the older frame-pacing checkbox.
+        enablePacing = enablePacing || enableVsync;
+    }
+
+    // The VRR success path uses its strict session refresh snapshot and
+    // returned above. Keep the legacy fallback query out of that path so it
+    // cannot invent a 60 Hz value or produce an unrelated warning.
+    m_DisplayFps = StreamUtils::getDisplayRefreshRate(window);
 
     if (enablePacing) {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -329,17 +421,27 @@ void Pacer::signalVsync()
     m_VsyncSignalled.wakeOne();
 }
 
+void Pacer::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info)
+{
+    if (m_VrrWorker != nullptr) {
+        m_VrrWorker->notifyWindowChanged(info);
+        return;
+    }
+
+    // Legacy pacing has no additional window-state work. The VRR worker
+    // overrides this path to discard stale work on suspension/minimize.
+}
+
 void Pacer::renderFrame(AVFrame* frame)
 {
     // Count time spent in Pacer's queues
     uint64_t beforeRender = LiGetMicroseconds();
-    m_VideoStats->totalPacerTimeUs += (beforeRender - (uint64_t)frame->pkt_dts);
-
     // Render it
     m_VsyncRenderer->renderFrame(frame);
     uint64_t afterRender = LiGetMicroseconds();
 
-    m_VideoStats->totalRenderTimeUs += (afterRender - beforeRender);
+    m_VideoStats->totalPacerTimeUs += beforeRender - static_cast<uint64_t>(frame->pkt_dts);
+    m_VideoStats->totalRenderTimeUs += afterRender - beforeRender;
     m_VideoStats->renderedFrames++;
 
     // Wait until after next frame to free this one to ensure the GPU
@@ -416,4 +518,19 @@ void Pacer::submitFrame(AVFrame* frame)
     else {
         enqueueFrameForRenderingAndUnlock(frame);
     }
+}
+
+void Pacer::submitFrame(PacedFrame&& frame)
+{
+    if (m_VrrWorker != nullptr) {
+        m_VrrWorker->submit(std::move(frame));
+        return;
+    }
+
+    submitFrame(frame.release());
+}
+
+bool Pacer::isVrrActive() const
+{
+    return m_VrrWorker != nullptr;
 }

--- a/app/streaming/video/ffmpeg-renderers/pacer/pacer.h
+++ b/app/streaming/video/ffmpeg-renderers/pacer/pacer.h
@@ -2,10 +2,15 @@
 
 #include "../../decoder.h"
 #include "../renderer.h"
+#include "vrr/vrrtypes.h"
 
 #include <QQueue>
 #include <QMutex>
 #include <QWaitCondition>
+
+#include <memory>
+
+class VrrPacingWorker;
 
 // The maximum number of frames pacer will ever hold is:
 // - 3 frames in the pacing queue
@@ -35,9 +40,18 @@ public:
 
     ~Pacer();
 
+    // Only the active VRR worker consumes the decoder-facing pacing metadata.
+    void submitFrame(PacedFrame&& frame);
+
     void submitFrame(AVFrame* frame);
 
-    bool initialize(SDL_Window* window, int maxVideoFps, bool enablePacing);
+    bool isVrrActive() const;
+
+    bool initialize(SDL_Window* window, int maxVideoFps,
+                    bool enablePacing, bool enableVsync,
+                    bool enableVrr, int vrrDisplayRefreshHz);
+
+    void notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info);
 
     void signalVsync();
 
@@ -75,4 +89,5 @@ private:
     int m_DisplayFps;
     PVIDEO_STATS m_VideoStats;
     int m_RendererAttributes;
+    std::unique_ptr<VrrPacingWorker> m_VrrWorker;
 };

--- a/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtargetwaiter.cpp
+++ b/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtargetwaiter.cpp
@@ -1,0 +1,164 @@
+#include "vrrtargetwaiter.h"
+
+#include <Limelight.h>
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <thread>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
+#endif
+
+namespace {
+
+constexpr uint64_t kMaximumActiveWaitUs = 500;
+// Cap the active region so learned scheduler correction cannot turn a
+// near-refresh stream into a multi-millisecond TIME_CRITICAL yield loop.
+constexpr uint64_t kMaximumAdditionalWakeLeadUs = 500;
+
+uint64_t saturatingAdd(uint64_t left, uint64_t right)
+{
+    const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+    return left > maximum - right ? maximum : left + right;
+}
+
+void sleepForUs(uint64_t durationUs)
+{
+    if (durationUs == 0) {
+        return;
+    }
+
+#ifdef _WIN32
+    struct WaitableTimer {
+        WaitableTimer() :
+            handle(CreateWaitableTimerExW(nullptr, nullptr,
+                                          CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                                          TIMER_MODIFY_STATE | SYNCHRONIZE))
+        {
+        }
+
+        ~WaitableTimer()
+        {
+            if (handle != nullptr) {
+                CloseHandle(handle);
+            }
+        }
+
+        HANDLE handle;
+    };
+
+    // std::this_thread::sleep_for() can overshoot sub-frame deadlines by a
+    // large fraction of Windows' timer tick. Reuse one high-resolution timer
+    // per pacing thread so the bounded final yield starts before the target
+    // instead of after the presentation window has already closed.
+    thread_local WaitableTimer timer;
+    if (timer.handle != nullptr) {
+        LARGE_INTEGER dueTime;
+        const uint64_t maximumUs =
+            static_cast<uint64_t>(std::numeric_limits<LONGLONG>::max() / 10);
+        const uint64_t boundedDurationUs = std::min(durationUs, maximumUs);
+        dueTime.QuadPart = -static_cast<LONGLONG>(boundedDurationUs * 10);
+        if (SetWaitableTimerEx(timer.handle, &dueTime, 0, nullptr, nullptr,
+                               nullptr, 0) &&
+                WaitForSingleObject(timer.handle, INFINITE) == WAIT_OBJECT_0) {
+            return;
+        }
+    }
+#endif
+
+    std::this_thread::sleep_for(std::chrono::microseconds(durationUs));
+}
+
+} // namespace
+
+VrrTargetWaitResult VrrTargetWaiter::waitUntil(
+    uint64_t deadlineUs, uint64_t additionalWakeLeadUs) const
+{
+    VrrTargetWaitResult result;
+    uint64_t nowUs = LiGetMicroseconds();
+    const uint64_t boundedWakeLeadUs = std::min(
+        additionalWakeLeadUs, kMaximumAdditionalWakeLeadUs);
+    const uint64_t activeWaitUs = saturatingAdd(kMaximumActiveWaitUs,
+                                                 boundedWakeLeadUs);
+    if (nowUs >= deadlineUs) {
+        result.deadlineAlreadyElapsed = true;
+        result.finalNowUs = nowUs;
+        return result;
+    }
+
+    unsigned int stagnantCoarseSleeps = 0;
+    while (nowUs < deadlineUs) {
+        const uint64_t remainingUs = deadlineUs - nowUs;
+        if (remainingUs <= activeWaitUs) {
+            break;
+        }
+
+        // Wake before the target by the fixed active margin plus any bounded
+        // delay learned from earlier scheduler overshoots. The remaining
+        // interval is deliberately delegated to the active path below.
+        const uint64_t coarseSleepUs =
+            remainingUs > activeWaitUs ? remainingUs - activeWaitUs : 1;
+        const uint64_t requestedWakeUs = saturatingAdd(nowUs, coarseSleepUs);
+        sleepForUs(coarseSleepUs);
+
+        const uint64_t afterSleepUs = LiGetMicroseconds();
+        result.schedulerDelayValid = true;
+        if (afterSleepUs > requestedWakeUs) {
+            const uint64_t coarseOvershootUs =
+                afterSleepUs - requestedWakeUs;
+            const uint64_t additionalLeadUs =
+                coarseOvershootUs > kMaximumActiveWaitUs ?
+                    coarseOvershootUs - kMaximumActiveWaitUs : 0;
+            result.schedulerDelayUs = std::max(
+                result.schedulerDelayUs, additionalLeadUs);
+        }
+        if (afterSleepUs <= nowUs) {
+            // A platform sleep that was interrupted before it yielded must
+            // not leave a pacing worker spinning for an unbounded interval.
+            if (++stagnantCoarseSleeps >= 2) {
+                nowUs = afterSleepUs;
+                break;
+            }
+        }
+        else {
+            stagnantCoarseSleeps = 0;
+            nowUs = afterSleepUs;
+        }
+    }
+
+    if (nowUs < deadlineUs) {
+        const uint64_t activeLimitUs = saturatingAdd(nowUs, activeWaitUs);
+        unsigned int stagnantYields = 0;
+
+        // The monotonic active-time limit is the real safety bound. A fixed
+        // yield-count limit is CPU- and scheduler-dependent: on a fast
+        // machine it can expire hundreds of microseconds early even though
+        // the clock is advancing normally. The stagnant-clock detector below
+        // remains the bounded escape from a stopped clock.
+        while (nowUs < deadlineUs && nowUs < activeLimitUs) {
+            std::this_thread::yield();
+            const uint64_t afterYieldUs = LiGetMicroseconds();
+            if (afterYieldUs <= nowUs) {
+                if (++stagnantYields >= 64) {
+                    break;
+                }
+            }
+            else {
+                stagnantYields = 0;
+                nowUs = afterYieldUs;
+            }
+        }
+    }
+
+    result.finalNowUs = nowUs;
+    return result;
+}

--- a/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtargetwaiter.h
+++ b/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtargetwaiter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+struct VrrTargetWaitResult {
+    uint64_t finalNowUs = 0;
+    // Additional early wake needed beyond the fixed active margin, measured
+    // at the coarse sleep boundary. Unlike final overshoot, this observation
+    // remains meaningful after an early-wake correction succeeds.
+    uint64_t schedulerDelayUs = 0;
+    bool schedulerDelayValid = false;
+    bool deadlineAlreadyElapsed = false;
+};
+
+class VrrTargetWaiter {
+public:
+    // Wait until an absolute deadline in the LiGetMicroseconds() epoch, which
+    // is also the epoch PacedFrame decode-completion times are stamped in.
+    // Learned scheduler delay may extend the early-wake/active region, but it
+    // remains bounded even if the platform scheduler fails to advance.
+    VrrTargetWaitResult waitUntil(uint64_t deadlineUs,
+                                  uint64_t additionalWakeLeadUs = 0) const;
+};

--- a/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtimingcontroller.cpp
+++ b/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtimingcontroller.cpp
@@ -1,0 +1,963 @@
+#include "vrrtimingcontroller.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+namespace {
+
+constexpr uint64_t kMicrosecondsPerSecond = 1000000ULL;
+constexpr uint64_t kRtpClockRate = 90000ULL;
+constexpr uint64_t kQ16One = 1ULL << 16;
+constexpr uint64_t kQ16Half = kQ16One >> 1;
+
+// Display-spacing guard.
+constexpr uint64_t kBaseGuardDivisor = 96;
+constexpr uint64_t kMinimumGuardUs = 100;
+constexpr uint64_t kMaximumBaseGuardUs = 250;
+constexpr uint64_t kMaximumAdaptiveGuardUs = 1000;
+constexpr uint64_t kGuardStepUs = 50;
+constexpr size_t kGuardDecayFrames = 120;
+
+// Render and scheduler lead budgets.
+constexpr uint64_t kRenderLeadFloorUs = 1000;
+constexpr uint64_t kRenderLeadCeilingUs = 6500;
+constexpr uint64_t kMaximumRenderWakeLeadUs = 2000;
+constexpr uint64_t kMaximumTargetWakeLeadUs = 500;
+constexpr unsigned int kPreparationPercentile = 99;
+constexpr unsigned int kSchedulerPercentile = 95;
+constexpr size_t kPreparationLearningSamples = 96;
+constexpr size_t kSchedulerLearningSamples = 19;
+
+// Readiness reserve.
+constexpr uint64_t kReadinessCeilingUs = 10000;
+constexpr uint64_t kColdStartReadinessDemandUs = 1500;
+constexpr uint64_t kMinimumReadinessReserveUs = 500;
+constexpr uint64_t kArrivalSpreadGuardUs = 900;
+constexpr uint64_t kReadinessAcquireStepUs = 1000;
+constexpr uint64_t kReadinessReleaseDivisor = 32;
+constexpr uint64_t kUsableHeadroomNumerator = 3;
+constexpr uint64_t kUsableHeadroomDenominator = 4;
+constexpr size_t kReadinessLearningSamples = 16;
+constexpr size_t kMinimumReadinessSamples = 16;
+constexpr unsigned int kReadinessLoosePercentile = 80;
+constexpr unsigned int kReadinessTightPercentile = 100;
+
+// Source cadence tracking.
+constexpr uint64_t kMaximumForwardMovementUs = 1000000;
+constexpr size_t kMinimumCadenceSamples = 6;
+constexpr size_t kMaximumCadenceSamples = 512;
+constexpr size_t kRateCandidateSamples = 3;
+constexpr uint64_t kLooseCadenceWindowUs = 350000;
+constexpr uint64_t kTightCadenceWindowUs = 1000000;
+constexpr uint64_t kLooseHeadroomDisplayPeriods = 2;
+constexpr uint64_t kMajorCadenceRatioNumerator = 7;
+constexpr uint64_t kMajorCadenceRatioDenominator = 2;
+constexpr uint64_t kCandidateCadenceRatio = 2;
+constexpr unsigned int kMaterialRateChangePercent = 12;
+constexpr size_t kPhaseErrorFrames = 3;
+
+// Latched near-refresh presentation hysteresis.
+constexpr uint64_t kLatchEnterHeadroomUs = 1500;
+constexpr uint64_t kLatchEnterHeadroomPeriods = 3;
+constexpr uint64_t kLatchExitHeadroomUs = 2000;
+constexpr uint64_t kLatchExitHeadroomPeriodNumerator = 13;
+constexpr uint64_t kLatchExitHeadroomPeriodDenominator = 4;
+
+uint64_t clampUnsigned(uint64_t value, uint64_t low, uint64_t high)
+{
+    if (high < low) {
+        high = low;
+    }
+    return std::max(low, std::min(value, high));
+}
+
+template<typename T>
+T percentile(const std::deque<T>& values, unsigned int requestedPercentile)
+{
+    if (values.empty()) {
+        return 0;
+    }
+    std::vector<T> ordered(values.begin(), values.end());
+    std::sort(ordered.begin(), ordered.end());
+    const size_t rank = std::max<size_t>(
+        1, (ordered.size() * requestedPercentile + 99) / 100);
+    return ordered[rank - 1];
+}
+
+template<typename T>
+void appendBounded(std::deque<T>& values, T value, size_t limit)
+{
+    while (values.size() >= limit) {
+        values.pop_front();
+    }
+    values.push_back(value);
+}
+
+} // namespace
+
+VrrTimingController::VrrTimingController(const VrrSessionConfig& config,
+                                         bool canLatchPresentation) :
+    m_Config(config),
+    m_CanLatchPresentation(canLatchPresentation)
+{
+    m_DisplayPeriodUs = periodForRate(m_Config.displayRefreshHz, 16667);
+    m_ConfiguredStreamPeriodQ16 = periodForRateQ16(
+        m_Config.streamRateHz, m_DisplayPeriodUs * kQ16One);
+    m_ConfiguredStreamPeriodUs = std::max<uint64_t>(
+        1, roundedQ16(m_ConfiguredStreamPeriodQ16));
+    m_BaseGuardUs = clampUnsigned(m_DisplayPeriodUs / kBaseGuardDivisor,
+                                  kMinimumGuardUs,
+                                  kMaximumBaseGuardUs);
+    clearTimeline(false);
+}
+
+void VrrTimingController::rebase()
+{
+    clearTimeline(true);
+}
+
+void VrrTimingController::clearTimeline(bool retainLearnedBudgets)
+{
+    const uint64_t previousReadinessDemandUs = m_ReadinessDemandUs;
+    const bool previousReadinessModelValid = m_ReadinessModelValid;
+
+    m_SourcePeriodUsQ16 = m_ConfiguredStreamPeriodQ16;
+    m_SourcePeriodUs = std::max<uint64_t>(
+        1, roundedQ16(m_SourcePeriodUsQ16));
+    m_LatchedPresentation = m_CanLatchPresentation && m_SourcePeriodUs <
+        saturatingAdd(m_DisplayPeriodUs,
+                      latchedPresentationHeadroomUs());
+    m_ReadinessBudgetUs = 0;
+    m_ReadinessPhaseUs = 0;
+    m_ReadinessDemandUs = retainLearnedBudgets ?
+        previousReadinessDemandUs : kColdStartReadinessDemandUs;
+    m_ReadinessModelValid = retainLearnedBudgets &&
+        previousReadinessModelValid;
+    m_HaveTimeline = false;
+    m_SourceTimeUs = 0;
+    m_SourceTimeUsQ16 = 0;
+    m_SourceFrameOrdinal = 0;
+    m_UnwrappedRtpTicks = 0;
+    m_LastFrameNumber = -1;
+    m_HaveLastFrameNumber = false;
+    m_LastRtpTimestamp = 0;
+    m_LastTimestampValid = false;
+    m_RtpConversionRemainder = 0;
+    m_FrameConversionRemainder = 0;
+    m_LastCadenceUsedRtp = false;
+    m_PhaseErrorFrames = 0;
+
+    m_CadenceSamples.clear();
+    m_RateCandidateSamples.clear();
+    m_ReadyOffsets.clear();
+    m_PreparationDurations.clear();
+    m_RenderSchedulerDelays.clear();
+    m_TargetSchedulerDelays.clear();
+    m_Pending = PendingFrame {};
+
+    if (retainLearnedBudgets) {
+        m_RenderLeadUs = clampUnsigned(m_RenderLeadUs,
+                                       renderLeadFloorUs(),
+                                       renderLeadCeilingUs());
+        m_RenderWakeLeadUs = std::min(m_RenderWakeLeadUs,
+                                      kMaximumRenderWakeLeadUs);
+        m_TargetWakeLeadUs = std::min(m_TargetWakeLeadUs,
+                                      kMaximumTargetWakeLeadUs);
+        m_GuardUs = clampUnsigned(m_GuardUs,
+                                  m_BaseGuardUs,
+                                  guardCeilingUs());
+    }
+    else {
+        m_RenderLeadUs = clampUnsigned(kRenderLeadFloorUs,
+                                       renderLeadFloorUs(),
+                                       renderLeadCeilingUs());
+        m_RenderWakeLeadUs = 0;
+        m_TargetWakeLeadUs = 0;
+        m_GuardUs = m_BaseGuardUs;
+    }
+}
+
+void VrrTimingController::initializeTimeline(const PacedFrame& frame)
+{
+    m_HaveTimeline = true;
+    anchorSourceTime(frame.decodeCompleteUs());
+    m_SourceFrameOrdinal = 0;
+    m_UnwrappedRtpTicks = 0;
+    m_LastFrameNumber = frame.frameNumber();
+    m_HaveLastFrameNumber = frame.frameNumber() >= 0;
+    m_LastRtpTimestamp = frame.rtpTimestamp();
+    m_LastTimestampValid = frame.timestampValid();
+    m_CadenceSamples.clear();
+    m_RateCandidateSamples.clear();
+    if (frame.timestampValid()) {
+        m_CadenceSamples.push_back(CadenceSample {});
+    }
+}
+
+VrrTimingDecision VrrTimingController::schedule(const PacedFrame& frame,
+                                                 uint64_t nowUs)
+{
+    m_Pending = PendingFrame {};
+
+    CadenceObservation cadence;
+    bool rebased = false;
+    if (!m_HaveTimeline) {
+        initializeTimeline(frame);
+        rebased = true;
+    }
+    else {
+        const bool frameNumberReset =
+            m_HaveLastFrameNumber && frame.frameNumber() >= 0 &&
+            frame.frameNumber() <= m_LastFrameNumber;
+
+        if (frameNumberReset) {
+            rebase();
+            initializeTimeline(frame);
+            rebased = true;
+        }
+        else {
+            cadence = observeCadence(frame);
+            if (cadence.needsRebase) {
+                rebase();
+                initializeTimeline(frame);
+                rebased = true;
+            }
+            else {
+                const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+                const uint64_t projectedMovementQ16 =
+                    cadence.frameDelta != 0 &&
+                    m_SourcePeriodUsQ16 > maximum / cadence.frameDelta ?
+                        maximum : m_SourcePeriodUsQ16 * cadence.frameDelta;
+                m_SourceTimeUsQ16 = saturatingAdd(m_SourceTimeUsQ16,
+                                                   projectedMovementQ16);
+                m_SourceTimeUs = roundedQ16(m_SourceTimeUsQ16);
+
+                if (cadence.phaseDiscontinuity) {
+                    // A large cadence transition or isolated source gap is a
+                    // local phase event, not a reason to forget the learned
+                    // rate. Anchor the live one-slot path to the ready frame
+                    // while the cumulative estimator confirms or abandons its
+                    // provisional segment.
+                    anchorSourceTime(frame.decodeCompleteUs());
+                }
+
+                m_LastFrameNumber = frame.frameNumber();
+                m_HaveLastFrameNumber = frame.frameNumber() >= 0;
+                m_LastRtpTimestamp = frame.rtpTimestamp();
+                m_LastTimestampValid = frame.timestampValid();
+            }
+        }
+    }
+
+    int64_t readyOffsetUs = signedDifference(frame.decodeCompleteUs(),
+                                              m_SourceTimeUs);
+
+    // Local phase recovery: re-anchor the live one-slot path on this frame
+    // while retaining the cumulative cadence fit.
+    const auto reanchorPhase = [&]() {
+        anchorSourceTime(frame.decodeCompleteUs());
+        readyOffsetUs = 0;
+        cadence.phaseDiscontinuity = true;
+        cadence.eligible = false;
+        m_PhaseErrorFrames = 0;
+    };
+
+    if (!rebased && !cadence.phaseDiscontinuity && cadence.eligible) {
+        const int64_t ceilingUs = static_cast<int64_t>(readinessCeilingUs());
+        if (readyOffsetUs < -ceilingUs) {
+            // A frame that is ready well before the old slower clock must not
+            // wait behind an obsolete cutscene cadence. The display floor and
+            // latched near-refresh mode still bound how quickly it can submit.
+            reanchorPhase();
+        }
+        else if (readyOffsetUs > ceilingUs) {
+            ++m_PhaseErrorFrames;
+        }
+        else {
+            m_PhaseErrorFrames = 0;
+        }
+
+        if (!cadence.phaseDiscontinuity &&
+                m_PhaseErrorFrames >= kPhaseErrorFrames) {
+            // A bounded readiness reserve cannot repay a sustained source
+            // phase error. Re-anchor locally while retaining the cumulative
+            // cadence fit, rather than repeatedly rebasing the whole model.
+            reanchorPhase();
+        }
+    }
+    else {
+        m_PhaseErrorFrames = 0;
+    }
+    if (rebased || cadence.sourceRateChanged ||
+        cadence.phaseDiscontinuity) {
+        // A new source epoch or local phase recovery is anchored by the first
+        // directly observed ready offset. Cadence history is retained for the
+        // phase-only cases above.
+        m_ReadyOffsets.clear();
+        const int64_t ceilingUs = static_cast<int64_t>(readinessCeilingUs());
+        m_ReadinessPhaseUs = std::max(
+            -ceilingUs, std::min(readyOffsetUs, ceilingUs));
+        // A source-phase reset must not acquire a standing reserve in one
+        // cadence-breaking jump. Start on the observed phase and let clean
+        // arrival evidence build or release the reserve smoothly.
+        applyReadinessBudget(false);
+    }
+
+    uint64_t targetUs = saturatingAdd(
+        std::max(addSigned(m_SourceTimeUs, m_ReadinessBudgetUs), nowUs),
+        m_RenderLeadUs);
+
+    // This is a live, one-slot path. An unconfirmed RTP/frame jump may
+    // describe already-skipped content, never hundreds of milliseconds that
+    // the client should wait again. Reseed poisoned playout phase without
+    // discarding the cumulative cadence model.
+    const uint64_t maximumDirectTargetUs = saturatingAdd(
+        nowUs,
+        saturatingAdd(std::max(m_ConfiguredStreamPeriodUs,
+                               m_SourcePeriodUs),
+                      m_RenderLeadUs));
+    if (targetUs > maximumDirectTargetUs) {
+        // Do not clear cadence history when a faster source makes the old
+        // playout phase point into the future. Reseed phase from this already
+        // decoded frame and let the cumulative fit heal the rate.
+        reanchorPhase();
+        m_ReadyOffsets.clear();
+        m_ReadinessBudgetUs = 0;
+        m_ReadinessPhaseUs = 0;
+        targetUs = saturatingAdd(std::max(frame.decodeCompleteUs(), nowUs),
+                                 m_RenderLeadUs);
+    }
+
+    targetUs = std::max(targetUs, earliestSubmissionUs());
+    const uint64_t totalLeadUs = saturatingAdd(m_RenderLeadUs,
+                                               m_RenderWakeLeadUs);
+
+    VrrTimingDecision decision;
+    decision.sourcePeriodUs = m_SourcePeriodUs;
+    decision.renderStartUs = targetUs > totalLeadUs ?
+        targetUs - totalLeadUs : 0;
+    decision.targetUs = targetUs;
+    decision.targetWakeLeadUs = m_TargetWakeLeadUs;
+
+    const uint64_t learnedHeadroomUs = headroomUs();
+    if (!m_CanLatchPresentation) {
+        m_LatchedPresentation = false;
+    }
+    else if (m_LatchedPresentation) {
+        // A temporary spacing correction can take a cadence just below the
+        // entry threshold and correctly select the conservative path. Once
+        // that guard has completely decayed, however, retaining the wider
+        // hysteresis band would make an otherwise safe 100 FPS / 120 Hz
+        // stream stay latched indefinitely. Keep hysteresis while protection
+        // is still elevated, then restore immediate presentation at the
+        // normal eligibility boundary.
+        if (learnedHeadroomUs >=
+                latchedPresentationExitHeadroomUs() ||
+            (m_GuardUs == m_BaseGuardUs &&
+             learnedHeadroomUs >=
+                latchedPresentationHeadroomUs())) {
+            m_LatchedPresentation = false;
+        }
+    }
+    else if (learnedHeadroomUs <
+             latchedPresentationHeadroomUs()) {
+        m_LatchedPresentation = true;
+    }
+    decision.latchedPresentation = m_LatchedPresentation;
+
+    m_Pending.valid = true;
+    m_Pending.cadenceEligible = !rebased && cadence.eligible;
+    m_Pending.readyOffsetUs = readyOffsetUs;
+    return decision;
+}
+
+VrrTimingController::CadenceObservation
+VrrTimingController::observeCadence(const PacedFrame& frame)
+{
+    CadenceObservation observation;
+
+    uint64_t frameDelta = 1;
+    if (m_HaveLastFrameNumber && frame.frameNumber() >= 0) {
+        if (frame.frameNumber() <= m_LastFrameNumber) {
+            observation.needsRebase = true;
+            return observation;
+        }
+        frameDelta = static_cast<uint64_t>(frame.frameNumber() -
+                                           m_LastFrameNumber);
+    }
+    observation.frameDelta = frameDelta;
+
+    if (frame.timestampValid() && m_LastTimestampValid) {
+        const uint32_t wrappedDelta =
+            frame.rtpTimestamp() - m_LastRtpTimestamp;
+        if (wrappedDelta == 0 || wrappedDelta > 0x7fffffffU) {
+            observation.needsRebase = true;
+            return observation;
+        }
+
+        const uint64_t carriedRemainder = m_LastCadenceUsedRtp ?
+            m_RtpConversionRemainder : 0;
+        const uint64_t intervalNumerator =
+            static_cast<uint64_t>(wrappedDelta) * kMicrosecondsPerSecond +
+            carriedRemainder;
+        const uint64_t intervalUs = intervalNumerator / kRtpClockRate;
+        if (intervalUs > kMaximumForwardMovementUs) {
+            observation.needsRebase = true;
+            return observation;
+        }
+
+        m_RtpConversionRemainder = intervalNumerator % kRtpClockRate;
+        m_FrameConversionRemainder = 0;
+        m_LastCadenceUsedRtp = true;
+
+        observation.intervalUs = intervalUs;
+        observeRtpCadence(wrappedDelta, observation);
+        return observation;
+    }
+
+    if (m_Config.streamRateHz <= 0 ||
+        frameDelta > static_cast<uint64_t>(m_Config.streamRateHz)) {
+        observation.needsRebase = true;
+        return observation;
+    }
+
+    const uint64_t carriedRemainder = !m_LastCadenceUsedRtp ?
+        m_FrameConversionRemainder : 0;
+    const uint64_t intervalNumerator =
+        frameDelta * kMicrosecondsPerSecond + carriedRemainder;
+    observation.intervalUs = intervalNumerator /
+        static_cast<uint64_t>(m_Config.streamRateHz);
+    m_FrameConversionRemainder = intervalNumerator %
+        static_cast<uint64_t>(m_Config.streamRateHz);
+    m_RtpConversionRemainder = 0;
+    m_LastCadenceUsedRtp = false;
+    m_CadenceSamples.clear();
+    m_RateCandidateSamples.clear();
+    observation.eligible = frameDelta == 1;
+    return observation;
+}
+
+void VrrTimingController::observeRtpCadence(
+    uint32_t rtpDelta, CadenceObservation& observation)
+{
+    const CadenceSample previous {
+        m_SourceFrameOrdinal,
+        m_UnwrappedRtpTicks,
+    };
+    m_SourceFrameOrdinal = saturatingAdd(m_SourceFrameOrdinal,
+                                          observation.frameDelta);
+    m_UnwrappedRtpTicks = saturatingAdd(m_UnwrappedRtpTicks,
+                                         static_cast<uint64_t>(rtpDelta));
+    const CadenceSample current {
+        m_SourceFrameOrdinal,
+        m_UnwrappedRtpTicks,
+    };
+
+    const bool majorDeparture = isMajorCadenceDeparture(
+        observation.intervalUs, observation.frameDelta);
+
+    if (!m_RateCandidateSamples.empty()) {
+        // A normal interval immediately after a major departure identifies an
+        // isolated source/capture gap. Preserve the stable rate, discard the
+        // provisional segment, and begin a fresh cumulative phase at the
+        // current sample.
+        const uint64_t observedPeriodUs = std::max<uint64_t>(
+            1, observation.intervalUs / observation.frameDelta);
+        const bool returnedToStableCadence =
+            observedPeriodUs <= m_SourcePeriodUs * kCandidateCadenceRatio &&
+            m_SourcePeriodUs <= observedPeriodUs * kCandidateCadenceRatio;
+        if (returnedToStableCadence) {
+            m_RateCandidateSamples.clear();
+            m_CadenceSamples.clear();
+            m_CadenceSamples.push_back(current);
+            observation.phaseDiscontinuity = true;
+            return;
+        }
+
+        appendCadenceSample(m_RateCandidateSamples, current);
+        observation.phaseDiscontinuity = true;
+        if (m_RateCandidateSamples.size() >= kRateCandidateSamples) {
+            const uint64_t candidatePeriodQ16 = fittedSourcePeriodQ16(
+                m_RateCandidateSamples);
+            if (candidatePeriodQ16 != 0) {
+                observation.sourceRateChanged = acceptSourcePeriodQ16(
+                    candidatePeriodQ16);
+                m_CadenceSamples = m_RateCandidateSamples;
+                m_RateCandidateSamples.clear();
+                observation.eligible = true;
+            }
+        }
+        return;
+    }
+
+    if (majorDeparture) {
+        m_RateCandidateSamples.push_back(previous);
+        m_RateCandidateSamples.push_back(current);
+        observation.phaseDiscontinuity = true;
+        return;
+    }
+
+    appendCadenceSample(m_CadenceSamples, current);
+    observation.eligible = true;
+    if (m_CadenceSamples.size() >= kMinimumCadenceSamples) {
+        const uint64_t fittedPeriodQ16 = fittedSourcePeriodQ16(
+            m_CadenceSamples);
+        if (fittedPeriodQ16 != 0 &&
+            acceptSourcePeriodQ16(fittedPeriodQ16)) {
+            observation.sourceRateChanged = true;
+            observation.phaseDiscontinuity = true;
+        }
+    }
+}
+
+void VrrTimingController::appendCadenceSample(
+    std::deque<CadenceSample>& samples, const CadenceSample& sample)
+{
+    samples.push_back(sample);
+    while (samples.size() > kMaximumCadenceSamples) {
+        samples.pop_front();
+    }
+
+    while (samples.size() > kMinimumCadenceSamples) {
+        const uint64_t spanTicks = samples.back().rtpTicks -
+            samples.front().rtpTicks;
+        const uint64_t spanUs = spanTicks * kMicrosecondsPerSecond /
+            kRtpClockRate;
+        if (spanUs <= cadenceWindowUs()) {
+            break;
+        }
+        samples.pop_front();
+    }
+}
+
+uint64_t VrrTimingController::fittedSourcePeriodQ16(
+    const std::deque<CadenceSample>& samples) const
+{
+    if (samples.size() < 2) {
+        return 0;
+    }
+
+    const CadenceSample& first = samples.front();
+    const CadenceSample& last = samples.back();
+    if (last.frameOrdinal <= first.frameOrdinal ||
+        last.rtpTicks <= first.rtpTicks) {
+        return 0;
+    }
+
+    // RTP timestamps from a host-refresh-quantized source form a staircase.
+    // OLS weighs the placement of each staircase step, so its slope breathes
+    // as a long atom crosses the window.  The endpoint span measures only
+    // the net source movement and still accounts for skipped local frames.
+    const uint64_t spanFrames = last.frameOrdinal - first.frameOrdinal;
+    const uint64_t spanTicks = last.rtpTicks - first.rtpTicks;
+    constexpr uint64_t kPeriodQ16Scale =
+        kMicrosecondsPerSecond * kQ16One;
+    const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+
+    // The cadence window is at most one previous window plus one valid
+    // one-second RTP interval, so these products are comfortably 64-bit in
+    // normal operation. Keep explicit guards for malformed frame numbers.
+    if (spanTicks > maximum / kPeriodQ16Scale ||
+        spanFrames > maximum / kRtpClockRate) {
+        return 0;
+    }
+
+    const uint64_t numerator = spanTicks * kPeriodQ16Scale;
+    const uint64_t denominator = spanFrames * kRtpClockRate;
+    const uint64_t quotient = numerator / denominator;
+    const uint64_t remainder = numerator % denominator;
+    const uint64_t halfway = denominator / 2 + denominator % 2;
+    if (remainder >= halfway && quotient < maximum) {
+        return quotient + 1;
+    }
+    return quotient;
+}
+
+uint64_t VrrTimingController::cadenceWindowUs() const
+{
+    const uint64_t cadenceHeadroomUs = headroomUs();
+    const uint64_t looseHeadroomUs =
+        m_DisplayPeriodUs * kLooseHeadroomDisplayPeriods;
+    if (cadenceHeadroomUs >= looseHeadroomUs) {
+        return kLooseCadenceWindowUs;
+    }
+    if (cadenceHeadroomUs <= m_DisplayPeriodUs) {
+        return kTightCadenceWindowUs;
+    }
+
+    const uint64_t tightnessNumerator = looseHeadroomUs - cadenceHeadroomUs;
+    const uint64_t windowRangeUs = kTightCadenceWindowUs -
+        kLooseCadenceWindowUs;
+    return kLooseCadenceWindowUs +
+        windowRangeUs * tightnessNumerator /
+            std::max<uint64_t>(1, looseHeadroomUs - m_DisplayPeriodUs);
+}
+
+bool VrrTimingController::isMajorCadenceDeparture(
+    uint64_t intervalUs, uint64_t frameDelta) const
+{
+    if (intervalUs == 0 || frameDelta == 0 || m_SourcePeriodUs == 0) {
+        return false;
+    }
+    const uint64_t observedPeriodUs = std::max<uint64_t>(
+        1, intervalUs / frameDelta);
+    return observedPeriodUs * kMajorCadenceRatioDenominator >
+               m_SourcePeriodUs * kMajorCadenceRatioNumerator ||
+        m_SourcePeriodUs * kMajorCadenceRatioDenominator >
+               observedPeriodUs * kMajorCadenceRatioNumerator;
+}
+
+bool VrrTimingController::acceptSourcePeriodQ16(uint64_t periodUsQ16)
+{
+    if (periodUsQ16 == 0) {
+        return false;
+    }
+
+    // The negotiated stream rate is an upper bound on source FPS. Preserve
+    // it at Q16 precision so fractional rates do not acquire an artificial
+    // drift from the rounded microsecond period.
+    periodUsQ16 = std::max(periodUsQ16, m_ConfiguredStreamPeriodQ16);
+    const uint64_t previousPeriodUs = m_SourcePeriodUs;
+    m_SourcePeriodUsQ16 = periodUsQ16;
+    m_SourcePeriodUs = std::max<uint64_t>(1, roundedQ16(periodUsQ16));
+    m_RenderLeadUs = clampUnsigned(m_RenderLeadUs,
+                                   renderLeadFloorUs(),
+                                   renderLeadCeilingUs());
+    m_GuardUs = clampUnsigned(m_GuardUs,
+                              m_BaseGuardUs,
+                              guardCeilingUs());
+
+    // Only a material departure from the previous period counts as a rate
+    // change for the caller's phase/eligibility handling.
+    if (previousPeriodUs == 0) {
+        return m_SourcePeriodUs != 0;
+    }
+    const uint64_t differenceUs = m_SourcePeriodUs > previousPeriodUs ?
+        m_SourcePeriodUs - previousPeriodUs :
+        previousPeriodUs - m_SourcePeriodUs;
+    return differenceUs * 100 >
+        previousPeriodUs * kMaterialRateChangePercent;
+}
+
+void VrrTimingController::anchorSourceTime(uint64_t sourceTimeUs)
+{
+    m_SourceTimeUs = sourceTimeUs;
+    const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+    m_SourceTimeUsQ16 = sourceTimeUs > maximum / kQ16One ?
+        maximum : sourceTimeUs * kQ16One;
+}
+
+void VrrTimingController::notePreparationDuration(
+    uint64_t preparationDurationUs)
+{
+    if (!m_Pending.valid) {
+        return;
+    }
+    m_Pending.hasPreparationDuration = true;
+    m_Pending.preparationDurationUs = preparationDurationUs;
+}
+
+void VrrTimingController::noteSchedulerDelays(uint64_t renderDelayUs,
+                                              uint64_t targetDelayUs,
+                                              bool targetDelayValid)
+{
+    appendBounded(m_RenderSchedulerDelays, renderDelayUs,
+                  kSchedulerLearningSamples);
+    if (targetDelayValid) {
+        appendBounded(m_TargetSchedulerDelays, targetDelayUs,
+                      kSchedulerLearningSamples);
+    }
+    updateLearnedBudgets();
+}
+
+void VrrTimingController::noteSpacingDeficit(uint64_t deficitUs)
+{
+    if (deficitUs != 0) {
+        m_CleanSpacingFrames = 0;
+        const uint64_t increaseUs = std::max(kGuardStepUs, deficitUs);
+        m_GuardUs = std::min(guardCeilingUs(),
+                             saturatingAdd(m_GuardUs, increaseUs));
+        return;
+    }
+
+    if (m_GuardUs > m_BaseGuardUs &&
+        ++m_CleanSpacingFrames >= kGuardDecayFrames) {
+        m_GuardUs -= std::min(kGuardStepUs, m_GuardUs - m_BaseGuardUs);
+        m_CleanSpacingFrames = 0;
+    }
+}
+
+void VrrTimingController::noteSubmission(bool submitted, bool cancelled,
+                                         uint64_t submissionUs)
+{
+    if (!m_Pending.valid) {
+        return;
+    }
+
+    if (submitted) {
+        // Cancellation is a reason, not proof that nothing reached the native
+        // presentation queue (Vulkan must submit some abandoned images).
+        m_HaveLastSubmission = true;
+        m_LastSubmissionUs = submissionUs;
+
+        if (!cancelled) {
+            if (m_Pending.cadenceEligible) {
+                appendBounded(m_ReadyOffsets, m_Pending.readyOffsetUs,
+                              kReadinessLearningSamples);
+            }
+            if (m_Pending.hasPreparationDuration) {
+                appendBounded(m_PreparationDurations,
+                              m_Pending.preparationDurationUs,
+                              kPreparationLearningSamples);
+            }
+            updateReadinessModel();
+            updateLearnedBudgets();
+        }
+    }
+
+    m_Pending = PendingFrame {};
+}
+
+void VrrTimingController::updateLearnedBudgets()
+{
+    if (!m_PreparationDurations.empty()) {
+        m_RenderLeadUs = clampUnsigned(
+            percentile(m_PreparationDurations, kPreparationPercentile),
+            renderLeadFloorUs(), renderLeadCeilingUs());
+    }
+
+    if (!m_RenderSchedulerDelays.empty()) {
+        m_RenderWakeLeadUs = std::min(
+            kMaximumRenderWakeLeadUs,
+            percentile(m_RenderSchedulerDelays, kSchedulerPercentile));
+    }
+
+    if (!m_TargetSchedulerDelays.empty()) {
+        m_TargetWakeLeadUs = std::min(
+            kMaximumTargetWakeLeadUs,
+            percentile(m_TargetSchedulerDelays, kSchedulerPercentile));
+    }
+}
+
+void VrrTimingController::updateReadinessModel()
+{
+    if (m_ReadyOffsets.size() < kMinimumReadinessSamples) {
+        return;
+    }
+
+    // Learn exogenous decode-arrival variation, not absolute source phase or
+    // queue age created by this controller. The earliest observed offset is
+    // the local phase baseline. Near the display ceiling, preserve the whole
+    // arrival tail because there is too little cadence slack to absorb a late
+    // frame. Slower sources can use p80 and avoid making the slowest fifth
+    // standing latency for every frame.
+    const int64_t lowUs = *std::min_element(m_ReadyOffsets.begin(),
+                                            m_ReadyOffsets.end());
+    const unsigned int highPercentile = headroomUs() > m_DisplayPeriodUs ?
+        kReadinessLoosePercentile : kReadinessTightPercentile;
+    const int64_t highUs = percentile(m_ReadyOffsets, highPercentile);
+    const uint64_t spreadUs = highUs > lowUs ?
+        static_cast<uint64_t>(highUs - lowUs) : 0;
+    const uint64_t candidateDemandUs = clampUnsigned(
+        saturatingAdd(spreadUs, kArrivalSpreadGuardUs),
+        kMinimumReadinessReserveUs, readinessCeilingUs());
+
+    if (!m_ReadinessModelValid) {
+        m_ReadinessDemandUs = candidateDemandUs;
+        m_ReadinessModelValid = true;
+    }
+    else if (candidateDemandUs > m_ReadinessDemandUs) {
+        // Attack immediately, release slowly.
+        m_ReadinessDemandUs = candidateDemandUs;
+    }
+    else if (candidateDemandUs < m_ReadinessDemandUs) {
+        const uint64_t difference = m_ReadinessDemandUs - candidateDemandUs;
+        m_ReadinessDemandUs -= std::max<uint64_t>(
+            1, difference / kReadinessReleaseDivisor);
+    }
+
+    m_ReadinessPhaseUs = lowUs;
+    applyReadinessBudget(true);
+}
+
+void VrrTimingController::applyReadinessBudget(bool acquireReserve)
+{
+    // Cadence slack can absorb most arrival variation without committing a
+    // decoded frame early. Preserve one quarter as service margin, and retain
+    // a small floor near the panel ceiling where Mailbox still needs a
+    // standing cadence cushion. In this projected-source-clock design, small
+    // cadence slack cannot substitute for readiness reserve: doing so lets
+    // quantized late arrivals clamp the target to "now" and turns their 8/16
+    // ms atoms into visible presentation bursts. Credit slack only when at
+    // least a full additional display period is available; tight and
+    // near-ceiling cadences retain the complete learned cushion.
+    const uint64_t cadenceHeadroomUs = headroomUs();
+    const uint64_t usableHeadroomUs =
+        m_SourcePeriodUs >= m_DisplayPeriodUs * kLooseHeadroomDisplayPeriods ?
+            cadenceHeadroomUs * kUsableHeadroomNumerator /
+                kUsableHeadroomDenominator : 0;
+    const uint64_t effectiveDemandUs = m_ReadinessModelValid ?
+        m_ReadinessDemandUs : kColdStartReadinessDemandUs;
+    const uint64_t appliedReserveUs = std::max(
+        kMinimumReadinessReserveUs,
+        effectiveDemandUs > usableHeadroomUs ?
+            effectiveDemandUs - usableHeadroomUs : 0);
+
+    const int64_t ceilingUs = static_cast<int64_t>(readinessCeilingUs());
+    const int64_t reserveUs = static_cast<int64_t>(
+        std::min<uint64_t>(appliedReserveUs,
+                           static_cast<uint64_t>(ceilingUs)));
+    const int64_t desiredUs = m_ReadinessPhaseUs >
+            std::numeric_limits<int64_t>::max() - reserveUs ?
+        std::numeric_limits<int64_t>::max() :
+        m_ReadinessPhaseUs + reserveUs;
+    const int64_t clampedDesiredUs = std::max(
+        -ceilingUs, std::min(desiredUs, ceilingUs));
+    if (!acquireReserve) {
+        m_ReadinessBudgetUs = std::max(
+            -ceilingUs, std::min(m_ReadinessPhaseUs, ceilingUs));
+    }
+    else if (clampedDesiredUs > m_ReadinessBudgetUs) {
+        m_ReadinessBudgetUs += std::min<int64_t>(
+            clampedDesiredUs - m_ReadinessBudgetUs,
+            static_cast<int64_t>(kReadinessAcquireStepUs));
+    }
+    else if (clampedDesiredUs < m_ReadinessBudgetUs) {
+        m_ReadinessBudgetUs -= std::min<int64_t>(
+            m_ReadinessBudgetUs - clampedDesiredUs,
+            static_cast<int64_t>(kReadinessAcquireStepUs));
+    }
+}
+
+uint64_t VrrTimingController::headroomUs() const
+{
+    const uint64_t floorUs = saturatingAdd(m_DisplayPeriodUs, m_GuardUs);
+    return m_SourcePeriodUs > floorUs ? m_SourcePeriodUs - floorUs : 0;
+}
+
+uint64_t VrrTimingController::latchedPresentationHeadroomUs() const
+{
+    return std::max(kLatchEnterHeadroomUs,
+                    m_DisplayPeriodUs * kLatchEnterHeadroomPeriods);
+}
+
+uint64_t VrrTimingController::latchedPresentationExitHeadroomUs() const
+{
+    return std::max(kLatchExitHeadroomUs,
+                    m_DisplayPeriodUs * kLatchExitHeadroomPeriodNumerator /
+                        kLatchExitHeadroomPeriodDenominator);
+}
+
+uint64_t VrrTimingController::displayPeriodUs() const
+{
+    return m_DisplayPeriodUs;
+}
+
+uint64_t VrrTimingController::earliestSubmissionUs() const
+{
+    if (!m_HaveLastSubmission) {
+        return 0;
+    }
+    return saturatingAdd(
+        m_LastSubmissionUs,
+        saturatingAdd(m_DisplayPeriodUs, m_GuardUs));
+}
+
+uint64_t VrrTimingController::lastSubmissionUs() const
+{
+    return m_LastSubmissionUs;
+}
+
+bool VrrTimingController::hasLastSubmission() const
+{
+    return m_HaveLastSubmission;
+}
+
+uint64_t VrrTimingController::renderLeadFloorUs() const
+{
+    return std::min(kRenderLeadFloorUs, m_SourcePeriodUs);
+}
+
+uint64_t VrrTimingController::renderLeadCeilingUs() const
+{
+    const uint64_t ceilingUs = std::min(kRenderLeadCeilingUs,
+                                        m_SourcePeriodUs);
+    return std::max(renderLeadFloorUs(), ceilingUs);
+}
+
+uint64_t VrrTimingController::readinessCeilingUs() const
+{
+    return std::min(kReadinessCeilingUs, m_SourcePeriodUs);
+}
+
+uint64_t VrrTimingController::guardCeilingUs() const
+{
+    const uint64_t sourceSlackUs = m_SourcePeriodUs > m_DisplayPeriodUs ?
+        m_SourcePeriodUs - m_DisplayPeriodUs : 0;
+    return std::max(m_BaseGuardUs,
+                    std::min(kMaximumAdaptiveGuardUs, sourceSlackUs));
+}
+
+uint64_t VrrTimingController::periodForRate(int rateHz, uint64_t fallbackUs)
+{
+    if (rateHz <= 0) {
+        return fallbackUs;
+    }
+    const uint64_t rate = static_cast<uint64_t>(rateHz);
+    return std::max<uint64_t>(1,
+        (kMicrosecondsPerSecond + rate / 2) / rate);
+}
+
+uint64_t VrrTimingController::periodForRateQ16(int rateHz,
+                                               uint64_t fallbackQ16)
+{
+    if (rateHz <= 0) {
+        return fallbackQ16;
+    }
+    const uint64_t rate = static_cast<uint64_t>(rateHz);
+    constexpr uint64_t kPeriodQ16Scale =
+        kMicrosecondsPerSecond * kQ16One;
+    return std::max<uint64_t>(1,
+        (kPeriodQ16Scale + rate / 2) / rate);
+}
+
+uint64_t VrrTimingController::saturatingAdd(uint64_t left, uint64_t right)
+{
+    const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+    return left > maximum - right ? maximum : left + right;
+}
+
+uint64_t VrrTimingController::addSigned(uint64_t value, int64_t adjustment)
+{
+    if (adjustment >= 0) {
+        return saturatingAdd(value, static_cast<uint64_t>(adjustment));
+    }
+    const uint64_t magnitude =
+        static_cast<uint64_t>(-(adjustment + 1)) + 1;
+    return value > magnitude ? value - magnitude : 0;
+}
+
+int64_t VrrTimingController::signedDifference(uint64_t left, uint64_t right)
+{
+    if (left >= right) {
+        const uint64_t difference = left - right;
+        return difference > static_cast<uint64_t>(
+                   std::numeric_limits<int64_t>::max()) ?
+            std::numeric_limits<int64_t>::max() :
+            static_cast<int64_t>(difference);
+    }
+
+    const uint64_t difference = right - left;
+    if (difference > static_cast<uint64_t>(
+                         std::numeric_limits<int64_t>::max())) {
+        return std::numeric_limits<int64_t>::min();
+    }
+    return -static_cast<int64_t>(difference);
+}
+
+uint64_t VrrTimingController::roundedQ16(uint64_t valueQ16)
+{
+    return saturatingAdd(valueQ16, kQ16Half) / kQ16One;
+}

--- a/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtimingcontroller.h
+++ b/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtimingcontroller.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "vrrtypes.h"
+
+#include <cstdint>
+#include <deque>
+
+struct VrrTimingDecision {
+    uint64_t sourcePeriodUs = 0;
+    uint64_t renderStartUs = 0;
+    uint64_t targetUs = 0;
+    uint64_t targetWakeLeadUs = 0;
+    bool latchedPresentation = false;
+};
+
+// Platform-neutral, feed-forward VRR timing. The controller projects the
+// sender clock into the local monotonic epoch and learns bounded readiness,
+// render, scheduler, and spacing budgets. It contains no renderer/native API
+// types; the worker translates platform observations into neutral timing
+// feedback.
+class VrrTimingController {
+public:
+    VrrTimingController(const VrrSessionConfig& config,
+                        bool canLatchPresentation);
+
+    // Starts a fresh source epoch while retaining learned render/wake budgets
+    // and the last submission instant used by the display-spacing floor.
+    void rebase();
+
+    VrrTimingDecision schedule(const PacedFrame& frame, uint64_t nowUs);
+
+    // Samples affect subsequent frames only. The current presentation target
+    // never moves after rendering has begun.
+    void notePreparationDuration(uint64_t preparationDurationUs);
+    void noteSchedulerDelays(uint64_t renderDelayUs,
+                             uint64_t targetDelayUs,
+                             bool targetDelayValid);
+
+    // A positive deficit means the worker reached the presentation boundary
+    // before the display-spacing floor. The worker corrects the current frame;
+    // this feedback adjusts one bounded guard for future frames.
+    void noteSpacingDeficit(uint64_t deficitUs);
+
+    // The worker records its own call boundary and supplies only the neutral
+    // lifecycle result. The timing controller has no renderer/native types.
+    void noteSubmission(bool submitted, bool cancelled,
+                        uint64_t submissionUs);
+
+    uint64_t displayPeriodUs() const;
+    uint64_t earliestSubmissionUs() const;
+    uint64_t lastSubmissionUs() const;
+    bool hasLastSubmission() const;
+
+private:
+    struct PendingFrame {
+        bool valid = false;
+        bool cadenceEligible = false;
+        bool hasPreparationDuration = false;
+        int64_t readyOffsetUs = 0;
+        uint64_t preparationDurationUs = 0;
+    };
+
+    struct CadenceObservation {
+        uint64_t intervalUs = 0;
+        uint64_t frameDelta = 1;
+        bool eligible = false;
+        bool sourceRateChanged = false;
+        bool phaseDiscontinuity = false;
+        bool needsRebase = false;
+    };
+
+    struct CadenceSample {
+        uint64_t frameOrdinal = 0;
+        uint64_t rtpTicks = 0;
+    };
+
+    void clearTimeline(bool retainLearnedBudgets);
+    void initializeTimeline(const PacedFrame& frame);
+    CadenceObservation observeCadence(const PacedFrame& frame);
+    void observeRtpCadence(uint32_t rtpDelta,
+                           CadenceObservation& observation);
+    void appendCadenceSample(std::deque<CadenceSample>& samples,
+                             const CadenceSample& sample);
+    uint64_t fittedSourcePeriodQ16(
+        const std::deque<CadenceSample>& samples) const;
+    uint64_t cadenceWindowUs() const;
+    bool isMajorCadenceDeparture(uint64_t intervalUs,
+                                 uint64_t frameDelta) const;
+    bool acceptSourcePeriodQ16(uint64_t periodUsQ16);
+    void anchorSourceTime(uint64_t sourceTimeUs);
+    void updateLearnedBudgets();
+    void updateReadinessModel();
+    void applyReadinessBudget(bool acquireReserve);
+
+    uint64_t headroomUs() const;
+    uint64_t renderLeadFloorUs() const;
+    uint64_t renderLeadCeilingUs() const;
+    uint64_t readinessCeilingUs() const;
+    uint64_t guardCeilingUs() const;
+    uint64_t latchedPresentationHeadroomUs() const;
+    uint64_t latchedPresentationExitHeadroomUs() const;
+    static uint64_t periodForRate(int rateHz, uint64_t fallbackUs);
+    static uint64_t periodForRateQ16(int rateHz, uint64_t fallbackQ16);
+    static uint64_t saturatingAdd(uint64_t left, uint64_t right);
+    static uint64_t addSigned(uint64_t value, int64_t adjustment);
+    static int64_t signedDifference(uint64_t left, uint64_t right);
+    static uint64_t roundedQ16(uint64_t valueQ16);
+
+    VrrSessionConfig m_Config;
+    uint64_t m_ConfiguredStreamPeriodUs = 0;
+    uint64_t m_ConfiguredStreamPeriodQ16 = 0;
+    uint64_t m_DisplayPeriodUs = 0;
+    uint64_t m_BaseGuardUs = 0;
+    uint64_t m_GuardUs = 0;
+
+    uint64_t m_SourcePeriodUs = 0;
+    uint64_t m_SourcePeriodUsQ16 = 0;
+    int64_t m_ReadinessBudgetUs = 0;
+    int64_t m_ReadinessPhaseUs = 0;
+    uint64_t m_ReadinessDemandUs = 0;
+    bool m_ReadinessModelValid = false;
+    uint64_t m_RenderLeadUs = 0;
+    uint64_t m_RenderWakeLeadUs = 0;
+    uint64_t m_TargetWakeLeadUs = 0;
+    bool m_CanLatchPresentation = true;
+    bool m_LatchedPresentation = false;
+
+    bool m_HaveTimeline = false;
+    uint64_t m_SourceTimeUs = 0;
+    uint64_t m_SourceTimeUsQ16 = 0;
+    uint64_t m_SourceFrameOrdinal = 0;
+    uint64_t m_UnwrappedRtpTicks = 0;
+    int m_LastFrameNumber = -1;
+    bool m_HaveLastFrameNumber = false;
+    uint32_t m_LastRtpTimestamp = 0;
+    bool m_LastTimestampValid = false;
+    // Fractional-rate remainder carry. The carried remainder belongs to the
+    // cadence source that produced it, so switching between RTP and frame
+    // numbers must not reuse the other source's remainder.
+    uint64_t m_RtpConversionRemainder = 0;
+    uint64_t m_FrameConversionRemainder = 0;
+    bool m_LastCadenceUsedRtp = false;
+
+    bool m_HaveLastSubmission = false;
+    uint64_t m_LastSubmissionUs = 0;
+    unsigned int m_CleanSpacingFrames = 0;
+    unsigned int m_PhaseErrorFrames = 0;
+
+    std::deque<CadenceSample> m_CadenceSamples;
+    std::deque<CadenceSample> m_RateCandidateSamples;
+    std::deque<int64_t> m_ReadyOffsets;
+    std::deque<uint64_t> m_PreparationDurations;
+    std::deque<uint64_t> m_RenderSchedulerDelays;
+    std::deque<uint64_t> m_TargetSchedulerDelays;
+
+    PendingFrame m_Pending;
+};

--- a/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtypes.h
+++ b/app/streaming/video/ffmpeg-renderers/pacer/vrr/vrrtypes.h
@@ -1,0 +1,91 @@
+#pragma once
+
+// The VRR pacing path deliberately keeps its data contract separate from
+// FFmpeg's PTS/DTS fields.  Those fields are decoder-owned and are still used
+// by the legacy pacing path, while these values describe the frame as it
+// crossed the decoder/pacer boundary.
+
+#include <cstdint>
+#include <memory>
+
+extern "C" {
+#include <libavutil/frame.h>
+}
+
+struct VrrSessionConfig {
+    int displayRefreshHz = 0;
+    int streamRateHz = 0;
+};
+
+// A move-only frame record.  Decoder completion is captured while the
+// corresponding DECODE_UNIT is still available.  A raw RTP timestamp of zero
+// is valid; timestampValid is intentionally separate to make that explicit.
+class PacedFrame {
+public:
+    PacedFrame() = default;
+
+    PacedFrame(AVFrame* frame,
+               int frameNumber,
+               uint32_t rtpTimestamp,
+               bool timestampValid,
+               uint64_t decodeCompleteUs) :
+        m_Frame(frame),
+        m_FrameNumber(frameNumber),
+        m_RtpTimestamp(rtpTimestamp),
+        m_TimestampValid(timestampValid),
+        m_DecodeCompleteUs(decodeCompleteUs)
+    {
+    }
+
+    PacedFrame(PacedFrame&&) noexcept = default;
+    PacedFrame& operator=(PacedFrame&&) noexcept = default;
+
+    AVFrame* frame() const
+    {
+        return m_Frame.get();
+    }
+
+    AVFrame* release()
+    {
+        return m_Frame.release();
+    }
+
+    explicit operator bool() const
+    {
+        return m_Frame != nullptr;
+    }
+
+    int frameNumber() const
+    {
+        return m_FrameNumber;
+    }
+
+    uint32_t rtpTimestamp() const
+    {
+        return m_RtpTimestamp;
+    }
+
+    bool timestampValid() const
+    {
+        return m_TimestampValid;
+    }
+
+    uint64_t decodeCompleteUs() const
+    {
+        return m_DecodeCompleteUs;
+    }
+
+private:
+    struct FrameDeleter {
+        void operator()(AVFrame* frame) const
+        {
+            av_frame_free(&frame);
+        }
+    };
+
+    std::unique_ptr<AVFrame, FrameDeleter> m_Frame;
+    int m_FrameNumber = -1;
+    uint32_t m_RtpTimestamp = 0;
+    bool m_TimestampValid = false;
+    uint64_t m_DecodeCompleteUs = 0;
+};

--- a/app/streaming/video/ffmpeg-renderers/pacer/vrrpacingworker.cpp
+++ b/app/streaming/video/ffmpeg-renderers/pacer/vrrpacingworker.cpp
@@ -1,0 +1,521 @@
+#include "vrrpacingworker.h"
+
+#include "vrr/vrrtimingcontroller.h"
+
+#include <Limelight.h>
+
+#include <algorithm>
+#include <utility>
+
+namespace {
+
+// Keep enough decoded successors to absorb the short gap-then-burst delivery
+// pattern seen near the panel ceiling. Capacity remains bounded and evicts the
+// oldest queued successor under sustained pressure, so it cannot accumulate
+// an unbounded latency backlog.
+constexpr size_t kMaximumQueuedFrames = 3;
+
+constexpr uint32_t kVrrWindowStateMask =
+    WINDOW_STATE_CHANGE_SIZE |
+    WINDOW_STATE_CHANGE_DISPLAY |
+    WINDOW_STATE_CHANGE_MINIMIZED |
+    WINDOW_STATE_CHANGE_RESTORED;
+constexpr uint32_t kVrrDisplayEpochStateMask =
+    WINDOW_STATE_CHANGE_SIZE |
+    WINDOW_STATE_CHANGE_DISPLAY;
+
+uint64_t submissionBoundaryUs(const VrrPresentFeedback& feedback,
+                              uint64_t operationStartUs,
+                              uint64_t operationEndUs)
+{
+    if (!feedback.presented) {
+        return 0;
+    }
+
+    // A backend may wait for physical scanout inside presentAdaptive(). Use
+    // its exact native-call timestamp only when it belongs to this operation;
+    // stale or cross-epoch feedback must not poison every future spacing floor.
+    if (feedback.submissionTimeValid &&
+            operationStartUs <= operationEndUs &&
+            feedback.submissionTimeUs >= operationStartUs &&
+            feedback.submissionTimeUs <= operationEndUs) {
+        return feedback.submissionTimeUs;
+    }
+
+    // Presenters without native timing are required to be thin. Anchoring at
+    // entry prevents an unrelated blocking return from adding a display period
+    // to every subsequent frame.
+    return operationStartUs;
+}
+
+} // namespace
+
+VrrPacingWorker::VrrPacingWorker(IVrrFramePresenter* presenter,
+                                 const VrrSessionConfig& config,
+                                 PVIDEO_STATS videoStats) :
+    m_Presenter(presenter),
+    m_VideoStats(videoStats),
+    m_TimingController(std::make_unique<VrrTimingController>(
+        config, presenter != nullptr &&
+                presenter->canLatchAdaptivePresent()))
+{
+}
+
+VrrPacingWorker::~VrrPacingWorker()
+{
+    {
+        QMutexLocker lock(&m_FrameQueueLock);
+        m_Stopping.store(true);
+        m_FrameQueueNotEmpty.wakeAll();
+    }
+
+    if (m_WorkerThread != nullptr) {
+        SDL_WaitThread(m_WorkerThread, nullptr);
+        m_WorkerThread = nullptr;
+    }
+
+    discardQueuedFrames(false);
+}
+
+bool VrrPacingWorker::start()
+{
+    if (m_Presenter == nullptr ||
+        m_Presenter->checkSupport() != VrrFallbackReason::NoFallback) {
+        return false;
+    }
+
+    m_WorkerThread = SDL_CreateThread(VrrPacingWorker::threadProc,
+                                      "PacerVRR", this);
+    if (m_WorkerThread == nullptr) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "Failed to create VRR pacing worker: %s", SDL_GetError());
+        return false;
+    }
+
+    return true;
+}
+
+void VrrPacingWorker::submit(PacedFrame&& frame)
+{
+    if (!frame) {
+        return;
+    }
+
+    PacedFrame dropped;
+    bool queued = false;
+    {
+        QMutexLocker lock(&m_FrameQueueLock);
+        // Close the race where suspension can begin after the optimistic
+        // check above but before this producer acquires the queue lock.
+        if (m_Stopping.load() || m_Suspended.load()) {
+            dropped = std::move(frame);
+        }
+        else {
+            if (m_FrameQueue.size() >= kMaximumQueuedFrames) {
+                dropped = std::move(m_FrameQueue.front());
+                m_FrameQueue.pop_front();
+            }
+            m_FrameQueue.emplace_back(std::move(frame));
+            queued = true;
+        }
+    }
+
+    // The evicted frame is released here rather than under the queue lock, so
+    // returning a decoder surface cannot stall the time-critical worker.
+    if (dropped) {
+        m_VideoStats->pacerDroppedFrames++;
+    }
+    if (queued) {
+        m_FrameQueueNotEmpty.wakeOne();
+    }
+}
+
+void VrrPacingWorker::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info)
+{
+    if (info == nullptr) {
+        return;
+    }
+
+    const uint32_t flags = info->stateChangeFlags & kVrrWindowStateMask;
+    if (flags == 0) {
+        return;
+    }
+
+    if (flags & WINDOW_STATE_CHANGE_MINIMIZED) {
+        m_Suspended.store(true);
+        discardQueuedFrames(true);
+    }
+    if (flags & WINDOW_STATE_CHANGE_RESTORED) {
+        m_Suspended.store(false);
+    }
+
+    m_PendingWindowStateFlags.fetch_or(flags);
+    m_FrameQueueNotEmpty.wakeAll();
+}
+
+int VrrPacingWorker::threadProc(void* context)
+{
+    return static_cast<VrrPacingWorker*>(context)->run();
+}
+
+int VrrPacingWorker::run()
+{
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+    if (SDL_SetThreadPriority(SDL_THREAD_PRIORITY_TIME_CRITICAL) < 0) {
+#else
+    if (SDL_SetThreadPriority(SDL_THREAD_PRIORITY_HIGH) < 0) {
+#endif
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Unable to set VRR pacing worker priority: %s",
+                    SDL_GetError());
+    }
+
+    // Abandons the prepared image and counts the frame as dropped. The worker
+    // owns the target and display-spacing policy, so the timing controller is
+    // always told how the abandoned submission ended.
+    auto cancelPresentation = [this]() {
+        const uint64_t startUs = LiGetMicroseconds();
+        VrrPresentFeedback feedback = m_Presenter->cancelFrame();
+        const uint64_t endUs = LiGetMicroseconds();
+        feedback.cancelled = true;
+        recordSubmission(feedback, startUs, endUs);
+        m_VideoStats->pacerDroppedFrames++;
+    };
+
+    while (!isStopping()) {
+        consumeWindowStateNotifications();
+
+        PacedFrame frame;
+        if (!dequeueFrame(frame)) {
+            break;
+        }
+
+        consumeWindowStateNotifications();
+        if (isStopping()) {
+            if (frame) {
+                m_VideoStats->pacerDroppedFrames++;
+            }
+            continue;
+        }
+        if (presentationSuspended()) {
+            if (frame) {
+                m_VideoStats->pacerDroppedFrames++;
+            }
+            // dequeueFrame() wakes without a frame so suspension can be
+            // delivered to the backend. Once delivered, block here until a
+            // restore or shutdown notification changes the atomic state.
+            QMutexLocker lock(&m_FrameQueueLock);
+            while (!isStopping() && m_Suspended.load()) {
+                m_FrameQueueNotEmpty.wait(&m_FrameQueueLock);
+            }
+            continue;
+        }
+        if (!frame) {
+            // dequeueFrame() also wakes the worker without a frame so window
+            // state can be delivered while suspended.
+            continue;
+        }
+
+        if (m_RebaseOnNextFrame) {
+            m_TimingController->rebase();
+            m_RebaseOnNextFrame = false;
+        }
+
+        const VrrTimingDecision decision = m_TimingController->schedule(
+            frame, LiGetMicroseconds());
+
+        // schedule() deliberately clamps an overdue target to the current
+        // one-slot deadline. That is right for the newest frame, but it makes
+        // the later target-relative stale check unable to see time already
+        // spent waiting in this worker's queue. If a fresher successor exists,
+        // skip a frame that is already more than one source interval old before
+        // rendering it; its RTP/frame delta remains in the controller, so the
+        // successor preserves cadence without re-anchoring the whole model.
+        const uint64_t scheduleNowUs = LiGetMicroseconds();
+        const uint64_t scheduleAgeUs = scheduleNowUs >=
+                frame.decodeCompleteUs() ?
+            scheduleNowUs - frame.decodeCompleteUs() : 0;
+        if (decision.sourcePeriodUs != 0 &&
+            scheduleAgeUs > decision.sourcePeriodUs && hasQueuedFrame()) {
+            m_VideoStats->pacerDroppedFrames++;
+            m_TimingController->noteSubmission(false, false, 0);
+            continue;
+        }
+
+        const VrrTargetWaitResult renderWait =
+            m_TargetWaiter.waitUntil(decision.renderStartUs);
+        // A deadline that was already in the past is not an OS wake delay.
+        // This matters when a decoded frame arrives after its projected render
+        // start: readiness/render learning owns that lateness instead.
+        const uint64_t renderWaitOvershootUs =
+            renderWait.deadlineAlreadyElapsed ||
+                    renderWait.finalNowUs <= decision.renderStartUs ?
+                0 : renderWait.finalNowUs - decision.renderStartUs;
+
+        bool displayEpochInterrupted =
+            (consumeWindowStateNotifications() &
+                kVrrDisplayEpochStateMask) != 0;
+        if (displayEpochInterrupted ||
+                presentationSuspended() || isStopping()) {
+            cancelPresentation();
+            continue;
+        }
+
+        // A frame can become stale while the worker waits for its render
+        // start. Leave the surface unprepared and let the next iteration start
+        // fresh rather than rendering an avoidably old image.
+        if (decision.sourcePeriodUs != 0 &&
+            LiGetMicroseconds() > decision.targetUs + decision.sourcePeriodUs &&
+            hasQueuedFrame()) {
+            m_VideoStats->pacerDroppedFrames++;
+            m_TimingController->rebase();
+            continue;
+        }
+
+        const uint64_t preparationStartUs = LiGetMicroseconds();
+        const VrrPrepareResult preparation =
+            m_Presenter->prepareFrame(frame.frame());
+        const uint64_t preparationEndUs = LiGetMicroseconds();
+        const uint64_t preparationDurationUs =
+            preparationEndUs >= preparationStartUs ?
+                preparationEndUs - preparationStartUs : 0;
+        m_TimingController->notePreparationDuration(preparationDurationUs);
+
+        // Always drain, even when already interrupted: the drain is what
+        // reconciles the presenter's suspension state and arms the rebase.
+        displayEpochInterrupted =
+            (consumeWindowStateNotifications() &
+                kVrrDisplayEpochStateMask) != 0 || displayEpochInterrupted;
+        if (!preparation.prepared || displayEpochInterrupted ||
+                presentationSuspended() || isStopping()) {
+            VrrPresentFeedback feedback = preparation.feedback;
+            uint64_t operationStartUs = preparationStartUs;
+            uint64_t operationEndUs = preparationEndUs;
+            const bool mustCancel = !feedback.presented &&
+                (preparation.prepared || preparation.cancellationMaySubmit ||
+                 !feedback.cancelled);
+            if (mustCancel) {
+                // A presenter may need to submit an acquired image in order
+                // to abandon it. It reports only that neutral fact; the worker
+                // owns the target and display-spacing policy.
+                if (preparation.cancellationMaySubmit) {
+                    waitForSubmissionFloor(decision);
+                }
+                operationStartUs = LiGetMicroseconds();
+                feedback = m_Presenter->cancelFrame();
+                operationEndUs = LiGetMicroseconds();
+            }
+            feedback.cancelled = true;
+            recordSubmission(feedback, operationStartUs, operationEndUs);
+            m_VideoStats->pacerDroppedFrames++;
+            m_DeferredFrame = std::move(frame);
+            continue;
+        }
+
+        const VrrTargetWaitResult targetWait =
+            m_TargetWaiter.waitUntil(decision.targetUs,
+                                      decision.targetWakeLeadUs);
+        // Always drain, even when already interrupted: the drain is what
+        // reconciles the presenter's suspension state and arms the rebase.
+        displayEpochInterrupted =
+            (consumeWindowStateNotifications() &
+                kVrrDisplayEpochStateMask) != 0 || displayEpochInterrupted;
+        if (displayEpochInterrupted ||
+                presentationSuspended() || isStopping()) {
+            if (preparation.cancellationMaySubmit) {
+                waitForSubmissionFloor(decision);
+            }
+            cancelPresentation();
+            m_DeferredFrame = std::move(frame);
+            continue;
+        }
+
+        // Recheck both mathematical floors immediately before Present. The
+        // waiter deliberately has a bounded active phase, so a pathological
+        // clock must not turn an early return into an early submission.
+        // This frame's floor is fixed before the clean-spacing feedback, so a
+        // guard decay can only take effect from the next frame onward.
+        const uint64_t presentationFloorUs = std::max(
+            decision.targetUs, m_TimingController->earliestSubmissionUs());
+        m_TimingController->noteSpacingDeficit(0);
+        while (LiGetMicroseconds() < presentationFloorUs) {
+            m_TargetWaiter.waitUntil(presentationFloorUs);
+        }
+
+        if (m_TimingController->hasLastSubmission()) {
+            const uint64_t minimumUntornUs =
+                m_TimingController->lastSubmissionUs() +
+                m_TimingController->displayPeriodUs();
+
+            // A second check protects against a clock anomaly between the
+            // first check and the actual call boundary.
+            const uint64_t nowUs = LiGetMicroseconds();
+            if (nowUs < minimumUntornUs) {
+                m_TimingController->noteSpacingDeficit(minimumUntornUs - nowUs);
+                const uint64_t correctedFloorUs =
+                    m_TimingController->earliestSubmissionUs();
+                while (LiGetMicroseconds() < correctedFloorUs) {
+                    m_TargetWaiter.waitUntil(correctedFloorUs);
+                }
+            }
+        }
+
+        // The mathematical floor and its correction can add another
+        // display-period wait after the primary target checkpoint. Drain
+        // notifications once more at the actual submission boundary so a
+        // minimize or a renderer-accepted display epoch cannot slip through
+        // that final wait and be presented under the old decision.
+        // Always drain, even when already interrupted: the drain is what
+        // reconciles the presenter's suspension state and arms the rebase.
+        displayEpochInterrupted =
+            (consumeWindowStateNotifications() &
+                kVrrDisplayEpochStateMask) != 0 || displayEpochInterrupted;
+        if (displayEpochInterrupted ||
+                presentationSuspended() || isStopping()) {
+            cancelPresentation();
+            m_DeferredFrame = std::move(frame);
+            continue;
+        }
+
+        m_TimingController->noteSchedulerDelays(
+            renderWaitOvershootUs,
+            targetWait.schedulerDelayUs,
+            targetWait.schedulerDelayValid);
+
+        VrrPresentRequest presentRequest;
+        presentRequest.latchedPresentation = decision.latchedPresentation;
+
+        const uint64_t presentStartUs = LiGetMicroseconds();
+        const VrrPresentFeedback feedback =
+            m_Presenter->presentAdaptive(presentRequest);
+        const uint64_t presentEndUs = LiGetMicroseconds();
+        recordSubmission(feedback, presentStartUs, presentEndUs);
+
+        if (feedback.presented && !feedback.cancelled) {
+            m_VideoStats->totalPacerTimeUs +=
+                preparationStartUs >= frame.decodeCompleteUs() ?
+                    preparationStartUs - frame.decodeCompleteUs() : 0;
+            m_VideoStats->totalRenderTimeUs += preparationDurationUs +
+                (presentEndUs >= presentStartUs ?
+                    presentEndUs - presentStartUs : 0);
+            m_VideoStats->renderedFrames++;
+        }
+        else {
+            m_VideoStats->pacerDroppedFrames++;
+        }
+
+        m_DeferredFrame = std::move(frame);
+    }
+
+    // Release any native state retained between preparation and presentation.
+    m_Presenter->cancelFrame();
+    return 0;
+}
+
+bool VrrPacingWorker::dequeueFrame(PacedFrame& frame)
+{
+    QMutexLocker lock(&m_FrameQueueLock);
+    while (!isStopping() && !m_Suspended.load() && m_FrameQueue.empty()) {
+        m_FrameQueueNotEmpty.wait(&m_FrameQueueLock);
+    }
+
+    if (isStopping()) {
+        return false;
+    }
+    if (m_Suspended.load()) {
+        return true;
+    }
+
+    frame = std::move(m_FrameQueue.front());
+    m_FrameQueue.pop_front();
+    return true;
+}
+
+bool VrrPacingWorker::hasQueuedFrame()
+{
+    QMutexLocker lock(&m_FrameQueueLock);
+    return !m_FrameQueue.empty();
+}
+
+void VrrPacingWorker::discardQueuedFrames(bool countDrops)
+{
+    std::deque<PacedFrame> discardedFrames;
+    {
+        QMutexLocker lock(&m_FrameQueueLock);
+        discardedFrames.swap(m_FrameQueue);
+    }
+
+    if (countDrops) {
+        m_VideoStats->pacerDroppedFrames +=
+            static_cast<uint32_t>(discardedFrames.size());
+    }
+}
+
+uint32_t VrrPacingWorker::consumeWindowStateNotifications()
+{
+    uint32_t consumedFlags = m_PendingWindowStateFlags.exchange(0);
+    if (consumedFlags == 0) {
+        return 0;
+    }
+
+    // Minimize/restore can race while this worker is draining notifications.
+    // Reconcile to the authoritative atomic state rather than applying a stale
+    // flag snapshot in event order.
+    bool suspended = m_Suspended.load();
+    while (true) {
+        const uint32_t newerFlags = m_PendingWindowStateFlags.exchange(0);
+        consumedFlags |= newerFlags;
+        const bool latestSuspended = m_Suspended.load();
+        if (newerFlags == 0 && latestSuspended == suspended) {
+            break;
+        }
+        suspended = latestSuspended;
+    }
+
+    if (suspended != m_PresenterSuspended) {
+        m_Presenter->setSuspended(suspended);
+        m_PresenterSuspended = suspended;
+    }
+    m_RebaseOnNextFrame = true;
+    return consumedFlags;
+}
+
+bool VrrPacingWorker::presentationSuspended() const
+{
+    // If UI state changed just after notification draining, either side being
+    // suspended is enough to prevent a misclassified finish. The next loop
+    // reconciles the presenter to the newest authoritative state.
+    return m_Suspended.load() || m_PresenterSuspended;
+}
+
+bool VrrPacingWorker::isStopping() const
+{
+    return m_Stopping.load();
+}
+
+void VrrPacingWorker::waitForSubmissionFloor(const VrrTimingDecision& decision)
+{
+    const uint64_t submissionFloorUs = std::max(
+        decision.targetUs, m_TimingController->earliestSubmissionUs());
+    if (LiGetMicroseconds() >= submissionFloorUs) {
+        return;
+    }
+
+    m_TargetWaiter.waitUntil(submissionFloorUs, decision.targetWakeLeadUs);
+
+    // The waiter deliberately bounds each active phase. Re-enter it until the
+    // shared monotonic clock confirms the floor; an incomplete wait must never
+    // become permission to submit.
+    while (LiGetMicroseconds() < submissionFloorUs) {
+        m_TargetWaiter.waitUntil(submissionFloorUs);
+    }
+}
+
+void VrrPacingWorker::recordSubmission(const VrrPresentFeedback& feedback,
+                                       uint64_t operationStartUs,
+                                       uint64_t operationEndUs)
+{
+    m_TimingController->noteSubmission(
+        feedback.presented, feedback.cancelled,
+        submissionBoundaryUs(feedback, operationStartUs, operationEndUs));
+}

--- a/app/streaming/video/ffmpeg-renderers/pacer/vrrpacingworker.h
+++ b/app/streaming/video/ffmpeg-renderers/pacer/vrrpacingworker.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "../../decoder.h"
+#include "../ivrrframepresenter.h"
+#include "vrr/vrrtargetwaiter.h"
+#include "vrr/vrrtypes.h"
+
+#include <atomic>
+#include <deque>
+#include <memory>
+
+#include <QMutex>
+#include <QWaitCondition>
+
+class VrrTimingController;
+struct VrrTimingDecision;
+
+// The complete VRR execution path lives in this one worker.  It owns a bounded
+// queue and the renderer context from preparation through presentation;
+// fixed-VSync and unpaced Pacer behavior never enter it.
+class VrrPacingWorker {
+public:
+    VrrPacingWorker(IVrrFramePresenter* presenter,
+                    const VrrSessionConfig& config,
+                    PVIDEO_STATS videoStats);
+    ~VrrPacingWorker();
+
+    VrrPacingWorker(const VrrPacingWorker&) = delete;
+    VrrPacingWorker& operator=(const VrrPacingWorker&) = delete;
+
+    bool start();
+
+    void submit(PacedFrame&& frame);
+
+    // Calls from the UI/main thread only manipulate worker-owned state. All
+    // backend notifications are delivered by the worker itself.
+    void notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info);
+
+private:
+    static int threadProc(void* context);
+
+    int run();
+    bool dequeueFrame(PacedFrame& frame);
+    bool hasQueuedFrame();
+    void discardQueuedFrames(bool countDrops);
+    uint32_t consumeWindowStateNotifications();
+    bool presentationSuspended() const;
+    bool isStopping() const;
+    void waitForSubmissionFloor(const VrrTimingDecision& decision);
+    void recordSubmission(const VrrPresentFeedback& feedback,
+                          uint64_t operationStartUs,
+                          uint64_t operationEndUs);
+
+    IVrrFramePresenter* m_Presenter;
+    PVIDEO_STATS m_VideoStats;
+
+    std::unique_ptr<VrrTimingController> m_TimingController;
+    VrrTargetWaiter m_TargetWaiter;
+
+    QMutex m_FrameQueueLock;
+    QWaitCondition m_FrameQueueNotEmpty;
+    std::deque<PacedFrame> m_FrameQueue;
+    // Keeps the most recently presented frame alive until the next result so a
+    // decoder-owned surface cannot be recycled while the GPU still reads it.
+    PacedFrame m_DeferredFrame;
+    SDL_Thread* m_WorkerThread = nullptr;
+    std::atomic_bool m_Stopping { false };
+    std::atomic_bool m_Suspended { false };
+    std::atomic_uint32_t m_PendingWindowStateFlags { 0 };
+    bool m_PresenterSuspended = false;
+    bool m_RebaseOnNextFrame = false;
+};

--- a/app/streaming/video/ffmpeg-renderers/plvk.cpp
+++ b/app/streaming/video/ffmpeg-renderers/plvk.cpp
@@ -3,6 +3,8 @@
 #include "streaming/session.h"
 #include "streaming/streamutils.h"
 
+#include <Limelight.h>
+
 // Implementation in plvk_c.c
 #define PL_LIBAV_IMPLEMENTATION 0
 #include <libplacebo/utils/libav.h>
@@ -54,6 +56,56 @@ public:
     DrmMasterLocker(DrmMasterLocker&&) noexcept = delete;
     DrmMasterLocker& operator=(DrmMasterLocker&&) noexcept = delete;
 };
+
+namespace {
+
+bool hasEnvironmentValue(const char* name)
+{
+    const char* value = SDL_getenv(name);
+    return value != nullptr && value[0] != '\0';
+}
+
+bool isGamescopePresentation(const char* videoDriver)
+{
+    // Gamescope commonly exposes an X11 or Wayland SDL backend, so the SDL
+    // driver alone cannot distinguish it from a desktop compositor. These
+    // environment values are Gamescope's platform identity.
+    return (videoDriver != nullptr && SDL_strcmp(videoDriver, "gamescope") == 0) ||
+           hasEnvironmentValue("GAMESCOPE_WAYLAND_DISPLAY") ||
+           hasEnvironmentValue("GAMESCOPE_XWAYLAND_DISPLAY");
+}
+
+bool isGamescopeWsiPresentation(const char* videoDriver)
+{
+    // The Gamescope WSI layer presents through its own Mailbox driver
+    // swapchain even when the application-facing mode is FIFO. Restrict the
+    // exception to an explicitly enabled WSI layer so ordinary X11 FIFO
+    // cannot be mistaken for adaptive presentation.
+    const char* enabled = SDL_getenv("ENABLE_GAMESCOPE_WSI");
+    return isGamescopePresentation(videoDriver) && enabled != nullptr &&
+           SDL_strcmp(enabled, "1") == 0;
+}
+
+bool isWaylandPresentation(const char* videoDriver)
+{
+    return videoDriver != nullptr && SDL_strcmp(videoDriver, "wayland") == 0 &&
+           !isGamescopePresentation(videoDriver);
+}
+
+bool isImmediatePresentation(const char* videoDriver)
+{
+    if (isGamescopePresentation(videoDriver)) {
+        return true;
+    }
+
+    return videoDriver != nullptr &&
+           (SDL_strcmp(videoDriver, "x11") == 0 ||
+            SDL_strcmp(videoDriver, "X11") == 0 ||
+            SDL_strcmp(videoDriver, "kmsdrm") == 0 ||
+            SDL_strcmp(videoDriver, "KMSDRM") == 0);
+}
+
+} // namespace
 
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(60, 26, 100)
 static const char *k_OptionalDeviceExtensions[] = {
@@ -158,7 +210,12 @@ PlVkRenderer::PlVkRenderer(AVHWDeviceType hwDeviceType, IFFmpegRenderer *backend
 
 PlVkRenderer::~PlVkRenderer()
 {
-    // The render context must have been cleaned up by now
+    // A VRR worker can be stopped between preparation and presentation. A
+    // started libplacebo frame owns an internal swapchain mutex, so release it
+    // before any of the Vulkan objects below are destroyed.
+    cancelVrrFrame();
+
+    // The render context must have been cleaned up by now.
     SDL_assert(!m_HasPendingSwapchainFrame);
 
     if (m_Vulkan != nullptr) {
@@ -494,42 +551,11 @@ bool PlVkRenderer::initialize(PDECODER_PARAMETERS params)
         return false;
     }
 
-    if (params->enableVsync) {
-        // FIFO mode improves frame pacing compared with Mailbox, especially for
-        // platforms like X11 that lack a VSyncSource implementation for Pacer.
-        m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
-    }
-    else {
-        // We want immediate mode for V-Sync disabled if possible
-        if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device, VK_PRESENT_MODE_IMMEDIATE_KHR)) {
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                        "Using Immediate present mode with V-Sync disabled");
-            m_VkPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
-        }
-        else {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Immediate present mode is not supported by the Vulkan driver. Latency may be higher than normal with V-Sync disabled.");
-
-            // FIFO Relaxed can tear if the frame is running late
-            if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device, VK_PRESENT_MODE_FIFO_RELAXED_KHR)) {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "Using FIFO Relaxed present mode with V-Sync disabled");
-                m_VkPresentMode = VK_PRESENT_MODE_FIFO_RELAXED_KHR;
-            }
-            // Mailbox at least provides non-blocking behavior
-            else if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device, VK_PRESENT_MODE_MAILBOX_KHR)) {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "Using Mailbox present mode with V-Sync disabled");
-                m_VkPresentMode = VK_PRESENT_MODE_MAILBOX_KHR;
-            }
-            // FIFO is always supported
-            else {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "Using FIFO present mode with V-Sync disabled");
-                m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
-            }
-        }
-    }
+    // Vulkan present mode is immutable for a swapchain. Select it before the
+    // first creation, rather than trying to latch a different policy per
+    // present. The legacy selection remains unchanged unless VRR was
+    // explicitly requested for this session.
+    selectPresentationMode(params);
 
     // Start with a swapchain that is double-buffered for lowest display latency
     if (!createSwapchain(1)) {
@@ -632,8 +658,153 @@ bool PlVkRenderer::initialize(PDECODER_PARAMETERS params)
 }
 
 
+void PlVkRenderer::selectLegacyPresentMode(PDECODER_PARAMETERS params)
+{
+    if (params->enableVsync) {
+        // FIFO mode improves frame pacing compared with Mailbox, especially for
+        // platforms like X11 that lack a VSyncSource implementation for Pacer.
+        m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+        return;
+    }
+
+    // We want immediate mode for V-Sync disabled if possible.
+    if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device,
+                                               VK_PRESENT_MODE_IMMEDIATE_KHR)) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Using Immediate present mode with V-Sync disabled");
+        m_VkPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+    }
+    else {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Immediate present mode is not supported by the Vulkan driver. Latency may be higher than normal with V-Sync disabled.");
+
+        // FIFO Relaxed can tear if the frame is running late.
+        if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device,
+                                                   VK_PRESENT_MODE_FIFO_RELAXED_KHR)) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Using FIFO Relaxed present mode with V-Sync disabled");
+            m_VkPresentMode = VK_PRESENT_MODE_FIFO_RELAXED_KHR;
+        }
+        // Mailbox at least provides non-blocking behavior.
+        else if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device,
+                                                        VK_PRESENT_MODE_MAILBOX_KHR)) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Using Mailbox present mode with V-Sync disabled");
+            m_VkPresentMode = VK_PRESENT_MODE_MAILBOX_KHR;
+        }
+        // FIFO is always supported.
+        else {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Using FIFO present mode with V-Sync disabled");
+            m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+        }
+    }
+}
+
+void PlVkRenderer::selectPresentationMode(PDECODER_PARAMETERS params)
+{
+    m_VrrRequested = params->enableVrr;
+    m_VrrSuspended = false;
+    m_VrrWindowChangePending.store(false);
+    m_VrrFramePrepared = false;
+    m_VrrPreparingFrame = false;
+    m_VrrRenderSucceeded = false;
+
+    if (!m_VrrRequested) {
+        selectLegacyPresentMode(params);
+        return;
+    }
+
+#ifdef Q_OS_WIN32
+    // Windows Vulkan has no validated VRR backend in this design. Force the
+    // fixed FIFO fallback even if a caller bypassed the normal session check.
+    m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+    m_VrrFallbackReason = VrrFallbackReason::WindowsVulkan;
+    return;
+#else
+    if (!params->enableVsync) {
+        m_VrrFallbackReason = VrrFallbackReason::IneffectiveVsync;
+        selectLegacyPresentMode(params);
+        return;
+    }
+
+    // The session owns this qualification snapshot. Do not query the display
+    // again here: the renderer must make the same decision as session setup
+    // for its entire lifetime.
+    if (params->vrrDisplayRefreshHz <= 0) {
+        m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+        m_VrrFallbackReason = VrrFallbackReason::InvalidRefresh;
+        return;
+    }
+
+    if (m_Vulkan == nullptr || m_Vulkan->phys_device == VK_NULL_HANDLE) {
+        m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+        m_VrrFallbackReason = VrrFallbackReason::InitializationFailed;
+        return;
+    }
+
+    if (!isRenderThreadSupported()) {
+        m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+        m_VrrFallbackReason = VrrFallbackReason::MainThreadRenderer;
+        return;
+    }
+
+    const char* videoDriver = SDL_GetCurrentVideoDriver();
+    const bool gamescopeWsi = isGamescopeWsiPresentation(videoDriver);
+    if (isWaylandPresentation(videoDriver)) {
+        // Wayland uses Mailbox when the surface reports it. Do not use
+        // Immediate as a substitute: the selection is intentionally fixed at
+        // creation and FIFO is the safe fallback for this compositor path.
+        if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device,
+                                                   VK_PRESENT_MODE_MAILBOX_KHR)) {
+            m_VkPresentMode = VK_PRESENT_MODE_MAILBOX_KHR;
+            m_VrrFallbackReason = VrrFallbackReason::NoFallback;
+            return;
+        }
+    }
+    else if (isImmediatePresentation(videoDriver)) {
+        // X11, Gamescope, and KMSDRM use Immediate when it is exposed by the
+        // selected Vulkan surface. This only describes queue behavior; it
+        // makes no claim about display adaptive-sync state.
+        if (isPresentModeSupportedByPhysicalDevice(m_Vulkan->phys_device,
+                                                   VK_PRESENT_MODE_IMMEDIATE_KHR)) {
+            m_VkPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+            m_VrrFallbackReason = VrrFallbackReason::NoFallback;
+            return;
+        }
+
+        // Gamescope WSI intentionally does not expose Immediate on current
+        // SteamOS. Its FIFO swapchain is still non-blocking because the WSI
+        // layer maps it onto Gamescope's own Mailbox driver swapchain, so
+        // adaptive pacing remains correct here.
+        if (gamescopeWsi) {
+            m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+            m_VrrFallbackReason = VrrFallbackReason::NoFallback;
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Gamescope WSI uses FIFO application presentation; retaining adaptive VRR pacing");
+            return;
+        }
+    }
+
+    // A FIFO fallback is deliberately not passed to the VRR worker: it would
+    // move presentation timing downstream of the worker's target wait.
+    m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+    m_VrrFallbackReason = VrrFallbackReason::AdaptivePresentationUnavailable;
+#endif
+}
+
+
 bool PlVkRenderer::createSwapchain(int depth)
 {
+    // libplacebo requires every successful start_frame() to be balanced by a
+    // submit before replacing its swapchain. Normally this is already false;
+    // retaining the guard makes resize and device-reset paths safe too.
+    if (m_HasPendingSwapchainFrame) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Discarding pending Vulkan swapchain frame before recreation");
+        cancelVrrFrame();
+    }
+
     pl_swapchain_destroy(&m_Swapchain);
 
     pl_vulkan_swapchain_params vkSwapchainParams = {};
@@ -885,75 +1056,283 @@ void PlVkRenderer::endRenderTiming()
 #endif
 }
 
+void PlVkRenderer::queueRenderDeviceReset()
+{
+    SDL_Event event = {};
+    event.type = SDL_RENDER_DEVICE_RESET;
+    SDL_PushEvent(&event);
+}
+
+bool PlVkRenderer::submitPendingSwapchainFrame()
+{
+    if (!m_HasPendingSwapchainFrame) {
+        return true;
+    }
+
+    // A frame is consumed even if submit reports failure. Never retry it:
+    // libplacebo's start_frame()/submit_frame() pairing is exactly once.
+    m_HasPendingSwapchainFrame = false;
+    const bool submitted = m_Swapchain != nullptr &&
+                           pl_swapchain_submit_frame(m_Swapchain);
+    SDL_zero(m_SwapchainFrame);
+    return submitted;
+}
+
+bool PlVkRenderer::acquirePendingSwapchainFrame()
+{
+#ifndef Q_OS_WIN32
+    // With libplacebo's Vulkan backend, swap_buffers() waits for queued
+    // presents. Both the legacy and VRR paths need that before acquiring an
+    // image so their final submit can remain non-blocking.
+    pl_swapchain_swap_buffers(m_Swapchain);
+#endif
+
+    int vkDrawableW;
+    int vkDrawableH;
+    SDL_Vulkan_GetDrawableSize(m_Window, &vkDrawableW, &vkDrawableH);
+    if (!pl_swapchain_resize(m_Swapchain, &vkDrawableW, &vkDrawableH)) {
+        // Swapchain (re)creation can fail while the window is occluded.
+        return false;
+    }
+
+    if (!pl_swapchain_start_frame(m_Swapchain, &m_SwapchainFrame)) {
+        return false;
+    }
+
+    m_HasPendingSwapchainFrame = true;
+
+#ifdef PLVK_USE_EARLY_RENDER_TO_WAIT
+    // Preserve the MoltenVK drawable-acquisition workaround for the rare
+    // non-Windows platform where this path is enabled. It does not present.
+    pl_frame targetFrame;
+    pl_frame_from_swapchain(&targetFrame, &m_SwapchainFrame);
+    targetFrame.num_overlays = 1;
+    targetFrame.overlays = &m_EmptyOverlay;
+
+    beginRenderTiming();
+    if (!pl_render_image(m_Renderer, nullptr, &targetFrame, &pl_render_fast_params)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "pl_render_image() failed during render wait");
+    }
+    endRenderTiming();
+#endif
+
+    return true;
+}
+
 void PlVkRenderer::waitToRender()
 {
     // Check if the GPU has failed before doing anything else
     if (pl_gpu_is_failed(m_Vulkan->gpu)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "GPU is in failed state. Recreating renderer.");
-        SDL_Event event;
-        event.type = SDL_RENDER_DEVICE_RESET;
-        SDL_PushEvent(&event);
+        queueRenderDeviceReset();
         return;
     }
 
-#ifndef Q_OS_WIN32
-    // With libplacebo's Vulkan backend, all swap_buffers does is wait for queued
-    // presents to finish. This happens to be exactly what we want to do here, since
-    // it lets us wait to select a queued frame for rendering until we know that we
-    // can present without blocking in renderFrame().
-    //
-    // NB: This seems to cause performance problems with the Windows display stack
-    // (particularly on Nvidia) so we will only do this for non-Windows platforms.
-    pl_swapchain_swap_buffers(m_Swapchain);
-#endif
-
-    // Handle the swapchain being resized
-    int vkDrawableW, vkDrawableH;
-    SDL_Vulkan_GetDrawableSize(m_Window, &vkDrawableW, &vkDrawableH);
-    if (!pl_swapchain_resize(m_Swapchain, &vkDrawableW, &vkDrawableH)) {
-        // Swapchain (re)creation can fail if the window is occluded
-        return;
-    }
-
-    // Get the next swapchain buffer for rendering. If this fails, renderFrame()
-    // will try again.
-    //
-    // NB: After calling this successfully, we *MUST* call pl_swapchain_submit_frame(),
-    // hence the implementation of cleanupRenderContext() which does just this in case
-    // renderFrame() wasn't called after waitToRender().
-    if (pl_swapchain_start_frame(m_Swapchain, &m_SwapchainFrame)) {
-        m_HasPendingSwapchainFrame = true;
-
-#ifdef PLVK_USE_EARLY_RENDER_TO_WAIT
-        // This is a workaround for MoltenVK which lazily fetches a drawable when the
-        // swapchain frame is first modified (rather than in pl_swapchain_start_frame()).
-        // By rendering an empty overlay on the swapchain here, we will trigger this wait
-        // in the desired context (before we've latched the next frame to present), rather
-        // than in the renderFrame() path where delays directly increase video latency.
-        pl_frame targetFrame;
-        pl_frame_from_swapchain(&targetFrame, &m_SwapchainFrame);
-        targetFrame.num_overlays = 1;
-        targetFrame.overlays = &m_EmptyOverlay;
-
-        beginRenderTiming();
-        if (!pl_render_image(m_Renderer, nullptr, &targetFrame, &pl_render_fast_params)) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "pl_render_image() failed during render wait");
-        }
-        endRenderTiming();
-#endif
-    }
+    acquirePendingSwapchainFrame();
 }
 
 void PlVkRenderer::cleanupRenderContext()
 {
-    // We have to submit a pending swapchain frame before shutting down
-    // in order to release a mutex that pl_swapchain_start_frame() acquires.
-    if (m_HasPendingSwapchainFrame) {
-        pl_swapchain_submit_frame(m_Swapchain);
-        m_HasPendingSwapchainFrame = false;
+    // We have to submit a pending swapchain frame before shutting down in
+    // order to release a mutex that pl_swapchain_start_frame() acquires.
+    cancelVrrFrame();
+}
+
+IVrrFramePresenter* PlVkRenderer::getVrrFramePresenter()
+{
+    // Return the presenter on every platform so a direct capability query gets
+    // the concrete Windows Vulkan rejection rather than an opaque null.
+    return this;
+}
+
+VrrFallbackReason PlVkRenderer::checkSupport() const
+{
+    // selectPresentationMode() only reports NoFallback after it committed the
+    // swapchain to an adaptive presentation mode, so there is nothing further
+    // to re-derive from the present mode or the video driver here.
+    if (m_VrrFallbackReason != VrrFallbackReason::NoFallback) {
+        return m_VrrFallbackReason;
     }
+
+    return m_VrrRequested && m_Vulkan != nullptr && m_Swapchain != nullptr &&
+        m_Renderer != nullptr ? VrrFallbackReason::NoFallback :
+        VrrFallbackReason::InitializationFailed;
+}
+
+VrrPrepareResult PlVkRenderer::prepareFrame(AVFrame* frame)
+{
+    VrrPrepareResult result;
+    if (frame == nullptr || checkSupport() != VrrFallbackReason::NoFallback ||
+            m_VrrSuspended) {
+        return result;
+    }
+
+    // The contract has one worker, but make a duplicate preparation safe.
+    if (m_VrrFramePrepared || m_HasPendingSwapchainFrame) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Vulkan VRR discarded an unpresented prepared frame");
+        result.cancellationMaySubmit = m_HasPendingSwapchainFrame;
+        return result;
+    }
+
+    // A size/display callback arrives on the main thread. Clear the current
+    // generation before acquisition; a concurrent new callback remains set
+    // and makes presentAdaptive() safely abandon this image.
+    m_VrrWindowChangePending.exchange(false);
+
+    if (m_Vulkan == nullptr || m_Vulkan->gpu == nullptr ||
+        m_Swapchain == nullptr || m_Window == nullptr) {
+        return result;
+    }
+
+    if (pl_gpu_is_failed(m_Vulkan->gpu)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "GPU is in failed state during Vulkan VRR preparation. Recreating renderer.");
+        queueRenderDeviceReset();
+        return result;
+    }
+
+    if (!acquirePendingSwapchainFrame()) {
+        return result;
+    }
+
+    if (m_VrrWindowChangePending.load()) {
+        result.cancellationMaySubmit = m_HasPendingSwapchainFrame;
+        return result;
+    }
+
+    m_VrrPreparingFrame = true;
+    m_VrrRenderSucceeded = false;
+    renderFrame(frame);
+
+    // pl_render_image() records work for the acquired image. Flush it now so
+    // GPU rendering can overlap the worker's target wait, but retain the
+    // swapchain frame: only presentAdaptive() is allowed to submit its
+    // display transition/present.
+    if (m_VrrRenderSucceeded && m_Vulkan != nullptr && m_Vulkan->gpu != nullptr) {
+        pl_gpu_flush(m_Vulkan->gpu);
+    }
+
+    m_VrrPreparingFrame = false;
+
+    if (!m_VrrRenderSucceeded || m_VrrWindowChangePending.load()) {
+        if (m_Vulkan != nullptr && m_Vulkan->gpu != nullptr &&
+            pl_gpu_is_failed(m_Vulkan->gpu)) {
+            queueRenderDeviceReset();
+        }
+        result.cancellationMaySubmit = m_HasPendingSwapchainFrame;
+        return result;
+    }
+
+    m_VrrFramePrepared = true;
+    result.prepared = true;
+    result.cancellationMaySubmit = true;
+    return result;
+}
+
+VrrPresentFeedback PlVkRenderer::presentAdaptive(const VrrPresentRequest&)
+{
+    // Vulkan presentation mode is selected when the swapchain is created, so
+    // the per-present latch preference cannot be honored here and is ignored.
+    if (!m_VrrFramePrepared || !m_HasPendingSwapchainFrame ||
+        m_VrrSuspended ||
+        m_VrrWindowChangePending.load()) {
+        return cancelFrame();
+    }
+
+    if (m_Vulkan == nullptr || m_Vulkan->gpu == nullptr ||
+        pl_gpu_is_failed(m_Vulkan->gpu)) {
+        VrrPresentFeedback feedback = cancelFrame();
+        queueRenderDeviceReset();
+        return feedback;
+    }
+
+    m_VrrFramePrepared = false;
+    const uint64_t submissionTimeUs = LiGetMicroseconds();
+    const bool submitted = submitPendingSwapchainFrame();
+
+    VrrPresentFeedback feedback;
+    if (!submitted) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "pl_swapchain_submit_frame() failed on Vulkan VRR path");
+        queueRenderDeviceReset();
+        feedback.cancelled = true;
+        return feedback;
+    }
+
+    feedback.presented = true;
+    feedback.submissionTimeValid = true;
+    feedback.submissionTimeUs = submissionTimeUs;
+    return feedback;
+}
+
+bool PlVkRenderer::cancelVrrFrame()
+{
+    const bool hadPendingFrame = m_HasPendingSwapchainFrame;
+    m_VrrPreparingFrame = false;
+    m_VrrFramePrepared = false;
+    m_VrrRenderSucceeded = false;
+
+    const bool submitted = submitPendingSwapchainFrame();
+    if (!submitted && hadPendingFrame) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "pl_swapchain_submit_frame() failed while abandoning Vulkan VRR frame");
+        if (m_VrrRequested) {
+            queueRenderDeviceReset();
+        }
+    }
+    return hadPendingFrame && submitted;
+}
+
+VrrPresentFeedback PlVkRenderer::cancelFrame()
+{
+    VrrPresentFeedback feedback;
+    feedback.cancelled = true;
+    const uint64_t submissionTimeUs = LiGetMicroseconds();
+    // A Vulkan swapchain image can only be abandoned by submitting it, so an
+    // abandoned frame really does occupy a display slot. Report it as
+    // presented so the worker advances its display-spacing floor.
+    feedback.presented = cancelVrrFrame();
+    if (feedback.presented) {
+        feedback.submissionTimeValid = true;
+        feedback.submissionTimeUs = submissionTimeUs;
+    }
+    return feedback;
+}
+
+void PlVkRenderer::setSuspended(bool suspended)
+{
+    m_VrrSuspended = suspended;
+    if (!suspended) {
+        // Re-run resize/start-frame after restoration without changing the
+        // swapchain's immutable presentation mode.
+        m_VrrWindowChangePending.store(true);
+    }
+}
+
+bool PlVkRenderer::restoreFixedPresentation(VrrFallbackReason reason)
+{
+    // Pacer calls this synchronously after it failed to create the VRR worker,
+    // before any frame or legacy render thread exists. The Vulkan present mode
+    // is immutable, so restore FIFO by recreating the swapchain rather than
+    // continuing with a Mailbox or Immediate selection under fixed pacing.
+    cancelVrrFrame();
+    m_VrrRequested = false;
+    m_VrrSuspended = false;
+    m_VrrWindowChangePending.store(false);
+    m_VrrFallbackReason = reason == VrrFallbackReason::NoFallback ?
+        VrrFallbackReason::InitializationFailed : reason;
+    m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+
+    if (!createSwapchain(1)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "Failed to recreate Vulkan FIFO swapchain after VRR worker startup failure");
+        return false;
+    }
+
+    return true;
 }
 
 void PlVkRenderer::renderFrame(AVFrame *frame)
@@ -1071,16 +1450,32 @@ void PlVkRenderer::renderFrame(AVFrame *frame)
 
 #ifndef PLVK_USE_EARLY_RENDER_TO_WAIT
     // For PLVK_USE_EARLY_RENDER_TO_WAIT, we already timed our early render in waitToRender()
+    // NB: The VRR path exits below without calling endRenderTiming(). That is
+    // harmless because PLVK_USE_DYNAMIC_SWAPCHAIN_DEPTH (which is what
+    // endRenderTiming() feeds) is only defined alongside
+    // PLVK_USE_EARLY_RENDER_TO_WAIT on Darwin, where VRR is never selected.
     beginRenderTiming();
 #endif
 
     // Render the video image and overlays into the swapchain buffer
     targetFrame.num_overlays = (int)overlays.size();
     targetFrame.overlays = overlays.data();
-    if (!pl_render_image(m_Renderer, &mappedFrame, &targetFrame, &pl_render_fast_params)) {
+    const bool renderSucceeded = pl_render_image(m_Renderer, &mappedFrame,
+                                                  &targetFrame,
+                                                  &pl_render_fast_params);
+    if (!renderSucceeded) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "pl_render_image() failed");
         // NB: We must fallthrough to call pl_swapchain_submit_frame()
+    }
+
+    if (m_VrrPreparingFrame) {
+        // The VRR worker owns the target wait. It calls presentAdaptive()
+        // later, so retain the acquired image instead of submitting here.
+        // Mapping and overlay lifetime can still end now because libplacebo
+        // retains the GPU work it recorded for the swapchain frame.
+        m_VrrRenderSucceeded = renderSucceeded;
+        goto UnmapExit;
     }
 
     // Submit the frame for display and swap buffers
@@ -1273,6 +1668,19 @@ void PlVkRenderer::notifyOverlayUpdated(Overlay::OverlayType type)
 
 bool PlVkRenderer::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info)
 {
+    if (info == nullptr) {
+        return false;
+    }
+
+    if (m_VrrRequested &&
+        (info->stateChangeFlags &
+         (WINDOW_STATE_CHANGE_SIZE | WINDOW_STATE_CHANGE_DISPLAY))) {
+        // This callback runs outside the pacing worker. Do not touch
+        // libplacebo here; the worker observes this flag before final submit
+        // and balances any acquired frame before resizing on its next prepare.
+        m_VrrWindowChangePending.store(true);
+    }
+
     // We can transparently handle size and display changes
     return !(info->stateChangeFlags & ~(WINDOW_STATE_CHANGE_SIZE | WINDOW_STATE_CHANGE_DISPLAY));
 }

--- a/app/streaming/video/ffmpeg-renderers/plvk.h
+++ b/app/streaming/video/ffmpeg-renderers/plvk.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ivrrframepresenter.h"
 #include "renderer.h"
 
 #ifdef Q_OS_WIN32
@@ -9,6 +10,8 @@
 #include <libplacebo/log.h>
 #include <libplacebo/renderer.h>
 #include <libplacebo/vulkan.h>
+
+#include <atomic>
 
 #ifdef Q_OS_DARWIN
 class MetalVulkanTextureFactory {
@@ -35,13 +38,21 @@ private:
 
 #endif
 
-class PlVkRenderer : public IFFmpegRenderer {
+class PlVkRenderer : public IFFmpegRenderer, public IVrrFramePresenter {
 public:
     PlVkRenderer(AVHWDeviceType hwDeviceType = AV_HWDEVICE_TYPE_NONE, IFFmpegRenderer *backendRenderer = nullptr);
     virtual ~PlVkRenderer() override;
     virtual bool initialize(PDECODER_PARAMETERS params) override;
     virtual bool prepareDecoderContext(AVCodecContext* context, AVDictionary** options) override;
     virtual void renderFrame(AVFrame* frame) override;
+    virtual IVrrFramePresenter* getVrrFramePresenter() override;
+    virtual VrrFallbackReason checkSupport() const override;
+    virtual VrrPrepareResult prepareFrame(AVFrame* frame) override;
+    virtual VrrPresentFeedback presentAdaptive(
+        const VrrPresentRequest& request) override;
+    virtual VrrPresentFeedback cancelFrame() override;
+    virtual void setSuspended(bool suspended) override;
+    virtual bool restoreFixedPresentation(VrrFallbackReason reason) override;
     virtual bool testRenderFrame(AVFrame* frame) override;
     virtual void waitToRender() override;
     virtual void cleanupRenderContext() override;
@@ -61,6 +72,12 @@ private:
 
     void beginRenderTiming();
     void endRenderTiming();
+    void selectPresentationMode(PDECODER_PARAMETERS params);
+    void selectLegacyPresentMode(PDECODER_PARAMETERS params);
+    bool acquirePendingSwapchainFrame();
+    bool submitPendingSwapchainFrame();
+    bool cancelVrrFrame();
+    void queueRenderDeviceReset();
 
     bool createSwapchain(int depth);
     bool createOverlay(pl_overlay* overlay, SDL_Surface* surface);
@@ -92,14 +109,14 @@ private:
     SDL_Window* m_Window = nullptr;
 
     // Stream state
-    int m_MaxVideoFps;
+    int m_MaxVideoFps = 0;
 
     // The libplacebo rendering state
     pl_log m_Log = nullptr;
     pl_vk_inst m_PlVkInstance = nullptr;
     VkSurfaceKHR m_VkSurface = VK_NULL_HANDLE;
     int m_SwapchainDepth = 0;
-    VkPresentModeKHR m_VkPresentMode;
+    VkPresentModeKHR m_VkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
     pl_vulkan m_Vulkan = nullptr;
     pl_swapchain m_Swapchain = nullptr;
     pl_renderer m_Renderer = nullptr;
@@ -111,9 +128,23 @@ private:
     pl_overlay_part m_EmptyOverlayPart = {};
 #endif
 
-    // Pending swapchain state shared between waitToRender(), renderFrame(), and cleanupRenderContext()
+    // Pending swapchain state shared between the legacy wait/render path and
+    // the VRR preparation/presentation path. A successfully started frame
+    // must always be submitted before it is resized, destroyed, or replaced.
     pl_swapchain_frame m_SwapchainFrame = {};
     bool m_HasPendingSwapchainFrame = false;
+
+    // VRR presentation state. The pacing worker is the only thread that
+    // touches the non-atomic fields after initialization. Window callbacks on
+    // the main thread only mark the atomic resize flag; the worker then safely
+    // abandons a prepared image before resizing the swapchain.
+    bool m_VrrRequested = false;
+    bool m_VrrSuspended = false;
+    VrrFallbackReason m_VrrFallbackReason = VrrFallbackReason::InitializationFailed;
+    std::atomic<bool> m_VrrWindowChangePending { false };
+    bool m_VrrPreparingFrame = false;
+    bool m_VrrFramePrepared = false;
+    bool m_VrrRenderSucceeded = false;
 
     // Overlay state
     SDL_SpinLock m_OverlayLock = 0;

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -137,6 +137,8 @@ private:
 #define RENDERER_ATTRIBUTE_NO_BUFFERING 0x08
 #define RENDERER_ATTRIBUTE_FORCE_PACING 0x10
 
+class IVrrFramePresenter;
+
 class IFFmpegRenderer : public Overlay::IOverlayRenderer {
 public:
     enum class RendererType {
@@ -256,6 +258,13 @@ public:
     virtual bool isRenderThreadSupported() {
         // Render thread is supported by default
         return true;
+    }
+
+    // Renderers opt into VRR through a separate presenter rather than changing
+    // renderFrame().  The ordinary fixed and unpaced paths continue to call
+    // renderFrame() exactly as before.
+    virtual IVrrFramePresenter* getVrrFramePresenter() {
+        return nullptr;
     }
 
     virtual bool isDirectRenderingSupported() {

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -5,6 +5,8 @@
 
 #include <h264_stream.h>
 
+#include <utility>
+
 extern "C" {
 #include <libavutil/mastering_display_metadata.h>
 #include <libavutil/pixdesc.h>
@@ -82,7 +84,37 @@ void FFmpegVideoDecoder::setHdrMode(bool enabled)
 
 bool FFmpegVideoDecoder::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info)
 {
-    return m_FrontendRenderer->notifyWindowChanged(info);
+    if (info == nullptr) {
+        return m_FrontendRenderer->notifyWindowChanged(info);
+    }
+
+    constexpr uint32_t deferredPacerFlags =
+        WINDOW_STATE_CHANGE_SIZE |
+        WINDOW_STATE_CHANGE_DISPLAY;
+    const WINDOW_STATE_CHANGE_INFO originalInfo = *info;
+
+    // Suspension must reach the worker immediately so it cannot submit
+    // another frame after a minimize/background notification. Geometry and
+    // display changes are different: the renderer first completes its
+    // synchronous refresh (D3D11) or queues the refresh that its next prepare
+    // must complete (Vulkan). Only then does the pacing worker mark the next
+    // frame as the first row of the new display epoch.
+    if (m_Pacer != nullptr &&
+            (originalInfo.stateChangeFlags & ~deferredPacerFlags) != 0) {
+        WINDOW_STATE_CHANGE_INFO pacingInfo = originalInfo;
+        pacingInfo.stateChangeFlags &= ~deferredPacerFlags;
+        m_Pacer->notifyWindowChanged(&pacingInfo);
+    }
+
+    const bool handled =
+        m_FrontendRenderer->notifyWindowChanged(info);
+    if (m_Pacer != nullptr && handled &&
+            (originalInfo.stateChangeFlags & deferredPacerFlags) != 0) {
+        WINDOW_STATE_CHANGE_INFO pacingInfo = originalInfo;
+        pacingInfo.stateChangeFlags &= deferredPacerFlags;
+        m_Pacer->notifyWindowChanged(&pacingInfo);
+    }
+    return handled;
 }
 
 int FFmpegVideoDecoder::getDecoderCapabilities()
@@ -498,7 +530,10 @@ bool FFmpegVideoDecoder::completeInitialization(const AVCodec* decoder, enum AVP
     if (testMode != TestMode::TestFrameOnly) {
         m_Pacer = new Pacer(m_FrontendRenderer, &m_ActiveWndVideoStats);
         if (!m_Pacer->initialize(params->window, params->frameRate,
-                                 params->enableFramePacing || (params->enableVsync && (m_FrontendRenderer->getRendererAttributes() & RENDERER_ATTRIBUTE_FORCE_PACING)))) {
+                                 params->enableFramePacing || (params->enableVsync && (m_FrontendRenderer->getRendererAttributes() & RENDERER_ATTRIBUTE_FORCE_PACING)),
+                                 params->enableVsync,
+                                 params->enableVrr,
+                                 params->vrrDisplayRefreshHz)) {
             return false;
         }
     }
@@ -1886,6 +1921,29 @@ void FFmpegVideoDecoder::decoderThreadProc()
                     SDL_assert(m_FrameInfoQueue.size() == m_FramesIn - m_FramesOut);
                     m_FramesOut++;
 
+                    // Only active VRR needs decoder-facing pacing metadata.
+                    // Keep legacy handoff and its AVFrame-only path unchanged.
+                    const bool vrrActive = m_Pacer->isVrrActive();
+                    uint64_t decodeCompleteUs = 0;
+                    int frameNumber = -1;
+                    uint32_t rtpTimestamp = 0;
+                    bool timestampValid = false;
+
+                    if (vrrActive) {
+                        // Capture timing while the matching DECODE_UNIT is
+                        // still available. RTP timestamp 0 is valid, so
+                        // validity is represented separately rather than
+                        // inferred from the raw value.
+                        decodeCompleteUs = LiGetMicroseconds();
+                        if (!m_FrameInfoQueue.isEmpty()) {
+                            // Snapshot without moving the legacy dequeue point.
+                            const DECODE_UNIT& du = m_FrameInfoQueue.head();
+                            frameNumber = du.frameNumber;
+                            rtpTimestamp = du.rtpTimestamp;
+                            timestampValid = true;
+                        }
+                    }
+
                     // Attach HDR metadata to the frame if it's not already present. We will defer to
                     // any metadata contained in the bitstream itself since that is guaranteed to be
                     // correctly synchronized to each frame, unlike our async HDR metadata message.
@@ -1952,26 +2010,39 @@ void FFmpegVideoDecoder::decoderThreadProc()
                     // Restore default log level after a successful decode
                     av_log_set_level(AV_LOG_INFO);
 
-                    // Capture a frame timestamp to measuring pacing delay
+                    // Keep the established legacy pacing timestamp at its
+                    // original handoff point. VRR never reads pkt_dts: its
+                    // PacedFrame carries the earlier decoder-complete stamp.
                     frame->pkt_dts = LiGetMicroseconds();
 
                     if (!m_FrameInfoQueue.isEmpty()) {
                         // Data buffers in the DU are not valid here!
                         DECODE_UNIT du = m_FrameInfoQueue.dequeue();
 
-                        // Count time in avcodec_send_packet() and avcodec_receive_frame()
-                        // as time spent decoding. Also count time spent in the decode unit
-                        // queue because that's directly caused by decoder latency.
-                        m_ActiveWndVideoStats.totalDecodeTimeUs += (LiGetMicroseconds() - du.enqueueTimeUs);
+                        // Preserve the legacy measurement point. VRR's
+                        // decode-complete timestamp above is intentionally a
+                        // separate, earlier value used only for scheduling.
+                        m_ActiveWndVideoStats.totalDecodeTimeUs +=
+                            (LiGetMicroseconds() - du.enqueueTimeUs);
 
-                        // Store the presentation time (90 kHz timebase)
+                        // Store the presentation time (90 kHz timebase) for
+                        // existing renderers. VRR uses PacedFrame instead.
                         frame->pts = (int64_t)du.rtpTimestamp;
                     }
 
                     m_ActiveWndVideoStats.decodedFrames++;
 
                     // Queue the frame for rendering (or render now if pacer is disabled)
-                    m_Pacer->submitFrame(frame);
+                    if (vrrActive) {
+                        m_Pacer->submitFrame(PacedFrame(frame,
+                                                        frameNumber,
+                                                        rtpTimestamp,
+                                                        timestampValid,
+                                                        decodeCompleteUs));
+                    }
+                    else {
+                        m_Pacer->submitFrame(frame);
+                    }
                 }
                 else if (err == AVERROR(EAGAIN)) {
                     VIDEO_FRAME_HANDLE handle;
@@ -2152,4 +2223,3 @@ void FFmpegVideoDecoder::renderFrameOnMainThread()
 {
     m_Pacer->renderOnMainThread();
 }
-

--- a/app/streaming/vrrratepolicy.cpp
+++ b/app/streaming/vrrratepolicy.cpp
@@ -1,0 +1,47 @@
+#include "vrrratepolicy.h"
+
+#include <algorithm>
+
+int VrrRatePolicy::vrrRateForRefresh(int refreshHz)
+{
+    // SDL reports zero for an unknown refresh rate, and rates at or below one
+    // cannot produce a meaningful stream-rate recommendation either.
+    if (refreshHz <= 1) {
+        return 0;
+    }
+
+    // Keep this integer-only so the documented floor behavior is stable on
+    // every supported compiler. floor(r - r^2 / 3600) is not the same as
+    // r - floor(r^2 / 3600) for rates such as 144 Hz.
+    return static_cast<int>((static_cast<long long>(refreshHz) *
+                             (3600LL - refreshHz)) / 3600LL);
+}
+
+int VrrRatePolicy::lowLatencyRateForRefresh(int refreshHz)
+{
+    if (refreshHz <= 1) {
+        return 0;
+    }
+
+    return (refreshHz / 6) * 5;
+}
+
+bool VrrRatePolicy::hasAdaptiveHeadroom(int streamRateHz, int displayRefreshHz)
+{
+    if (streamRateHz <= 0 || displayRefreshHz <= 0) {
+        return false;
+    }
+
+    constexpr long long microsecondsPerSecond = 1000000LL;
+    const auto periodForRate = [](int rateHz) {
+        const long long rate = static_cast<long long>(rateHz);
+        return std::max(1LL,
+                        (microsecondsPerSecond + rate / 2) / rate);
+    };
+
+    const long long displayPeriodUs = periodForRate(displayRefreshHz);
+    const long long streamPeriodUs = periodForRate(streamRateHz);
+    const long long guardUs = std::max(100LL,
+                                      std::min(displayPeriodUs / 64, 250LL));
+    return streamPeriodUs > displayPeriodUs + guardUs;
+}

--- a/app/streaming/vrrratepolicy.h
+++ b/app/streaming/vrrratepolicy.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// VRR rate selection and stream/display qualification live in one small policy
+// object shared by the settings UI, session startup, and Pacer. It has no
+// dependency on SDL, QSettings, or a renderer.
+class VrrRatePolicy
+{
+public:
+    // floor(refresh - refresh^2 / 3600)
+    static int vrrRateForRefresh(int refreshHz);
+
+    // floor((refresh * 5 / 6) / 5) * 5
+    static int lowLatencyRateForRefresh(int refreshHz);
+
+    // Adaptive presentation needs enough time between stream frames for one
+    // display period and the pacer's baseline safety guard. This is a
+    // deterministic session qualification, not a per-frame latching policy.
+    static bool hasAdaptiveHeadroom(int streamRateHz, int displayRefreshHz);
+};


### PR DESCRIPTION
## Summary

This adds an opt-in presentation mode for VRR-oriented streaming. Instead of
presenting on the raw decode-completion timeline, Moonlight learns the source
cadence and schedules decoded frames on a smooth playout clock with a small,
bounded readiness reserve.

The final policy is the result of many measured design iterations. Roughly 200
users tested different variations of this work across a range of systems,
display rates, stream rates, and Windows/Linux client configurations. Combined
with instrumented live traces and offline replay, that testing converged on the
version in this PR as the best overall balance of smoothness, tearing
resistance, latency, and recovery behavior.

This is a pacing and presentation policy; it does not itself enable Adaptive
Sync in the monitor, driver, compositor, or operating system. Those components
must already be configured for VRR where the selected backend uses adaptive
presentation.

## The problem

Moonlight's existing presentation choices expose two different failure modes
on VRR-oriented setups:

- Fixed V-Sync pacing quantizes presentation to a fixed vblank grid. Stream
  rates that do not divide the display rate can produce uneven repeated-frame
  cadence.
- Unpaced immediate presentation forwards host capture, encode, network, and
  decode timing variation directly into present timing. On Windows, an
  allow-tearing swapchain can then show both frame-time judder and compressed
  present intervals that tear.

The stream can have the correct average rate while still having a visibly poor
spacing distribution. A fixed delay does not solve that problem because it
moves every frame equally; the presentation timeline itself must be re-timed.

## What the final mode does

1. **Learns the source cadence.** The controller estimates the actual cadence
   from frame/RTP history instead of assuming the negotiated integer FPS is the
   exact source clock.
2. **Projects a smooth playout clock.** Frames are scheduled against that
   learned cadence instead of decode completion.
3. **Carries a bounded readiness reserve.** The reserve adapts to the observed
   late-arrival tail, attacks quickly after a miss, releases slowly, and is
   capped at the smaller of 10 ms or one source period.
4. **Learns render and scheduler lead.** Preparation and wake-up timing are
   measured separately so rendering can overlap the wait without moving the
   final submission target.
5. **Protects display spacing.** A guarded minimum submission interval prevents
   late-then-rush recovery from creating a burst of compressed presents.
6. **Uses backend-specific presentation.** The platform-neutral controller
   chooses the target time, while each renderer uses the presentation behavior
   available from its native API and window system.

The worker owns a bounded queue of decoded frames. Under sustained pressure,
suspension, resize, or a missed deadline, it may deliberately discard a frame
rather than build an unbounded latency backlog.

## D3D11 presentation policy

The Windows D3D11 renderer uses a flip-model, tearing-capable borderless
swapchain when DXGI exposes that capability. It can make a per-present choice:

- **Adaptive/immediate:** submit with `DXGI_PRESENT_ALLOW_TEARING`.
- **Latched/non-tearing:** omit `DXGI_PRESENT_ALLOW_TEARING` and use DXGI's
  synchronized presentation path.

The final tested safety boundary is display-scaled, not a fixed 1.5 ms
near-refresh threshold. D3D11 requests latched presentation when cadence
headroom is below:

`max(1.5 ms, 3 * display period)`

and uses a slightly wider exit boundary for hysteresis. On a 120 Hz display,
the entry threshold is therefore about 25 ms; in steady state this protects
roughly 30 FPS and higher cadences with the synchronized D3D path. Lower
cadences with wider headroom can use allow-tearing adaptive presentation.

This broad protection window is deliberate. Earlier immediate-present
variations produced tear storms and unstable recovery across tested systems.
The three-display-period policy performed best across the primary traces,
holdout traces, and user testing. As a result, the setting should be understood
as enabling the complete VRR-oriented pacing policy, not as a guarantee that
every D3D frame is presented through active adaptive refresh.

## Vulkan presentation policy

Vulkan present mode is selected once when the swapchain is created, so it
cannot honor D3D11's per-present latch request. The worker still smooths
submission cadence, but the WSI/compositor controls the exact physical display
transition:

- Wayland uses Mailbox when the surface exposes it.
- X11 and KMSDRM use Immediate when the surface exposes it.
- Gamescope WSI may retain FIFO because Gamescope maps the application
  swapchain into its own presentation path.
- Unsupported combinations restore a FIFO swapchain and fall back to fixed
  pacing.
- Windows Vulkan is not supported by this mode; Windows uses the validated
  D3D11 path.

Mailbox and FIFO are not immediate physical flips. The Vulkan path therefore
promises paced submissions through the selected WSI mode, not the same
physical-flip semantics as D3D11 allow-tearing presentation.

## Settings and session selection

VRR is exposed as an **Enable VRR** checkbox with these semantics:

- **V-Sync must be enabled.** The preference indicates that the user wants
  synchronized, tear-resistant presentation. The D3D backend may still use an
  allow-tearing present when the controller determines that adaptive headroom
  is sufficient.
- **Frame pacing is superseded while this mode is active.** The VRR worker owns
  presentation timing.
- **The FPS list adds calculated operating points.** Each detected refresh rate
  contributes a near-native `VRR (N FPS)` entry and a `Low-latency VRR
  (N FPS)` entry at 5/6 of native. Custom rates remain available.
- **Borderless fullscreen is forced for the session.** The saved window-mode
  preference is not modified.
- **Refresh is queried strictly.** The mode never qualifies using Moonlight's
  generic 60 Hz fallback guess.

Session startup checks the V-Sync preference, reported refresh rate, stream
headroom, renderer support, native presentation capability, and worker startup.
Moonlight does not have a portable monitor-level query proving that Adaptive
Sync is enabled. A successful capability check means the selected API path can
be used; it does not certify the connected panel or driver configuration.

If any gate rejects the mode, the session falls back to fixed V-Sync **with
frame pacing enabled**, even if the separate frame-pacing preference was off.
That fallback is intentional: a user who requested this mode asked for
synchronized presentation rather than raw immediate delivery. Sessions where
VRR is not requested retain the existing behavior.

## Validation

A representative instrumented Windows adaptive-path trace covered 67.5k live
frames on a 120 Hz VRR panel:

| Metric | Raw immediate presentation | Smoothed adaptive path |
|---|---:|---:|
| Absolute spacing error, median | ~1.4 ms | 122 us |
| Absolute spacing error, p90 | ~3.6 ms | 485 us |
| Flips more than 500 us early | ~41% | ~0% |
| Observed tearing | Persistent tear line | None |
| Pacer drops in the trace | Queue-dependent | Zero |
| Delivery skips | 5.6/s | 0.9/s |

Those figures describe that measured adaptive-path trace, not every backend,
stream rate, or latched D3D session.

Development builds also carried per-frame diagnostics and a replay harness.
Captured traces were replayed against candidate policies for the equivalent of
thousands of hours and scored for spacing error, missed slots, drops, recovery,
and latency. PresentMon and DXGI frame statistics were used on Windows to
cross-check application-side timing.

Across development, roughly 200 users exercised many variations of the pacing
design. Their results and reports were used alongside the instrumented and
replay data to select the final constants and presentation policy in this PR.
The development-only trace writer, replay harness, extended telemetry, and
native diagnostic queries were removed from the submitted diff to keep the
shipping change reviewable; the selected controller and presentation behavior
remain.

## Scope and limitations

- Windows/D3D11 has the deepest instrumented validation.
- Linux/Vulkan has substantial user testing, but physical presentation
  semantics remain WSI-, compositor-, driver-, and display-dependent.
- The feature cannot confirm that VRR is enabled in the monitor or operating
  system.
- The measured trace numbers are representative results, not universal
  guarantees.
- macOS/Metal is deliberately not included in this PR. Apple hardware was
  available, but testing and development focused on Windows and Linux.
  Built-in ProMotion uses stepped refresh behavior rather than the continuous
  VRR model targeted here, and the Metal renderer is currently being worked on
  by another contributor. To avoid overlapping that work and shipping an
  untested backend, macOS falls back to fixed pacing.
- Host capture or encode stalls longer than the bounded reserve remain visible;
  hiding them would require video-player-scale buffering.
- Reported display refresh can be virtualized or inaccurate, which can affect
  qualification and calculated FPS entries.

## Review focus

The core pacing policy has already been through extensive trace, replay, and
user testing. The most useful review areas are:

1. Native renderer lifecycle and synchronization, especially resize,
   suspension, device reset, and fallback.
2. Whether the settings communicate clearly that this is a complete
   VRR-oriented pacing policy and not a guarantee of active adaptive refresh on
   every frame.
3. Vulkan WSI behavior on additional compositor/driver combinations.
4. Coordinating any future macOS work with the contributor currently working
   on the Metal renderer; it should be a separately tested follow-up.

---

Implementation developed with Claude Code. PR description revised with
OpenAI Codex to match the final submitted behavior and validation scope.