### PR TITLE
Redesign performance stats overlay as a compact HUD panel

### DIFF
--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -976,6 +976,96 @@ void FFmpegVideoDecoder::stringifyVideoStats(VIDEO_STATS& stats, char* output, i
     }
 }
 
+// Compact variant of stringifyVideoStats() used for the on-screen overlay.
+// Three short lines instead of a diagnostic dump; the full form remains in logs.
+void FFmpegVideoDecoder::stringifyVideoStatsCompact(VIDEO_STATS& stats, char* output, int length)
+{
+    int offset = 0;
+    int ret;
+
+    output[0] = 0;
+
+    const char* codecString;
+    switch (m_VideoFormat) {
+    case VIDEO_FORMAT_H264:
+    case VIDEO_FORMAT_H264_HIGH8_444:
+        codecString = "H.264";
+        break;
+    case VIDEO_FORMAT_H265:
+    case VIDEO_FORMAT_H265_REXT8_444:
+        codecString = "HEVC";
+        break;
+    case VIDEO_FORMAT_H265_MAIN10:
+    case VIDEO_FORMAT_H265_REXT10_444:
+        codecString = LiGetCurrentHostDisplayHdrMode() ? "HEVC HDR" : "HEVC 10";
+        break;
+    case VIDEO_FORMAT_AV1_MAIN8:
+    case VIDEO_FORMAT_AV1_HIGH8_444:
+        codecString = "AV1";
+        break;
+    case VIDEO_FORMAT_AV1_MAIN10:
+    case VIDEO_FORMAT_AV1_HIGH10_444:
+        codecString = LiGetCurrentHostDisplayHdrMode() ? "AV1 HDR" : "AV1 10";
+        break;
+    default:
+        codecString = "?";
+        break;
+    }
+
+    if (stats.receivedFps > 0 && m_VideoDecoderCtx != nullptr) {
+        ret = snprintf(&output[offset], length - offset,
+                       "%dx%d  %s  %.0f FPS\n",
+                       m_VideoDecoderCtx->width,
+                       m_VideoDecoderCtx->height,
+                       codecString,
+                       stats.renderedFps);
+        if (ret < 0 || ret >= length - offset) {
+            return;
+        }
+        offset += ret;
+    }
+
+    if (stats.renderedFrames != 0) {
+        if (stats.lastRtt != 0) {
+            ret = snprintf(&output[offset], length - offset,
+                           "PING %u ms   DECODE %.1f ms   RENDER %.1f ms\n",
+                           stats.lastRtt,
+                           (double)(stats.totalDecodeTimeUs / 1000.0) / stats.decodedFrames,
+                           (double)(stats.totalRenderTimeUs / 1000.0) / stats.renderedFrames);
+        }
+        else {
+            ret = snprintf(&output[offset], length - offset,
+                           "DECODE %.1f ms   RENDER %.1f ms\n",
+                           (double)(stats.totalDecodeTimeUs / 1000.0) / stats.decodedFrames,
+                           (double)(stats.totalRenderTimeUs / 1000.0) / stats.renderedFrames);
+        }
+        if (ret < 0 || ret >= length - offset) {
+            return;
+        }
+        offset += ret;
+
+        float lossPct = (float)stats.networkDroppedFrames / stats.totalFrames * 100;
+        float jitterPct = (float)stats.pacerDroppedFrames / stats.decodedFrames * 100;
+        if (stats.framesWithHostProcessingLatency > 0) {
+            ret = snprintf(&output[offset], length - offset,
+                           "HOST %.1f ms   LOSS %.1f%%   JITTER %.1f%%",
+                           (float)stats.totalHostProcessingLatency / 10 / stats.framesWithHostProcessingLatency,
+                           lossPct,
+                           jitterPct);
+        }
+        else {
+            ret = snprintf(&output[offset], length - offset,
+                           "LOSS %.1f%%   JITTER %.1f%%",
+                           lossPct,
+                           jitterPct);
+        }
+        if (ret < 0 || ret >= length - offset) {
+            return;
+        }
+        offset += ret;
+    }
+}
+
 void FFmpegVideoDecoder::logVideoStats(VIDEO_STATS& stats, const char* title)
 {
     if (stats.renderedFps > 0 || stats.renderedFrames != 0) {
@@ -2126,9 +2216,9 @@ int FFmpegVideoDecoder::submitDecodeUnit(PDECODE_UNIT du)
             addVideoStats(m_LastWndVideoStats, lastTwoWndStats);
             addVideoStats(m_ActiveWndVideoStats, lastTwoWndStats);
 
-            stringifyVideoStats(lastTwoWndStats,
-                                Session::get()->getOverlayManager().getOverlayText(Overlay::OverlayDebug),
-                                Session::get()->getOverlayManager().getOverlayMaxTextLength());
+            stringifyVideoStatsCompact(lastTwoWndStats,
+                                       Session::get()->getOverlayManager().getOverlayText(Overlay::OverlayDebug),
+                                       Session::get()->getOverlayManager().getOverlayMaxTextLength());
             Session::get()->getOverlayManager().setOverlayTextUpdated(Overlay::OverlayDebug);
         }
 

--- a/app/streaming/video/ffmpeg.h
+++ b/app/streaming/video/ffmpeg.h
@@ -52,6 +52,8 @@ private:
 
     void stringifyVideoStats(VIDEO_STATS& stats, char* output, int length);
 
+    void stringifyVideoStatsCompact(VIDEO_STATS& stats, char* output, int length);
+
     void logVideoStats(VIDEO_STATS& stats, const char* title);
 
     void addVideoStats(VIDEO_STATS& src, VIDEO_STATS& dst);

--- a/app/streaming/video/overlaymanager.cpp
+++ b/app/streaming/video/overlaymanager.cpp
@@ -1,6 +1,8 @@
 #include "overlaymanager.h"
 #include "path.h"
 
+#include <QFile>
+
 using namespace Overlay;
 
 OverlayManager::OverlayManager() :
@@ -9,8 +11,16 @@ OverlayManager::OverlayManager() :
 {
     memset(m_Overlays, 0, sizeof(m_Overlays));
 
-    m_Overlays[OverlayType::OverlayDebug].color = {0xD0, 0xD0, 0x00, 0xFF};
-    m_Overlays[OverlayType::OverlayDebug].fontSize = 20;
+#ifdef Q_OS_WIN32
+    // Prefer a clean system UI font for the stats panel when available
+    QFile segoeFont("C:/Windows/Fonts/segoeui.ttf");
+    if (segoeFont.open(QIODevice::ReadOnly)) {
+        m_DebugFontData = segoeFont.readAll();
+    }
+#endif
+
+    m_Overlays[OverlayType::OverlayDebug].color = {0xF0, 0xF3, 0xF8, 0xFF};
+    m_Overlays[OverlayType::OverlayDebug].fontSize = 17;
 
     m_Overlays[OverlayType::OverlayStatusUpdate].color = {0xCC, 0x00, 0x00, 0xFF};
     m_Overlays[OverlayType::OverlayStatusUpdate].fontSize = 36;
@@ -124,14 +134,18 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
 
     // Construct the required font to render the overlay
     if (m_Overlays[type].font == nullptr) {
-        if (m_FontData.isEmpty()) {
+        // The debug overlay prefers the system UI font when one was loaded
+        QByteArray& fontData = (type == OverlayType::OverlayDebug && !m_DebugFontData.isEmpty()) ?
+                    m_DebugFontData : m_FontData;
+
+        if (fontData.isEmpty()) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                          "SDL overlay font failed to load");
             return;
         }
 
-        // m_FontData must stay around until the font is closed
-        m_Overlays[type].font = TTF_OpenFontRW(SDL_RWFromConstMem(m_FontData.constData(), m_FontData.size()),
+        // fontData must stay around until the font is closed
+        m_Overlays[type].font = TTF_OpenFontRW(SDL_RWFromConstMem(fontData.constData(), fontData.size()),
                                                1,
                                                m_Overlays[type].fontSize);
         if (m_Overlays[type].font == nullptr) {
@@ -145,17 +159,27 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
     }
 
     // Exchange the old surface with the new one
-    SDL_Surface* oldSurface = (SDL_Surface*)SDL_AtomicSetPtr(
-        (void**)&m_Overlays[type].surface,
-        m_Overlays[type].enabled ?
+    SDL_Surface* newSurface = nullptr;
+    if (m_Overlays[type].enabled) {
+        if (type == OverlayType::OverlayDebug) {
+            // The stats overlay renders as a compact panel instead of outlined text
+            newSurface = RenderStatsPanel(m_Overlays[type].font,
+                                          m_Overlays[type].text,
+                                          m_Overlays[type].color,
+                                          1024);
+        }
+        else {
             // The _Wrapped variant is required for line breaks to work
-            RenderTextOutlinedWrapped(m_Overlays[type].font,
-                                      m_Overlays[type].text,
-                                      m_Overlays[type].color,
-                                      {0, 0, 0, 255},
-                                      4,
-                                      1024)
-            : nullptr);
+            newSurface = RenderTextOutlinedWrapped(m_Overlays[type].font,
+                                                   m_Overlays[type].text,
+                                                   m_Overlays[type].color,
+                                                   {0, 0, 0, 255},
+                                                   4,
+                                                   1024);
+        }
+    }
+    SDL_Surface* oldSurface = (SDL_Surface*)SDL_AtomicSetPtr(
+        (void**)&m_Overlays[type].surface, newSurface);
 
     // Notify the renderer
     m_Renderer->notifyOverlayUpdated(type);
@@ -164,6 +188,65 @@ void OverlayManager::notifyOverlayUpdated(OverlayType type)
     if (oldSurface != nullptr) {
         SDL_FreeSurface(oldSurface);
     }
+}
+
+// Render overlay text as a compact panel: translucent dark card with rounded
+// corners and an accent bar, in the style of typical performance HUDs.
+SDL_Surface* OverlayManager::RenderStatsPanel(TTF_Font* font, const char* text, SDL_Color textColor, int wrapWidth)
+{
+    if (text == nullptr || text[0] == '\0') {
+        return nullptr;
+    }
+
+    SDL_Surface* textSurface = TTF_RenderUTF8_Blended_Wrapped(font, text, textColor, wrapWidth);
+    if (textSurface == nullptr) {
+        return nullptr;
+    }
+
+    constexpr int kPadX = 14;
+    constexpr int kPadY = 10;
+    constexpr int kAccent = 3;   // width of the accent bar on the left edge
+    constexpr int kRadius = 9;   // corner radius
+
+    int w = textSurface->w + kAccent + 2 * kPadX;
+    int h = textSurface->h + 2 * kPadY;
+
+    SDL_Surface* panel = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32, SDL_PIXELFORMAT_ARGB8888);
+    if (panel == nullptr) {
+        SDL_FreeSurface(textSurface);
+        return nullptr;
+    }
+
+    // Card background
+    SDL_FillRect(panel, nullptr, SDL_MapRGBA(panel->format, 0x0C, 0x0E, 0x14, 0xD0));
+
+    // Accent bar (left edge)
+    SDL_Rect accentRect = { 0, 0, kAccent, h };
+    SDL_FillRect(panel, &accentRect, SDL_MapRGBA(panel->format, 0x10, 0x89, 0x3E, 0xFF));
+
+    // Round the corners by clearing pixels outside each corner's arc
+    SDL_LockSurface(panel);
+    Uint32* pixels = (Uint32*)panel->pixels;
+    int pitch = panel->pitch / 4;
+    for (int cy = 0; cy < kRadius; cy++) {
+        for (int cx = 0; cx < kRadius; cx++) {
+            int dx = kRadius - 1 - cx;
+            int dy = kRadius - 1 - cy;
+            if (dx * dx + dy * dy > kRadius * kRadius) {
+                pixels[cy * pitch + cx] = 0;                          // top-left
+                pixels[cy * pitch + (w - 1 - cx)] = 0;                // top-right
+                pixels[(h - 1 - cy) * pitch + cx] = 0;                // bottom-left
+                pixels[(h - 1 - cy) * pitch + (w - 1 - cx)] = 0;      // bottom-right
+            }
+        }
+    }
+    SDL_UnlockSurface(panel);
+
+    SDL_Rect dst = { kAccent + kPadX, kPadY, textSurface->w, textSurface->h };
+    SDL_BlitSurface(textSurface, nullptr, panel, &dst);
+    SDL_FreeSurface(textSurface);
+
+    return panel;
 }
 
 SDL_Surface* OverlayManager::RenderTextOutlinedWrapped(TTF_Font* font, const char* text, SDL_Color textColor, SDL_Color outlineColor, int outlineWidth, int wrapWidth) {

--- a/app/streaming/video/overlaymanager.cpp
+++ b/app/streaming/video/overlaymanager.cpp
@@ -203,13 +203,27 @@ SDL_Surface* OverlayManager::RenderStatsPanel(TTF_Font* font, const char* text, 
         return nullptr;
     }
 
+    // The wrapped render surface can be as wide as wrapWidth; measure the widest
+    // actual line so the card hugs the text instead of painting the whole surface.
+    int textW = 0;
+    for (const QString& line : QString(text).split('\n')) {
+        int lineW = 0, lineH = 0;
+        if (!line.isEmpty() && TTF_SizeUTF8(font, line.toUtf8(), &lineW, &lineH) == 0) {
+            textW = qMax(textW, lineW);
+        }
+    }
+    if (textW == 0 || textW > textSurface->w) {
+        textW = textSurface->w;
+    }
+    int textH = textSurface->h;
+
     constexpr int kPadX = 14;
     constexpr int kPadY = 10;
     constexpr int kAccent = 3;   // width of the accent bar on the left edge
     constexpr int kRadius = 9;   // corner radius
 
-    int w = textSurface->w + kAccent + 2 * kPadX;
-    int h = textSurface->h + 2 * kPadY;
+    int w = textW + kAccent + 2 * kPadX;
+    int h = textH + 2 * kPadY;
 
     SDL_Surface* panel = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32, SDL_PIXELFORMAT_ARGB8888);
     if (panel == nullptr) {
@@ -242,8 +256,9 @@ SDL_Surface* OverlayManager::RenderStatsPanel(TTF_Font* font, const char* text, 
     }
     SDL_UnlockSurface(panel);
 
-    SDL_Rect dst = { kAccent + kPadX, kPadY, textSurface->w, textSurface->h };
-    SDL_BlitSurface(textSurface, nullptr, panel, &dst);
+    SDL_Rect src = { 0, 0, textW, textH };
+    SDL_Rect dst = { kAccent + kPadX, kPadY, textW, textH };
+    SDL_BlitSurface(textSurface, &src, panel, &dst);
     SDL_FreeSurface(textSurface);
 
     return panel;

--- a/app/streaming/video/overlaymanager.h
+++ b/app/streaming/video/overlaymanager.h
@@ -42,6 +42,7 @@ public:
 private:
     void notifyOverlayUpdated(OverlayType type);
     SDL_Surface* RenderTextOutlinedWrapped(TTF_Font* font, const char* text, SDL_Color textColor, SDL_Color outlineColor, int outlineWidth, int wrapWidth);
+    SDL_Surface* RenderStatsPanel(TTF_Font* font, const char* text, SDL_Color textColor, int wrapWidth);
 
     struct {
         bool enabled;
@@ -54,6 +55,7 @@ private:
     } m_Overlays[OverlayMax];
     IOverlayRenderer* m_Renderer;
     QByteArray m_FontData;
+    QByteArray m_DebugFontData;
 };
 
 }


### PR DESCRIPTION
## Motivation

The debug/stats overlay currently renders ~10 lines of verbose diagnostic text in a large outlined font, which covers a substantial part of the stream and reads more like a log dump than a HUD. For the common use case — glancing at FPS/latency/loss while playing — most of it is noise.

## Change

Renders the stats overlay as a compact three-line panel in the style of typical performance HUDs (GeForce/Game Bar-like):

```
1920x1080  HEVC  60 FPS
PING 5 ms   DECODE 1.1 ms   RENDER 2.4 ms
HOST 3.2 ms   LOSS 0.0%   JITTER 0.1%
```

- Translucent rounded dark card with a small accent bar, sized to the text.
- Uses the system UI font (Segoe UI) on Windows when available; falls back to the bundled ModeSeven everywhere else.
- Implemented entirely in `OverlayManager` + a new `stringifyVideoStatsCompact()`, so every renderer backend gets it with no per-renderer changes.
- The full verbose stats text is unchanged for logging (`logVideoStats`).

## Notes

- `OverlayStatusUpdate` rendering is untouched.
- If you'd prefer the compact panel behind a setting (keeping the verbose overlay as default), happy to rework it that way — went with replace-by-default since the verbose data remains available in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)