### PR TITLE
Add Wifi/Ethernet Bitrate Selection

### DIFF
--- a/app/backend/nvcomputer.cpp
+++ b/app/backend/nvcomputer.cpp
@@ -355,7 +355,7 @@ bool NvComputer::wake() const
     return success;
 }
 
-NvComputer::ReachabilityType NvComputer::getActiveAddressReachability() const
+NvComputer::ActiveAddressRoute NvComputer::getActiveAddressRoute() const
 {
     NvAddress copyOfActiveAddress;
 
@@ -363,7 +363,7 @@ NvComputer::ReachabilityType NvComputer::getActiveAddressReachability() const
         QReadLocker readLocker(&lock);
 
         if (activeAddress.isNull()) {
-            return ReachabilityType::RI_UNKNOWN;
+            return {ReachabilityType::RI_UNKNOWN, NetworkType::NT_UNKNOWN};
         }
 
         // Grab a copy of the active address to avoid having to hold
@@ -390,26 +390,35 @@ NvComputer::ReachabilityType NvComputer::getActiveAddressReachability() const
                 if (addr.ip() == s.localAddress()) {
                     qInfo() << "Found matching interface:" << nic.humanReadableName() << nic.hardwareAddress() << nic.flags();
 
+                    NetworkType networkType = NetworkType::NT_UNKNOWN;
+
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
                     qInfo() << "Interface Type:" << nic.type();
                     qInfo() << "Interface MTU:" << nic.maximumTransmissionUnit();
 
+                    if (nic.type() == QNetworkInterface::Ethernet) {
+                        networkType = NetworkType::NT_ETHERNET;
+                    }
+                    else if (nic.type() == QNetworkInterface::Wifi) {
+                        networkType = NetworkType::NT_WIFI;
+                    }
+
                     if (nic.type() == QNetworkInterface::Virtual ||
                             nic.type() == QNetworkInterface::Ppp) {
                         // Treat PPP and virtual interfaces as likely VPNs
-                        return ReachabilityType::RI_VPN;
+                        return {ReachabilityType::RI_VPN, networkType};
                     }
 
                     if (nic.maximumTransmissionUnit() != 0 && nic.maximumTransmissionUnit() < 1500) {
                         // Treat MTUs under 1500 as likely VPNs
-                        return ReachabilityType::RI_VPN;
+                        return {ReachabilityType::RI_VPN, networkType};
                     }
 #endif
 
                     if (nic.flags() & QNetworkInterface::IsPointToPoint) {
                         // Treat point-to-point links as likely VPNs.
                         // This check detects OpenVPN on Unix-like OSes.
-                        return ReachabilityType::RI_VPN;
+                        return {ReachabilityType::RI_VPN, networkType};
                     }
 
 #ifdef Q_OS_WINDOWS
@@ -421,45 +430,50 @@ NvComputer::ReachabilityType NvComputer::getActiveAddressReachability() const
                         //  - WireguardNT VPNs
                         //  - All WinTun-based VPNs (such as Slack Nebula)
                         //  - OpenVPN with tap-windows6
-                        return ReachabilityType::RI_VPN;
+                        return {ReachabilityType::RI_VPN, networkType};
                     }
 #endif
 
                     if (nic.hardwareAddress().startsWith("00:FF", Qt::CaseInsensitive)) {
                         // OpenVPN TAP interfaces have a MAC address starting with 00:FF on Windows
-                        return ReachabilityType::RI_VPN;
+                        return {ReachabilityType::RI_VPN, networkType};
                     }
 
                     if (nic.humanReadableName().startsWith("ZeroTier")) {
                         // ZeroTier interfaces always start with "ZeroTier"
-                        return ReachabilityType::RI_VPN;
+                        return {ReachabilityType::RI_VPN, networkType};
                     }
 
                     if (nic.humanReadableName().contains("VPN")) {
                         // This one is just a final VPN heuristic if all else fails
-                        return ReachabilityType::RI_VPN;
+                        return {ReachabilityType::RI_VPN, networkType};
                     }
 
                     // Didn't meet any of our VPN heuristics. Let's see if the peer address is on-link.
                     Q_ASSERT(addr.prefixLength() >= 0);
                     if (addr.prefixLength() >= 0 && s.localAddress().isInSubnet(s.peerAddress(), addr.prefixLength())) {
-                        return ReachabilityType::RI_LAN;
+                        return {ReachabilityType::RI_LAN, networkType};
                     }
 
                     // Default to unknown if nothing else matched
-                    return ReachabilityType::RI_UNKNOWN;
+                    return {ReachabilityType::RI_UNKNOWN, networkType};
                 }
             }
         }
 
         qWarning() << "No match found for address:" << s.localAddress();
-        return ReachabilityType::RI_UNKNOWN;
+        return {ReachabilityType::RI_UNKNOWN, NetworkType::NT_UNKNOWN};
     }
     else {
         // If we fail to connect, just pretend that it's not a VPN
         qWarning() << "Unable to check for reachability within 3 seconds";
-        return ReachabilityType::RI_UNKNOWN;
+        return {ReachabilityType::RI_UNKNOWN, NetworkType::NT_UNKNOWN};
     }
+}
+
+NvComputer::ReachabilityType NvComputer::getActiveAddressReachability() const
+{
+    return getActiveAddressRoute().reachability;
 }
 
 bool NvComputer::updateAppList(QVector<NvApp> newAppList) {

--- a/app/backend/nvcomputer.h
+++ b/app/backend/nvcomputer.h
@@ -60,6 +60,22 @@ public:
         RI_VPN,
     };
 
+    enum NetworkType
+    {
+        NT_UNKNOWN,
+        NT_ETHERNET,
+        NT_WIFI,
+    };
+
+    struct ActiveAddressRoute
+    {
+        ReachabilityType reachability;
+        NetworkType networkType;
+    };
+
+    ActiveAddressRoute
+    getActiveAddressRoute() const;
+
     ReachabilityType
     getActiveAddressReachability() const;
 

--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -349,6 +349,7 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.addToggleOption("vsync", "V-Sync");
     parser.addValueOption("fps", "FPS");
     parser.addValueOption("bitrate", "bitrate in Kbps");
+    parser.addValueOption("wifi-bitrate", "bitrate in Kbps for Wi-Fi and other non-Ethernet connections");
     parser.addValueOption("packet-size", "video packet size");
     parser.addChoiceOption("display-mode", "display mode", m_WindowModeMap.keys());
     parser.addChoiceOption("audio-config", "audio config", m_AudioConfigMap.keys());
@@ -417,9 +418,23 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
         if (!inRange(preferences->bitrateKbps, 500, 500000)) {
             fprintf(stderr, "Warning: Bitrate is out of the supported range (500 - 500000 Kbps). Performance may suffer!\n");
         }
+
+        // An explicit fixed bitrate should take precedence over the saved
+        // network-aware setting unless --wifi-bitrate is also provided.
+        preferences->useWifiBitrate = false;
     } else if (displaySet || parser.isSet("fps")) {
         preferences->bitrateKbps = preferences->getDefaultBitrate(
             preferences->width, preferences->height, preferences->fps, preferences->enableYUV444);
+    }
+
+    // Resolve --wifi-bitrate option
+    if (parser.isSet("wifi-bitrate")) {
+        preferences->wifiBitrateKbps = parser.getIntOption("wifi-bitrate");
+        if (!inRange(preferences->wifiBitrateKbps, 500, 500000)) {
+            fprintf(stderr, "Warning: Wi-Fi bitrate is out of the supported range (500 - 500000 Kbps). Performance may suffer!\n");
+        }
+
+        preferences->useWifiBitrate = true;
     }
 
     // Resolve --packet-size option

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -669,7 +669,9 @@ Flickable {
                 Label {
                     width: parent.width
                     id: bitrateTitle
-                    text: qsTr("Video bitrate:")
+                    text: StreamingPreferences.useWifiBitrate ?
+                              qsTr("Ethernet video bitrate: %1 Mbps").arg(slider.value / 1000.0) :
+                              qsTr("Video bitrate: %1 Mbps").arg(slider.value / 1000.0)
                     font.pointSize: 12
                     wrapMode: Text.Wrap
                 }
@@ -699,7 +701,6 @@ Flickable {
                         width: Math.min(bitrateDesc.implicitWidth, parent.width - (resetBitrateButton.visible ? resetBitrateButton.width + parent.spacing : 0))
 
                         onValueChanged: {
-                            bitrateTitle.text = qsTr("Video bitrate: %1 Mbps").arg(value / 1000.0)
                             StreamingPreferences.bitrateKbps = value
                         }
 
@@ -723,6 +724,61 @@ Flickable {
                             StreamingPreferences.autoAdjustBitrate = true
                             slider.value = defaultBitrate
                         }
+                    }
+                }
+
+                CheckBox {
+                    id: useWifiBitrate
+                    width: parent.width
+                    text: qsTr("Use a separate bitrate for Wi-Fi")
+                    font.pointSize: 12
+
+                    checked: StreamingPreferences.useWifiBitrate
+                    onCheckedChanged: {
+                        if (StreamingPreferences.useWifiBitrate !== checked) {
+                            StreamingPreferences.useWifiBitrate = checked
+                        }
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("The primary bitrate is used only when the route to the host is detected as Ethernet. Wi-Fi, VPN, and unknown connection types use the safer Wi-Fi bitrate.")
+                }
+
+                Label {
+                    width: parent.width
+                    id: wifiBitrateTitle
+                    text: qsTr("Wi-Fi video bitrate: %1 Mbps").arg(wifiBitrateSlider.value / 1000.0)
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                    visible: useWifiBitrate.checked
+                }
+
+                Label {
+                    width: parent.width
+                    id: wifiBitrateDesc
+                    text: qsTr("Used for Wi-Fi and whenever an Ethernet route cannot be confirmed.")
+                    font.pointSize: 9
+                    wrapMode: Text.Wrap
+                    visible: useWifiBitrate.checked
+                }
+
+                Slider {
+                    id: wifiBitrateSlider
+                    width: Math.min(wifiBitrateDesc.implicitWidth, parent.width)
+                    visible: useWifiBitrate.checked
+
+                    value: StreamingPreferences.wifiBitrateKbps
+
+                    stepSize: 500
+                    from: 500
+                    to: StreamingPreferences.unlockBitrate ? 500000 : 150000
+
+                    snapMode: "SnapOnRelease"
+
+                    onValueChanged: {
+                        StreamingPreferences.wifiBitrateKbps = value
                     }
                 }
 
@@ -1752,7 +1808,9 @@ Flickable {
                     onCheckedChanged: {
                         StreamingPreferences.unlockBitrate = checked
                         StreamingPreferences.bitrateKbps = Math.min(StreamingPreferences.bitrateKbps, slider.to)
+                        StreamingPreferences.wifiBitrateKbps = Math.min(StreamingPreferences.wifiBitrateKbps, wifiBitrateSlider.to)
                         slider.value = StreamingPreferences.bitrateKbps
+                        wifiBitrateSlider.value = StreamingPreferences.wifiBitrateKbps
                     }
 
                     ToolTip.delay: 1000

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -15,6 +15,8 @@
 #define SER_HEIGHT "height"
 #define SER_FPS "fps"
 #define SER_BITRATE "bitrate"
+#define SER_WIFI_BITRATE "wifibitrate"
+#define SER_USE_WIFI_BITRATE "usewifibitrate"
 #define SER_UNLOCK_BITRATE "unlockbitrate"
 #define SER_AUTOADJUSTBITRATE "autoadjustbitrate"
 #define SER_FULLSCREEN "fullscreen"
@@ -127,6 +129,8 @@ void StreamingPreferences::reload()
     fps = settings.value(SER_FPS, 60).toInt();
     enableYUV444 = settings.value(SER_YUV444, false).toBool();
     bitrateKbps = settings.value(SER_BITRATE, getDefaultBitrate(width, height, fps, enableYUV444)).toInt();
+    wifiBitrateKbps = settings.value(SER_WIFI_BITRATE, qMin(bitrateKbps, 20000)).toInt();
+    useWifiBitrate = settings.value(SER_USE_WIFI_BITRATE, false).toBool();
     unlockBitrate = settings.value(SER_UNLOCK_BITRATE, false).toBool();
     autoAdjustBitrate = settings.value(SER_AUTOADJUSTBITRATE, true).toBool();
     enableVsync = settings.value(SER_VSYNC, true).toBool();
@@ -327,6 +331,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_HEIGHT, height);
     settings.setValue(SER_FPS, fps);
     settings.setValue(SER_BITRATE, bitrateKbps);
+    settings.setValue(SER_WIFI_BITRATE, wifiBitrateKbps);
+    settings.setValue(SER_USE_WIFI_BITRATE, useWifiBitrate);
     settings.setValue(SER_UNLOCK_BITRATE, unlockBitrate);
     settings.setValue(SER_AUTOADJUSTBITRATE, autoAdjustBitrate);
     settings.setValue(SER_VSYNC, enableVsync);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -123,6 +123,8 @@ public:
     Q_PROPERTY(int height MEMBER height NOTIFY displayModeChanged)
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
     Q_PROPERTY(int bitrateKbps MEMBER bitrateKbps NOTIFY bitrateChanged)
+    Q_PROPERTY(int wifiBitrateKbps MEMBER wifiBitrateKbps NOTIFY wifiBitrateChanged)
+    Q_PROPERTY(bool useWifiBitrate MEMBER useWifiBitrate NOTIFY useWifiBitrateChanged)
     Q_PROPERTY(bool unlockBitrate MEMBER unlockBitrate NOTIFY unlockBitrateChanged)
     Q_PROPERTY(bool autoAdjustBitrate MEMBER autoAdjustBitrate NOTIFY autoAdjustBitrateChanged)
     Q_PROPERTY(bool enableVsync MEMBER enableVsync NOTIFY enableVsyncChanged)
@@ -165,6 +167,8 @@ public:
     int height;
     int fps;
     int bitrateKbps;
+    int wifiBitrateKbps;
+    bool useWifiBitrate;
     bool unlockBitrate;
     bool autoAdjustBitrate;
     bool enableVsync;
@@ -204,6 +208,8 @@ public:
 signals:
     void displayModeChanged();
     void bitrateChanged();
+    void wifiBitrateChanged();
+    void useWifiBitrateChanged();
     void unlockBitrateChanged();
     void autoAdjustBitrateChanged();
     void enableVsyncChanged();
@@ -246,4 +252,3 @@ private:
 
     QQmlEngine* m_QmlEngine;
 };
-

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -694,10 +694,6 @@ bool Session::initialize(QQuickWindow* qtWindow)
     }
 #endif
 
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "Video bitrate: %d kbps",
-                m_StreamConfig.bitrate);
-
     RAND_bytes(reinterpret_cast<unsigned char*>(m_StreamConfig.remoteInputAesKey),
                sizeof(m_StreamConfig.remoteInputAesKey));
 
@@ -1651,6 +1647,43 @@ bool Session::startConnectionAsync()
         hostInfo.rtspSessionUrl = rtspSessionUrlStr.data();
     }
 
+    NvComputer::ActiveAddressRoute activeAddressRoute = {
+        NvComputer::ReachabilityType::RI_UNKNOWN,
+        NvComputer::NetworkType::NT_UNKNOWN,
+    };
+
+    // Route detection does network I/O, so only perform it after we've already
+    // contacted the PC successfully. Reuse the result for packet-size selection.
+    if (m_Preferences->useWifiBitrate || m_Preferences->packetSize == 0) {
+        activeAddressRoute = m_Computer->getActiveAddressRoute();
+    }
+
+    if (m_Preferences->useWifiBitrate) {
+        if (activeAddressRoute.networkType == NvComputer::NetworkType::NT_ETHERNET &&
+                activeAddressRoute.reachability != NvComputer::ReachabilityType::RI_VPN) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Ethernet route detected; using configured Ethernet bitrate");
+        }
+        else {
+            m_StreamConfig.bitrate = m_Preferences->wifiBitrateKbps;
+
+            if (activeAddressRoute.networkType == NvComputer::NetworkType::NT_WIFI) {
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                            "Wi-Fi route detected; using configured Wi-Fi bitrate");
+            }
+            else if (activeAddressRoute.reachability == NvComputer::ReachabilityType::RI_VPN) {
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                            "VPN route detected; using configured Wi-Fi bitrate");
+            }
+            else {
+                // Only permit the potentially very high primary bitrate when the
+                // route is positively identified as Ethernet.
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "Non-Ethernet or unknown route detected; using configured Wi-Fi bitrate");
+            }
+        }
+    }
+
     if (m_Preferences->packetSize != 0) {
         // Override default packet size and remote streaming detection
         // NB: Using STREAM_CFG_AUTO will cap our packet size at 1024 for remote hosts.
@@ -1664,9 +1697,7 @@ bool Session::startConnectionAsync()
         // Use 1392 byte video packets by default
         m_StreamConfig.packetSize = 1392;
 
-        // getActiveAddressReachability() does network I/O, so we only attempt to check
-        // reachability if we've already contacted the PC successfully.
-        switch (m_Computer->getActiveAddressReachability()) {
+        switch (activeAddressRoute.reachability) {
         case NvComputer::RI_LAN:
             // This address is on-link, so treat it as a local address
             // even if it's not in RFC 1918 space or it's an IPv6 address.
@@ -1702,6 +1733,10 @@ bool Session::startConnectionAsync()
                                                                          m_StreamConfig.fps,
                                                                          false);
     }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Video bitrate: %d kbps",
+                m_StreamConfig.bitrate);
 
     int err = LiStartConnection(&hostInfo, &m_StreamConfig, &k_ConnCallbacks,
                                 &m_VideoCallbacks, &m_AudioCallbacks,


### PR DESCRIPTION
This PR adds settings options for different streaming bitrate depending on the Network Interface.

This is useful in cases where a user uses a device in both handheld (Wi-Fi) and docked (Ethernet) modes and may want to have a maxed out bitrate for Ethernet while falling back to something more sensible for Wifi. 

Tested on Macbook Pro w/MacOS 26.6 (25G72) against Windows server. 

<img width="556" height="346" alt="Screenshot 2026-08-04 at 12 41 36 PM" src="https://github.com/user-attachments/assets/c62eeaeb-2d19-4188-98dc-150880f21486" />
