### PR TITLE
[Feat] Introduce Bluetooth Controller for no desktop installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ for different architectures, which handle building deps and extra linking for yo
     * To build from the command line for development use on macOS or Linux, run `qmake6 moonlight-qt.pro` then `make debug` or `make release`.
         * The final binary will be placed in `app/moonlight`.
     * To create an embedded build for a single-purpose device, use `qmake6 "CONFIG+=embedded" moonlight-qt.pro` and build normally.
-        * This build will lack windowed mode, Discord/Help links, and other features that don't make sense on an embedded device.
+        * This build will lack windowed mode, Discord/Help links, and other features that don't make sense on an embedded device. 
+        * On Linux, it additionally gains a BlueZ-backed Bluetooth pairing view for devices with no desktop environment to pair a controller from. 
+        Add `"CONFIG+=disable-bluez"` to leave it out.
         * For platforms with poor GPU performance, add `"CONFIG+=gpuslow"` to prefer direct KMSDRM rendering over GL/Vulkan renderers. Direct KMSDRM rendering can use dedicated YUV/RGB conversion and scaling hardware rather than slower GPU shaders for these operations.
 
 ## Contribute

--- a/app/app.pro
+++ b/app/app.pro
@@ -61,7 +61,8 @@ macx:!disable-prebuilts {
     LIBS += -L$$PWD/../libs/mac/lib
 }
 
-unix:!macx {
+# Bluetooth pairing targets single-purpose devices
+unix:!macx:embedded {
     # BlueZ is controlled over D-Bus
     !disable-bluez {
         qtHaveModule(dbus) {

--- a/app/app.pro
+++ b/app/app.pro
@@ -61,6 +61,18 @@ macx:!disable-prebuilts {
     LIBS += -L$$PWD/../libs/mac/lib
 }
 
+unix:!macx {
+    # BlueZ is controlled over D-Bus
+    !disable-bluez {
+        qtHaveModule(dbus) {
+            message(BlueZ Bluetooth device management enabled)
+
+            QT += dbus
+            DEFINES += HAVE_BLUEZ
+        }
+    }
+}
+
 unix:if(!macx|disable-prebuilts) {
     CONFIG += link_pkgconfig
     PKGCONFIG += openssl sdl2 SDL2_ttf
@@ -175,6 +187,7 @@ SOURCES += \
     backend/nvcomputer.cpp \
     backend/nvhttp.cpp \
     backend/nvpairingmanager.cpp \
+    backend/bluetoothmanager.cpp \
     backend/computermanager.cpp \
     backend/boxartmanager.cpp \
     backend/richpresencemanager.cpp \
@@ -194,6 +207,7 @@ SOURCES += \
     streaming/session.cpp \
     streaming/audio/audio.cpp \
     streaming/audio/renderers/sdlaud.cpp \
+    gui/bluetoothdevicemodel.cpp \
     gui/computermodel.cpp \
     gui/appmodel.cpp \
     streaming/bandwidth.cpp \
@@ -219,6 +233,7 @@ HEADERS += \
     backend/nvcomputer.h \
     backend/nvhttp.h \
     backend/nvpairingmanager.h \
+    backend/bluetoothmanager.h \
     backend/computermanager.h \
     backend/boxartmanager.h \
     backend/richpresencemanager.h \
@@ -231,6 +246,7 @@ HEADERS += \
     streaming/session.h \
     streaming/audio/renderers/renderer.h \
     streaming/audio/renderers/sdl.h \
+    gui/bluetoothdevicemodel.h \
     gui/computermodel.h \
     gui/appmodel.h \
     streaming/video/decoder.h \

--- a/app/backend/bluetoothmanager.cpp
+++ b/app/backend/bluetoothmanager.cpp
@@ -1,0 +1,886 @@
+#include "bluetoothmanager.h"
+
+#include <QDebug>
+
+#ifdef HAVE_BLUEZ
+
+#include <QDBusConnection>
+#include <QDBusMetaType>
+#include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QDBusReply>
+
+#define BLUEZ_SERVICE QStringLiteral("org.bluez")
+#define BLUEZ_ROOT_PATH QStringLiteral("/")
+#define BLUEZ_MANAGER_PATH QStringLiteral("/org/bluez")
+
+#define ADAPTER_IFACE QStringLiteral("org.bluez.Adapter1")
+#define DEVICE_IFACE QStringLiteral("org.bluez.Device1")
+#define AGENT_MANAGER_IFACE QStringLiteral("org.bluez.AgentManager1")
+
+#define OBJECT_MANAGER_IFACE QStringLiteral("org.freedesktop.DBus.ObjectManager")
+#define PROPERTIES_IFACE QStringLiteral("org.freedesktop.DBus.Properties")
+
+#define AGENT_PATH QStringLiteral("/org/moonlight_stream/bluetooth/agent")
+
+// Numeric comparison pairing for modern devices
+#define AGENT_CAPABILITY QStringLiteral("DisplayYesNo")
+
+// Far longer than D-Bus default timeout
+#define DEVICE_CALL_TIMEOUT_MS (120 * 1000)
+
+namespace
+{
+
+// Helper definitions live at the end of this file
+QDBusMessage createAdapterCall(const QString& adapterPath, const QString& method);
+QDBusMessage createSetPropertyCall(const QString& path, const QString& interface,
+                                   const QString& property, const QVariant& value);
+void applyDeviceProperties(BluetoothDevice& device, const QVariantMap& properties);
+bool deviceLessThan(const BluetoothDevice& a, const BluetoothDevice& b);
+int insertPositionIn(const QVector<BluetoothDevice>& devices, const BluetoothDevice& device);
+
+}
+
+BluetoothAgent::BluetoothAgent(BluetoothManager* manager)
+    : QObject(manager),
+      m_Manager(manager),
+      m_RequestPending(false),
+      m_PendingType(BluetoothManager::ConfirmAuthorization)
+{
+}
+
+void BluetoothAgent::beginRequest(int type, const QString& devicePath, const QString& detail)
+{
+    // We always reply outside this slot
+    setDelayedReply(true);
+
+    if (m_RequestPending) {
+        qWarning() << "Rejecting Bluetooth agent request for" << devicePath << "- another request is pending";
+        QDBusConnection::systemBus().send(
+            message().createErrorReply(QStringLiteral("org.bluez.Error.Rejected"),
+                                       QStringLiteral("Another pairing request is already in progress")));
+        return;
+    }
+
+    m_PendingMessage = message();
+    m_PendingType = type;
+    m_RequestPending = true;
+
+    m_Manager->reportAgentRequest(type, devicePath, detail);
+}
+
+void BluetoothAgent::respond(bool accepted, const QString& value)
+{
+    if (!m_RequestPending) {
+        return;
+    }
+
+    QDBusMessage pendingMessage = m_PendingMessage;
+    int pendingType = m_PendingType;
+
+    m_RequestPending = false;
+    m_PendingMessage = QDBusMessage();
+
+    if (!accepted) {
+        QDBusConnection::systemBus().send(
+            pendingMessage.createErrorReply(QStringLiteral("org.bluez.Error.Rejected"),
+                                            QStringLiteral("Rejected by user")));
+        return;
+    }
+
+    switch (pendingType) {
+    case BluetoothManager::EnterPinCode:
+        QDBusConnection::systemBus().send(pendingMessage.createReply(value));
+        break;
+    case BluetoothManager::EnterPasskey:
+        QDBusConnection::systemBus().send(pendingMessage.createReply(QVariant(value.toUInt())));
+        break;
+    default:
+        QDBusConnection::systemBus().send(pendingMessage.createReply());
+        break;
+    }
+}
+
+void BluetoothAgent::abandonPendingRequest()
+{
+    if (!m_RequestPending) {
+        return;
+    }
+
+    m_RequestPending = false;
+    QDBusConnection::systemBus().send(
+        m_PendingMessage.createErrorReply(QStringLiteral("org.bluez.Error.Canceled"),
+                                          QStringLiteral("Cancelled")));
+    m_PendingMessage = QDBusMessage();
+}
+
+void BluetoothAgent::Release()
+{
+    qInfo() << "BlueZ released our pairing agent";
+    abandonPendingRequest();
+}
+
+QString BluetoothAgent::RequestPinCode(const QDBusObjectPath& device)
+{
+    beginRequest(BluetoothManager::EnterPinCode, device.path(), QString());
+    return QString();
+}
+
+void BluetoothAgent::DisplayPinCode(const QDBusObjectPath& device, const QString& pinCode)
+{
+    // BlueZ expects an immediate reply here
+    m_Manager->reportAgentRequest(BluetoothManager::DisplayCode, device.path(), pinCode);
+}
+
+uint BluetoothAgent::RequestPasskey(const QDBusObjectPath& device)
+{
+    beginRequest(BluetoothManager::EnterPasskey, device.path(), QString());
+    return 0;
+}
+
+void BluetoothAgent::DisplayPasskey(const QDBusObjectPath& device, uint passkey, ushort entered)
+{
+    Q_UNUSED(entered);
+
+    // Passkeys are always six digits
+    m_Manager->reportAgentRequest(BluetoothManager::DisplayCode, device.path(),
+                                  QStringLiteral("%1").arg(passkey, 6, 10, QLatin1Char('0')));
+}
+
+void BluetoothAgent::RequestConfirmation(const QDBusObjectPath& device, uint passkey)
+{
+    beginRequest(BluetoothManager::ConfirmPasskey, device.path(),
+                 QStringLiteral("%1").arg(passkey, 6, 10, QLatin1Char('0')));
+}
+
+void BluetoothAgent::RequestAuthorization(const QDBusObjectPath& device)
+{
+    beginRequest(BluetoothManager::ConfirmAuthorization, device.path(), QString());
+}
+
+void BluetoothAgent::AuthorizeService(const QDBusObjectPath& device, const QString& uuid)
+{
+    Q_UNUSED(uuid);
+
+    // Ask rather than silently granting access
+    beginRequest(BluetoothManager::ConfirmAuthorization, device.path(), QString());
+}
+
+void BluetoothAgent::Cancel()
+{
+    // Remote device gave up on us
+    abandonPendingRequest();
+
+    emit m_Manager->agentRequestCancelled();
+}
+
+BluetoothManager::BluetoothManager(QObject* parent)
+    : QObject(parent),
+      m_ServiceWatcher(nullptr),
+      m_Agent(nullptr),
+      m_AgentRegistered(false),
+      m_Powered(false),
+      m_Discovering(false)
+{
+    qDBusRegisterMetaType<DBusInterfaceList>();
+    qDBusRegisterMetaType<DBusManagedObjectList>();
+
+    if (!QDBusConnection::systemBus().isConnected()) {
+        qWarning() << "Unable to connect to the D-Bus system bus:"
+                   << QDBusConnection::systemBus().lastError().message();
+        m_StatusMessage = tr("Moonlight couldn't connect to the D-Bus system bus, so Bluetooth devices can't be managed here.");
+        return;
+    }
+
+    m_ServiceWatcher = new QDBusServiceWatcher(BLUEZ_SERVICE, QDBusConnection::systemBus(),
+                                               QDBusServiceWatcher::WatchForOwnerChange, this);
+    connect(m_ServiceWatcher, &QDBusServiceWatcher::serviceRegistered,
+            this, &BluetoothManager::onServiceRegistered);
+    connect(m_ServiceWatcher, &QDBusServiceWatcher::serviceUnregistered,
+            this, &BluetoothManager::onServiceUnregistered);
+
+    m_StatusMessage = tr("The BlueZ Bluetooth service isn't running on this system.");
+
+    // Match rules survive bluetoothd restarting
+    connectToBlueZ();
+
+    refreshManagedObjects();
+}
+
+BluetoothManager::~BluetoothManager()
+{
+    disconnectFromBlueZ();
+}
+
+void BluetoothManager::connectToBlueZ()
+{
+    QDBusConnection bus = QDBusConnection::systemBus();
+
+    bus.connect(BLUEZ_SERVICE, BLUEZ_ROOT_PATH, OBJECT_MANAGER_IFACE,
+                QStringLiteral("InterfacesAdded"), this,
+                SLOT(onInterfacesAdded(QDBusObjectPath,DBusInterfaceList)));
+    bus.connect(BLUEZ_SERVICE, BLUEZ_ROOT_PATH, OBJECT_MANAGER_IFACE,
+                QStringLiteral("InterfacesRemoved"), this,
+                SLOT(onInterfacesRemoved(QDBusObjectPath,QStringList)));
+
+    // Object path comes from trailing QDBusMessage
+    bus.connect(BLUEZ_SERVICE, QString(), PROPERTIES_IFACE,
+                QStringLiteral("PropertiesChanged"), this,
+                SLOT(onPropertiesChanged(QString,QVariantMap,QStringList,QDBusMessage)));
+
+    if (m_Agent == nullptr) {
+        m_Agent = new BluetoothAgent(this);
+        if (!bus.registerObject(AGENT_PATH, m_Agent, QDBusConnection::ExportAllSlots)) {
+            qWarning() << "Unable to export our Bluetooth pairing agent on D-Bus:"
+                       << bus.lastError().message();
+        }
+    }
+}
+
+void BluetoothManager::disconnectFromBlueZ()
+{
+    QDBusConnection bus = QDBusConnection::systemBus();
+
+    if (m_AgentRegistered) {
+        QDBusMessage msg = QDBusMessage::createMethodCall(BLUEZ_SERVICE, BLUEZ_MANAGER_PATH,
+                                                          AGENT_MANAGER_IFACE,
+                                                          QStringLiteral("UnregisterAgent"));
+        msg << QVariant::fromValue(QDBusObjectPath(AGENT_PATH));
+        bus.call(msg, QDBus::NoBlock);
+        m_AgentRegistered = false;
+    }
+
+    if (m_Agent != nullptr) {
+        m_Agent->abandonPendingRequest();
+        bus.unregisterObject(AGENT_PATH);
+    }
+}
+
+void BluetoothManager::refreshManagedObjects()
+{
+    QDBusMessage msg = QDBusMessage::createMethodCall(BLUEZ_SERVICE, BLUEZ_ROOT_PATH,
+                                                      OBJECT_MANAGER_IFACE,
+                                                      QStringLiteral("GetManagedObjects"));
+
+    auto watcher = new QDBusPendingCallWatcher(QDBusConnection::systemBus().asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        QDBusPendingReply<DBusManagedObjectList> reply = *w;
+        if (reply.isError()) {
+            qWarning() << "GetManagedObjects() failed:" << reply.error().message();
+            m_StatusMessage = tr("The BlueZ Bluetooth service isn't running on this system.");
+            emit availableChanged();
+            return;
+        }
+
+        const DBusManagedObjectList objects = reply.value();
+
+        // Find an adapter before devices
+        for (auto it = objects.constBegin(); it != objects.constEnd(); it++) {
+            if (it.value().contains(ADAPTER_IFACE) && m_AdapterPath.isEmpty()) {
+                setAdapter(it.key().path(), it.value().value(ADAPTER_IFACE));
+            }
+        }
+
+        if (m_AdapterPath.isEmpty()) {
+            qInfo() << "BlueZ is running but no Bluetooth adapter was found";
+            m_StatusMessage = tr("No Bluetooth adapter was found on this system.");
+            emit availableChanged();
+            return;
+        }
+
+        for (auto it = objects.constBegin(); it != objects.constEnd(); it++) {
+            if (it.value().contains(DEVICE_IFACE)) {
+                addOrUpdateDevice(it.key().path(), it.value().value(DEVICE_IFACE));
+            }
+        }
+    });
+}
+
+void BluetoothManager::setAdapter(const QString& path, const QVariantMap& properties)
+{
+    qInfo() << "Using Bluetooth adapter" << path;
+
+    m_AdapterPath = path;
+    m_AdapterName = properties.value(QStringLiteral("Alias")).toString();
+    if (m_AdapterName.isEmpty()) {
+        m_AdapterName = properties.value(QStringLiteral("Name")).toString();
+    }
+    m_StatusMessage = QString();
+
+    m_Powered = properties.value(QStringLiteral("Powered")).toBool();
+    m_Discovering = properties.value(QStringLiteral("Discovering")).toBool();
+
+    // Register our agent now BlueZ exists
+    if (!m_AgentRegistered && m_Agent != nullptr) {
+        QDBusMessage msg = QDBusMessage::createMethodCall(BLUEZ_SERVICE, BLUEZ_MANAGER_PATH,
+                                                          AGENT_MANAGER_IFACE,
+                                                          QStringLiteral("RegisterAgent"));
+        msg << QVariant::fromValue(QDBusObjectPath(AGENT_PATH)) << AGENT_CAPABILITY;
+
+        auto watcher = new QDBusPendingCallWatcher(QDBusConnection::systemBus().asyncCall(msg), this);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+            w->deleteLater();
+
+            QDBusPendingReply<> reply = *w;
+            if (reply.isError()) {
+                // Not fatal when another agent exists
+                qWarning() << "Unable to register our Bluetooth pairing agent:" << reply.error().message();
+                return;
+            }
+
+            m_AgentRegistered = true;
+
+            // Become default so prompts reach Moonlight
+            QDBusMessage defaultMsg = QDBusMessage::createMethodCall(BLUEZ_SERVICE, BLUEZ_MANAGER_PATH,
+                                                                     AGENT_MANAGER_IFACE,
+                                                                     QStringLiteral("RequestDefaultAgent"));
+            defaultMsg << QVariant::fromValue(QDBusObjectPath(AGENT_PATH));
+            QDBusConnection::systemBus().call(defaultMsg, QDBus::NoBlock);
+        });
+    }
+
+    emit availableChanged();
+    emit poweredChanged();
+    emit discoveringChanged();
+}
+
+void BluetoothManager::updateAdapterProperties(const QVariantMap& properties)
+{
+    if (properties.contains(QStringLiteral("Powered"))) {
+        bool powered = properties.value(QStringLiteral("Powered")).toBool();
+        if (powered != m_Powered) {
+            m_Powered = powered;
+            emit poweredChanged();
+        }
+    }
+
+    if (properties.contains(QStringLiteral("Discovering"))) {
+        bool discovering = properties.value(QStringLiteral("Discovering")).toBool();
+        if (discovering != m_Discovering) {
+            m_Discovering = discovering;
+            emit discoveringChanged();
+        }
+    }
+
+    if (properties.contains(QStringLiteral("Alias")) || properties.contains(QStringLiteral("Name"))) {
+        QString name = properties.value(QStringLiteral("Alias")).toString();
+        if (name.isEmpty()) {
+            name = properties.value(QStringLiteral("Name")).toString();
+        }
+        if (!name.isEmpty() && name != m_AdapterName) {
+            m_AdapterName = name;
+            emit availableChanged();
+        }
+    }
+}
+
+int BluetoothManager::indexOfDevice(const QString& path) const
+{
+    for (int i = 0; i < m_Devices.count(); i++) {
+        if (m_Devices.at(i).path == path) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+int BluetoothManager::sortedInsertPosition(const BluetoothDevice& device) const
+{
+    return insertPositionIn(m_Devices, device);
+}
+
+void BluetoothManager::replaceDevice(int index, const BluetoothDevice& device)
+{
+    QVector<BluetoothDevice> without = m_Devices;
+    without.removeAt(index);
+
+    int newIndex = insertPositionIn(without, device);
+    if (newIndex == index) {
+        m_Devices[index] = device;
+        emit deviceChanged(index);
+        return;
+    }
+
+    // Sort position changed, so move it
+    m_Devices.removeAt(index);
+    emit deviceRemoved(index);
+
+    m_Devices.insert(newIndex, device);
+    emit deviceAdded(newIndex);
+}
+
+void BluetoothManager::addOrUpdateDevice(const QString& path, const QVariantMap& properties)
+{
+    int index = indexOfDevice(path);
+    if (index >= 0) {
+        BluetoothDevice device = m_Devices.at(index);
+        applyDeviceProperties(device, properties);
+        replaceDevice(index, device);
+        return;
+    }
+
+    BluetoothDevice device;
+    device.path = path;
+    applyDeviceProperties(device, properties);
+
+    int insertIndex = sortedInsertPosition(device);
+    m_Devices.insert(insertIndex, device);
+    emit deviceAdded(insertIndex);
+}
+
+void BluetoothManager::removeDeviceByPath(const QString& path)
+{
+    int index = indexOfDevice(path);
+    if (index < 0) {
+        return;
+    }
+
+    m_Devices.removeAt(index);
+    emit deviceRemoved(index);
+}
+
+void BluetoothManager::setDeviceBusy(const QString& path, bool busy)
+{
+    int index = indexOfDevice(path);
+    if (index < 0 || m_Devices.at(index).busy == busy) {
+        return;
+    }
+
+    // Busy doesn't affect sort order
+    m_Devices[index].busy = busy;
+    emit deviceChanged(index);
+}
+
+QString BluetoothManager::deviceNameForPath(const QString& path) const
+{
+    int index = indexOfDevice(path);
+    if (index < 0) {
+        return tr("Unknown device");
+    }
+
+    const BluetoothDevice& device = m_Devices.at(index);
+    if (!device.name.isEmpty()) {
+        return device.name;
+    }
+    else if (!device.address.isEmpty()) {
+        return device.address;
+    }
+    else {
+        return tr("Unknown device");
+    }
+}
+
+void BluetoothManager::reportAgentRequest(int type, const QString& devicePath, const QString& detail)
+{
+    emit agentRequest(type, devicePath, deviceNameForPath(devicePath), detail);
+}
+
+void BluetoothManager::onServiceRegistered()
+{
+    qInfo() << "BlueZ appeared on the system bus";
+
+    // Match rules and agent still registered
+    refreshManagedObjects();
+}
+
+void BluetoothManager::onServiceUnregistered()
+{
+    qInfo() << "BlueZ disappeared from the system bus";
+
+    m_AgentRegistered = false;
+    if (m_Agent != nullptr) {
+        m_Agent->abandonPendingRequest();
+    }
+
+    m_AdapterPath.clear();
+    m_AdapterName.clear();
+    m_Powered = false;
+    m_Discovering = false;
+    m_StatusMessage = tr("The BlueZ Bluetooth service isn't running on this system.");
+
+    m_Devices.clear();
+    emit devicesReset();
+
+    emit availableChanged();
+    emit poweredChanged();
+    emit discoveringChanged();
+}
+
+void BluetoothManager::onInterfacesAdded(const QDBusObjectPath& path, const DBusInterfaceList& interfaces)
+{
+    if (interfaces.contains(ADAPTER_IFACE) && m_AdapterPath.isEmpty()) {
+        setAdapter(path.path(), interfaces.value(ADAPTER_IFACE));
+    }
+
+    if (interfaces.contains(DEVICE_IFACE)) {
+        addOrUpdateDevice(path.path(), interfaces.value(DEVICE_IFACE));
+    }
+}
+
+void BluetoothManager::onInterfacesRemoved(const QDBusObjectPath& path, const QStringList& interfaces)
+{
+    if (interfaces.contains(DEVICE_IFACE)) {
+        removeDeviceByPath(path.path());
+    }
+
+    if (interfaces.contains(ADAPTER_IFACE) && path.path() == m_AdapterPath) {
+        qInfo() << "Bluetooth adapter" << m_AdapterPath << "went away";
+
+        m_AdapterPath.clear();
+        m_AdapterName.clear();
+        m_Powered = false;
+        m_Discovering = false;
+        m_StatusMessage = tr("No Bluetooth adapter was found on this system.");
+
+        m_Devices.clear();
+        emit devicesReset();
+
+        emit availableChanged();
+        emit poweredChanged();
+        emit discoveringChanged();
+
+        // Another adapter may still be present
+        refreshManagedObjects();
+    }
+}
+
+void BluetoothManager::onPropertiesChanged(const QString& interface, const QVariantMap& changed,
+                                           const QStringList& invalidated, const QDBusMessage& message)
+{
+    // Needed so our slot signature matches PropertiesChanged
+    Q_UNUSED(invalidated);
+
+    if (interface == ADAPTER_IFACE) {
+        if (message.path() == m_AdapterPath) {
+            updateAdapterProperties(changed);
+        }
+    }
+    else if (interface == DEVICE_IFACE) {
+        int index = indexOfDevice(message.path());
+        if (index < 0) {
+            // InterfacesAdded always precedes PropertiesChanged
+            return;
+        }
+
+        BluetoothDevice device = m_Devices.at(index);
+        applyDeviceProperties(device, changed);
+
+        replaceDevice(index, device);
+    }
+}
+
+bool BluetoothManager::isAvailable() const
+{
+    return !m_AdapterPath.isEmpty();
+}
+
+bool BluetoothManager::isPowered() const
+{
+    return m_Powered;
+}
+
+bool BluetoothManager::isDiscovering() const
+{
+    return m_Discovering;
+}
+
+QString BluetoothManager::adapterName() const
+{
+    return m_AdapterName;
+}
+
+QString BluetoothManager::statusMessage() const
+{
+    return m_StatusMessage;
+}
+
+const QVector<BluetoothDevice>& BluetoothManager::devices() const
+{
+    return m_Devices;
+}
+
+void BluetoothManager::setPowered(bool powered)
+{
+    if (m_AdapterPath.isEmpty()) {
+        return;
+    }
+
+    QDBusMessage msg = createSetPropertyCall(m_AdapterPath, ADAPTER_IFACE,
+                                             QStringLiteral("Powered"), powered);
+
+    auto watcher = new QDBusPendingCallWatcher(QDBusConnection::systemBus().asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        QDBusPendingReply<> reply = *w;
+        if (reply.isError()) {
+            qWarning() << "Unable to change adapter power state:" << reply.error().message();
+            emit operationFailed(adapterName(), tr("turn Bluetooth on or off"), reply.error().message());
+        }
+    });
+}
+
+void BluetoothManager::startDiscovery()
+{
+    if (m_AdapterPath.isEmpty() || m_Discovering) {
+        return;
+    }
+
+    auto watcher = new QDBusPendingCallWatcher(
+        QDBusConnection::systemBus().asyncCall(createAdapterCall(m_AdapterPath, QStringLiteral("StartDiscovery"))), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        QDBusPendingReply<> reply = *w;
+        if (reply.isError()) {
+            qWarning() << "StartDiscovery() failed:" << reply.error().message();
+            emit operationFailed(adapterName(), tr("start scanning"), reply.error().message());
+        }
+    });
+}
+
+void BluetoothManager::stopDiscovery()
+{
+    if (m_AdapterPath.isEmpty() || !m_Discovering) {
+        return;
+    }
+
+    // Scan stops when our connection ends
+    QDBusConnection::systemBus().asyncCall(createAdapterCall(m_AdapterPath, QStringLiteral("StopDiscovery")));
+}
+
+void BluetoothManager::callDeviceMethod(const QString& path, const QString& method, const QString& operationName)
+{
+    if (indexOfDevice(path) < 0) {
+        return;
+    }
+
+    QDBusMessage msg = QDBusMessage::createMethodCall(BLUEZ_SERVICE, path, DEVICE_IFACE, method);
+
+    setDeviceBusy(path, true);
+
+    auto watcher = new QDBusPendingCallWatcher(
+        QDBusConnection::systemBus().asyncCall(msg, DEVICE_CALL_TIMEOUT_MS), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, path, method, operationName](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        setDeviceBusy(path, false);
+
+        QDBusPendingReply<> reply = *w;
+        if (reply.isError()) {
+            qWarning() << method << "failed on" << path << ":" << reply.error().message();
+            emit operationFailed(deviceNameForPath(path), operationName, reply.error().message());
+        }
+    });
+}
+
+void BluetoothManager::pairDevice(QString path)
+{
+    if (indexOfDevice(path) < 0) {
+        return;
+    }
+
+    QDBusMessage msg = QDBusMessage::createMethodCall(BLUEZ_SERVICE, path, DEVICE_IFACE,
+                                                      QStringLiteral("Pair"));
+
+    setDeviceBusy(path, true);
+
+    auto watcher = new QDBusPendingCallWatcher(
+        QDBusConnection::systemBus().asyncCall(msg, DEVICE_CALL_TIMEOUT_MS), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        setDeviceBusy(path, false);
+
+        QDBusPendingReply<> reply = *w;
+        if (reply.isError()) {
+            qWarning() << "Pair() failed on" << path << ":" << reply.error().message();
+            emit operationFailed(deviceNameForPath(path), tr("pair"), reply.error().message());
+            return;
+        }
+
+        // Untrusted devices cannot reconnect themselves
+        setDeviceTrusted(path, true);
+    });
+}
+
+void BluetoothManager::cancelPairing(QString path)
+{
+    if (m_Agent != nullptr) {
+        m_Agent->abandonPendingRequest();
+    }
+
+    callDeviceMethod(path, QStringLiteral("CancelPairing"), tr("cancel pairing with"));
+}
+
+void BluetoothManager::connectDevice(QString path)
+{
+    callDeviceMethod(path, QStringLiteral("Connect"), tr("connect to"));
+}
+
+void BluetoothManager::disconnectDevice(QString path)
+{
+    callDeviceMethod(path, QStringLiteral("Disconnect"), tr("disconnect from"));
+}
+
+void BluetoothManager::setDeviceTrusted(QString path, bool trusted)
+{
+    if (indexOfDevice(path) < 0) {
+        return;
+    }
+
+    QDBusMessage msg = createSetPropertyCall(path, DEVICE_IFACE, QStringLiteral("Trusted"), trusted);
+
+    auto watcher = new QDBusPendingCallWatcher(QDBusConnection::systemBus().asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        QDBusPendingReply<> reply = *w;
+        if (reply.isError()) {
+            qWarning() << "Unable to change trusted state of" << path << ":" << reply.error().message();
+            emit operationFailed(deviceNameForPath(path), tr("trust"), reply.error().message());
+        }
+    });
+}
+
+void BluetoothManager::removeDevice(QString path)
+{
+    if (m_AdapterPath.isEmpty() || indexOfDevice(path) < 0) {
+        return;
+    }
+
+    QDBusMessage msg = createAdapterCall(m_AdapterPath, QStringLiteral("RemoveDevice"));
+    msg << QVariant::fromValue(QDBusObjectPath(path));
+
+    auto watcher = new QDBusPendingCallWatcher(QDBusConnection::systemBus().asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        QDBusPendingReply<> reply = *w;
+        if (reply.isError()) {
+            qWarning() << "RemoveDevice() failed on" << path << ":" << reply.error().message();
+            emit operationFailed(deviceNameForPath(path), tr("remove"), reply.error().message());
+        }
+    });
+}
+
+void BluetoothManager::respondToAgentRequest(bool accepted, QString value)
+{
+    if (m_Agent != nullptr) {
+        m_Agent->respond(accepted, value);
+    }
+}
+
+// Helper functions declared near the top
+namespace
+{
+
+QDBusMessage createAdapterCall(const QString& adapterPath, const QString& method)
+{
+    return QDBusMessage::createMethodCall(BLUEZ_SERVICE, adapterPath, ADAPTER_IFACE, method);
+}
+
+QDBusMessage createSetPropertyCall(const QString& path, const QString& interface,
+                                   const QString& property, const QVariant& value)
+{
+    QDBusMessage msg = QDBusMessage::createMethodCall(BLUEZ_SERVICE, path, PROPERTIES_IFACE,
+                                                      QStringLiteral("Set"));
+    msg << interface << property << QVariant::fromValue(QDBusVariant(value));
+    return msg;
+}
+
+void applyDeviceProperties(BluetoothDevice& device, const QVariantMap& properties)
+{
+    if (properties.contains(QStringLiteral("Address"))) {
+        device.address = properties.value(QStringLiteral("Address")).toString();
+    }
+    if (properties.contains(QStringLiteral("Alias"))) {
+        device.name = properties.value(QStringLiteral("Alias")).toString();
+    }
+    if (properties.contains(QStringLiteral("Name")) && device.name.isEmpty()) {
+        device.name = properties.value(QStringLiteral("Name")).toString();
+    }
+    if (properties.contains(QStringLiteral("Paired"))) {
+        device.paired = properties.value(QStringLiteral("Paired")).toBool();
+    }
+    if (properties.contains(QStringLiteral("Trusted"))) {
+        device.trusted = properties.value(QStringLiteral("Trusted")).toBool();
+    }
+    if (properties.contains(QStringLiteral("Connected"))) {
+        device.connected = properties.value(QStringLiteral("Connected")).toBool();
+    }
+    if (properties.contains(QStringLiteral("Blocked"))) {
+        device.blocked = properties.value(QStringLiteral("Blocked")).toBool();
+    }
+}
+
+// Connected first, then paired, then alphabetical
+bool deviceLessThan(const BluetoothDevice& a, const BluetoothDevice& b)
+{
+    if (a.connected != b.connected) {
+        return a.connected;
+    }
+    if (a.paired != b.paired) {
+        return a.paired;
+    }
+    if (a.name.isEmpty() != b.name.isEmpty()) {
+        return !a.name.isEmpty();
+    }
+
+    int nameComparison = a.name.compare(b.name, Qt::CaseInsensitive);
+    if (nameComparison != 0) {
+        return nameComparison < 0;
+    }
+
+    return a.address < b.address;
+}
+
+int insertPositionIn(const QVector<BluetoothDevice>& devices, const BluetoothDevice& device)
+{
+    int i = 0;
+    while (i < devices.count() && deviceLessThan(devices.at(i), device)) {
+        i++;
+    }
+    return i;
+}
+
+}
+
+#else
+
+// No-op stubs when BlueZ is unavailable
+
+BluetoothManager::BluetoothManager(QObject* parent)
+    : QObject(parent)
+{
+    m_StatusMessage = tr("This build of Moonlight doesn't include Bluetooth support.");
+}
+
+BluetoothManager::~BluetoothManager() {}
+
+bool BluetoothManager::isAvailable() const { return false; }
+bool BluetoothManager::isPowered() const { return false; }
+bool BluetoothManager::isDiscovering() const { return false; }
+QString BluetoothManager::adapterName() const { return QString(); }
+QString BluetoothManager::statusMessage() const { return m_StatusMessage; }
+
+const QVector<BluetoothDevice>& BluetoothManager::devices() const { return m_Devices; }
+
+void BluetoothManager::setPowered(bool) {}
+void BluetoothManager::startDiscovery() {}
+void BluetoothManager::stopDiscovery() {}
+void BluetoothManager::pairDevice(QString) {}
+void BluetoothManager::cancelPairing(QString) {}
+void BluetoothManager::connectDevice(QString) {}
+void BluetoothManager::disconnectDevice(QString) {}
+void BluetoothManager::setDeviceTrusted(QString, bool) {}
+void BluetoothManager::removeDevice(QString) {}
+void BluetoothManager::respondToAgentRequest(bool, QString) {}
+
+#endif

--- a/app/backend/bluetoothmanager.h
+++ b/app/backend/bluetoothmanager.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QVector>
+
+#ifdef HAVE_BLUEZ
+#include <QDBusContext>
+#include <QDBusMessage>
+#include <QDBusObjectPath>
+#include <QDBusServiceWatcher>
+#include <QMap>
+#include <QVariantMap>
+
+// Types used by org.freedesktop.DBus.ObjectManager
+typedef QMap<QString, QVariantMap> DBusInterfaceList;
+typedef QMap<QDBusObjectPath, DBusInterfaceList> DBusManagedObjectList;
+
+Q_DECLARE_METATYPE(DBusInterfaceList)
+Q_DECLARE_METATYPE(DBusManagedObjectList)
+#endif
+
+class BluetoothManager;
+
+// Device known to BlueZ
+struct BluetoothDevice
+{
+    QString path;
+    QString address;
+    QString name;
+    bool paired = false;
+    bool trusted = false;
+    bool connected = false;
+    bool blocked = false;
+
+    // Set while our operation is pending
+    bool busy = false;
+};
+
+#ifdef HAVE_BLUEZ
+// Implements org.bluez.Agent1 for pairing prompts
+class BluetoothAgent : public QObject, protected QDBusContext
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.bluez.Agent1")
+
+public:
+    explicit BluetoothAgent(BluetoothManager* manager);
+
+    // Completes the outstanding agent request
+    void respond(bool accepted, const QString& value);
+
+    // Rejects any outstanding request
+    void abandonPendingRequest();
+
+public slots:
+    void Release();
+    QString RequestPinCode(const QDBusObjectPath& device);
+    void DisplayPinCode(const QDBusObjectPath& device, const QString& pinCode);
+    uint RequestPasskey(const QDBusObjectPath& device);
+    void DisplayPasskey(const QDBusObjectPath& device, uint passkey, ushort entered);
+    void RequestConfirmation(const QDBusObjectPath& device, uint passkey);
+    void RequestAuthorization(const QDBusObjectPath& device);
+    void AuthorizeService(const QDBusObjectPath& device, const QString& uuid);
+    void Cancel();
+
+private:
+    // Rejects the call if one is pending
+    void beginRequest(int type, const QString& devicePath, const QString& detail);
+
+    BluetoothManager* m_Manager;
+    QDBusMessage m_PendingMessage;
+    bool m_RequestPending;
+    int m_PendingType;
+};
+#endif
+
+class BluetoothManager : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool available READ isAvailable NOTIFY availableChanged)
+    Q_PROPERTY(bool powered READ isPowered WRITE setPowered NOTIFY poweredChanged)
+    Q_PROPERTY(bool discovering READ isDiscovering NOTIFY discoveringChanged)
+    Q_PROPERTY(QString adapterName READ adapterName NOTIFY availableChanged)
+    Q_PROPERTY(QString statusMessage READ statusMessage NOTIFY availableChanged)
+
+public:
+    // User interactions BlueZ requests during pairing
+    enum AgentRequestType
+    {
+        // User accepts or rejects pairing
+        ConfirmAuthorization,
+
+        // User confirms passkey matches device
+        ConfirmPasskey,
+
+        // User types the device's PIN code
+        EnterPinCode,
+
+        // User types the device's passkey
+        EnterPasskey,
+
+        // Code must be entered on device
+        DisplayCode
+    };
+    Q_ENUM(AgentRequestType)
+
+    explicit BluetoothManager(QObject* parent = nullptr);
+    ~BluetoothManager();
+
+    bool isAvailable() const;
+    bool isPowered() const;
+    bool isDiscovering() const;
+    QString adapterName() const;
+    QString statusMessage() const;
+
+    const QVector<BluetoothDevice>& devices() const;
+
+    Q_INVOKABLE void setPowered(bool powered);
+    Q_INVOKABLE void startDiscovery();
+    Q_INVOKABLE void stopDiscovery();
+
+    Q_INVOKABLE void pairDevice(QString path);
+    Q_INVOKABLE void cancelPairing(QString path);
+    Q_INVOKABLE void connectDevice(QString path);
+    Q_INVOKABLE void disconnectDevice(QString path);
+    Q_INVOKABLE void setDeviceTrusted(QString path, bool trusted);
+    Q_INVOKABLE void removeDevice(QString path);
+
+    // Answers the most recent agentRequest()
+    Q_INVOKABLE void respondToAgentRequest(bool accepted, QString value = QString());
+
+signals:
+    void availableChanged();
+    void poweredChanged();
+    void discoveringChanged();
+
+    // Emitted after devices() is updated
+    void deviceAdded(int index);
+    void deviceRemoved(int index);
+    void deviceChanged(int index);
+    void devicesReset();
+
+    void operationFailed(QString deviceName, QString operation, QString error);
+
+    // BlueZ needs input to finish pairing
+    void agentRequest(int type, QString devicePath, QString deviceName, QString detail);
+
+    // Pending request went away
+    void agentRequestCancelled();
+
+private:
+#ifdef HAVE_BLUEZ
+    friend class BluetoothAgent;
+
+    void connectToBlueZ();
+    void disconnectFromBlueZ();
+    void refreshManagedObjects();
+
+    void setAdapter(const QString& path, const QVariantMap& properties);
+    void updateAdapterProperties(const QVariantMap& properties);
+
+    void addOrUpdateDevice(const QString& path, const QVariantMap& properties);
+    void removeDeviceByPath(const QString& path);
+    int indexOfDevice(const QString& path) const;
+    int sortedInsertPosition(const BluetoothDevice& device) const;
+    void replaceDevice(int index, const BluetoothDevice& device);
+    void setDeviceBusy(const QString& path, bool busy);
+
+    QString deviceNameForPath(const QString& path) const;
+
+    // Async call reporting failures via operationFailed()
+    void callDeviceMethod(const QString& path, const QString& method, const QString& operationName);
+
+    void reportAgentRequest(int type, const QString& devicePath, const QString& detail);
+
+private slots:
+    void onServiceRegistered();
+    void onServiceUnregistered();
+    void onInterfacesAdded(const QDBusObjectPath& path, const DBusInterfaceList& interfaces);
+    void onInterfacesRemoved(const QDBusObjectPath& path, const QStringList& interfaces);
+    void onPropertiesChanged(const QString& interface, const QVariantMap& changed,
+                             const QStringList& invalidated, const QDBusMessage& message);
+
+private:
+    QDBusServiceWatcher* m_ServiceWatcher;
+    BluetoothAgent* m_Agent;
+    bool m_AgentRegistered;
+    QString m_AdapterPath;
+    QString m_AdapterName;
+    bool m_Powered;
+    bool m_Discovering;
+#endif
+
+    QVector<BluetoothDevice> m_Devices;
+    QString m_StatusMessage;
+};

--- a/app/gui/BluetoothView.qml
+++ b/app/gui/BluetoothView.qml
@@ -1,0 +1,449 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+
+import BluetoothDeviceModel 1.0
+
+import BluetoothManager 1.0
+import SdlGamepadKeyNavigation 1.0
+
+Item {
+    id: bluetoothView
+    objectName: qsTr("Bluetooth")
+    focus: true
+
+    property BluetoothDeviceModel deviceModel : createModel()
+
+    StackView.onActivated: {
+        BluetoothManager.operationFailed.connect(handleOperationFailed)
+        BluetoothManager.agentRequest.connect(handleAgentRequest)
+        BluetoothManager.agentRequestCancelled.connect(handleAgentRequestCancelled)
+
+        // Highlight first device for gamepad users
+        if (deviceList.currentIndex === -1 && SdlGamepadKeyNavigation.getConnectedGamepads() > 0) {
+            deviceList.currentIndex = 0
+        }
+    }
+
+    StackView.onDeactivating: {
+        BluetoothManager.operationFailed.disconnect(handleOperationFailed)
+        BluetoothManager.agentRequest.disconnect(handleAgentRequest)
+        BluetoothManager.agentRequestCancelled.disconnect(handleAgentRequestCancelled)
+
+        // Stop scanning when navigating away
+        BluetoothManager.stopDiscovery()
+    }
+
+    function handleOperationFailed(deviceName, operation, error)
+    {
+        errorDialog.text = qsTr("Moonlight was unable to %1 %2.").arg(operation).arg(deviceName) + "\n\n" + error
+        errorDialog.open()
+    }
+
+    function handleAgentRequest(type, devicePath, deviceName, detail)
+    {
+        if (type === BluetoothManager.DisplayCode) {
+            displayCodeDialog.deviceName = deviceName
+            displayCodeDialog.code = detail
+            displayCodeDialog.open()
+            return
+        }
+
+        if (type === BluetoothManager.EnterPinCode || type === BluetoothManager.EnterPasskey) {
+            codeEntryDialog.deviceName = deviceName
+            codeEntryDialog.requestType = type
+            codeEntryDialog.open()
+            return
+        }
+
+        confirmDialog.deviceName = deviceName
+        confirmDialog.passkey = (type === BluetoothManager.ConfirmPasskey) ? detail : ""
+        confirmDialog.open()
+    }
+
+    function handleAgentRequestCancelled()
+    {
+        confirmDialog.close()
+        codeEntryDialog.close()
+        displayCodeDialog.close()
+    }
+
+    // Helper functions
+    // The action the user likely wants
+    function activateDevice(device)
+    {
+        if (!device.paired) {
+            BluetoothManager.pairDevice(device.path)
+        }
+        else if (device.connected) {
+            BluetoothManager.disconnectDevice(device.path)
+        }
+        else {
+            BluetoothManager.connectDevice(device.path)
+        }
+    }
+
+    function createModel()
+    {
+        // StackView.push() reparents us after initialization
+        var model = Qt.createQmlObject('import BluetoothDeviceModel 1.0; BluetoothDeviceModel {}', bluetoothView, '')
+        model.initialize(BluetoothManager)
+        return model
+    }
+
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+        spacing: 15
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 15
+
+            Label {
+                text: BluetoothManager.adapterName ? BluetoothManager.adapterName : qsTr("Bluetooth")
+                font.pointSize: 16
+                elide: Label.ElideRight
+                Layout.fillWidth: true
+            }
+
+            Switch {
+                text: qsTr("Bluetooth on")
+                enabled: BluetoothManager.available
+                checked: BluetoothManager.powered
+                activeFocusOnTab: true
+
+                // Restore binding and let BlueZ confirm
+                function requestPowerChange(desiredState) {
+                    checked = Qt.binding(function() { return BluetoothManager.powered })
+                    BluetoothManager.setPowered(desiredState)
+                }
+
+                onClicked: requestPowerChange(checked)
+
+                Keys.onReturnPressed: requestPowerChange(!BluetoothManager.powered)
+                Keys.onEnterPressed: requestPowerChange(!BluetoothManager.powered)
+                Keys.onDownPressed: deviceList.forceActiveFocus(Qt.TabFocus)
+            }
+
+            BusyIndicator {
+                implicitWidth: 30
+                implicitHeight: 30
+                visible: BluetoothManager.discovering
+                running: visible
+            }
+
+            Button {
+                text: BluetoothManager.discovering ? qsTr("Stop scanning") : qsTr("Scan for devices")
+                enabled: BluetoothManager.available && BluetoothManager.powered
+                activeFocusOnTab: true
+
+                onClicked: {
+                    if (BluetoothManager.discovering) {
+                        BluetoothManager.stopDiscovery()
+                    }
+                    else {
+                        BluetoothManager.startDiscovery()
+                    }
+                }
+
+                Keys.onReturnPressed: clicked()
+                Keys.onEnterPressed: clicked()
+                Keys.onDownPressed: deviceList.forceActiveFocus(Qt.TabFocus)
+            }
+        }
+
+        Label {
+            Layout.fillWidth: true
+            visible: !BluetoothManager.available || !BluetoothManager.powered
+            wrapMode: Text.Wrap
+            font.pointSize: 12
+            text: !BluetoothManager.available ? BluetoothManager.statusMessage
+                                              : qsTr("Bluetooth is turned off. Turn it on to see nearby devices.")
+        }
+
+        ListView {
+            id: deviceList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            activeFocusOnTab: true
+            keyNavigationEnabled: true
+            boundsBehavior: Flickable.OvershootBounds
+
+            model: deviceModel
+
+            ScrollBar.vertical: ScrollBar {}
+
+            Component.onCompleted: {
+                // Don't highlight until the user interacts
+                currentIndex = -1
+            }
+
+            Label {
+                anchors.centerIn: parent
+                width: parent.width - 40
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                font.pointSize: 14
+                visible: deviceList.count === 0 && BluetoothManager.available && BluetoothManager.powered
+                text: BluetoothManager.discovering ? qsTr("Searching for nearby Bluetooth devices…")
+                                                   : qsTr("No Bluetooth devices yet. Press 'Scan for devices' and put your device into pairing mode.")
+            }
+
+            delegate: ItemDelegate {
+                width: deviceList.width
+                height: 76
+
+                highlighted: deviceList.activeFocus && ListView.isCurrentItem
+
+                property alias deviceContextMenu : deviceContextMenuLoader.item
+
+                Image {
+                    id: deviceIcon
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                    source: "qrc:/res/bluetooth.svg"
+                    opacity: model.connected ? 1.0 : 0.4
+                    sourceSize {
+                        width: 40
+                        height: 40
+                    }
+                }
+
+                Column {
+                    anchors.left: deviceIcon.right
+                    anchors.leftMargin: 15
+                    anchors.right: deviceBusyIndicator.left
+                    anchors.rightMargin: 15
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 4
+
+                    Label {
+                        width: parent.width
+                        text: model.name
+                        font.pointSize: 14
+                        elide: Text.ElideRight
+                    }
+
+                    Label {
+                        width: parent.width
+                        text: model.address ? (model.statusText + "  •  " + model.address) : model.statusText
+                        font.pointSize: 10
+                        opacity: 0.7
+                        elide: Text.ElideRight
+                    }
+                }
+
+                BusyIndicator {
+                    id: deviceBusyIndicator
+                    anchors.right: parent.right
+                    anchors.rightMargin: 20
+                    anchors.verticalCenter: parent.verticalCenter
+                    implicitWidth: 32
+                    implicitHeight: 32
+                    visible: model.busy
+                    running: visible
+                }
+
+                Loader {
+                    id: deviceContextMenuLoader
+                    asynchronous: true
+                    sourceComponent: NavigableMenu {
+                        id: deviceContextMenu
+                        initiator: deviceContextMenuLoader.parent
+
+                        MenuItem {
+                            text: model.name
+                            font.bold: true
+                            enabled: false
+                        }
+                        NavigableMenuItem {
+                            text: qsTr("Pair")
+                            visible: !model.paired
+                            onTriggered: BluetoothManager.pairDevice(model.path)
+                        }
+                        NavigableMenuItem {
+                            text: qsTr("Connect")
+                            visible: model.paired && !model.connected
+                            onTriggered: BluetoothManager.connectDevice(model.path)
+                        }
+                        NavigableMenuItem {
+                            text: qsTr("Disconnect")
+                            visible: model.connected
+                            onTriggered: BluetoothManager.disconnectDevice(model.path)
+                        }
+                        NavigableMenuItem {
+                            text: qsTr("Trust this device")
+                            visible: model.paired && !model.trusted
+                            onTriggered: BluetoothManager.setDeviceTrusted(model.path, true)
+                        }
+                        NavigableMenuItem {
+                            text: qsTr("Stop trusting this device")
+                            visible: model.paired && model.trusted
+                            onTriggered: BluetoothManager.setDeviceTrusted(model.path, false)
+                        }
+                        NavigableMenuItem {
+                            text: qsTr("Cancel pairing")
+                            visible: model.busy && !model.paired
+                            onTriggered: BluetoothManager.cancelPairing(model.path)
+                        }
+                        NavigableMenuItem {
+                            text: qsTr("Remove this device")
+                            visible: model.paired
+                            onTriggered: {
+                                removeDeviceDialog.devicePath = model.path
+                                removeDeviceDialog.deviceName = model.name
+                                removeDeviceDialog.open()
+                            }
+                        }
+                    }
+                }
+
+                onClicked: activateDevice(model)
+
+                onPressAndHold: {
+                    // popup() positions the menu under cursor
+                    if (deviceContextMenu.popup) {
+                        deviceContextMenu.popup()
+                    }
+                    else {
+                        // Qt 5.9 doesn't have popup()
+                        deviceContextMenu.open()
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.RightButton
+                    onClicked: {
+                        parent.pressAndHold()
+                    }
+                }
+
+                Keys.onMenuPressed: {
+                    // open() positions the menu on delegate
+                    deviceContextMenu.open()
+                }
+
+                Keys.onReturnPressed: clicked()
+                Keys.onEnterPressed: clicked()
+
+                Keys.onUpPressed: {
+                    if (deviceList.currentIndex === 0) {
+                        // Move focus to the toolbar
+                        deviceList.nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+                    }
+                    else {
+                        deviceList.decrementCurrentIndex()
+                    }
+                }
+
+                Keys.onDownPressed: {
+                    deviceList.incrementCurrentIndex()
+                }
+
+                Keys.onDeletePressed: {
+                    if (model.paired) {
+                        removeDeviceDialog.devicePath = model.path
+                        removeDeviceDialog.deviceName = model.name
+                        removeDeviceDialog.open()
+                    }
+                }
+            }
+        }
+    }
+
+    // ErrorMessageDialog's Help link is irrelevant here
+    NavigableMessageDialog {
+        id: errorDialog
+        standardButtons: Dialog.Ok
+        imageSrc: "qrc:/res/baseline-error_outline-24px.svg"
+    }
+
+    NavigableMessageDialog {
+        id: removeDeviceDialog
+        property string devicePath : ""
+        property string deviceName : ""
+
+        standardButtons: Dialog.Yes | Dialog.No
+        text: qsTr("Are you sure you want to remove '%1'? You will have to pair it again to use it.").arg(deviceName)
+
+        onAccepted: BluetoothManager.removeDevice(devicePath)
+    }
+
+    // Shown when BlueZ asks for approval
+    NavigableMessageDialog {
+        id: confirmDialog
+        property string deviceName : ""
+        property string passkey : ""
+
+        closePolicy: Popup.NoAutoClose
+        standardButtons: Dialog.Yes | Dialog.No
+        imageSrc: "qrc:/res/baseline-help_outline-24px.svg"
+        text: passkey ? (qsTr("Confirm that '%1' is showing this code:").arg(deviceName) + "\n\n" + passkey)
+                      : qsTr("Allow '%1' to pair with this computer?").arg(deviceName)
+
+        onAccepted: BluetoothManager.respondToAgentRequest(true)
+        onRejected: BluetoothManager.respondToAgentRequest(false)
+    }
+
+    // Code must be typed on device
+    NavigableMessageDialog {
+        id: displayCodeDialog
+        property string deviceName : ""
+        property string code : ""
+
+        standardButtons: Dialog.Ok
+        imageSrc: "qrc:/res/baseline-help_outline-24px.svg"
+        text: qsTr("Enter this code on '%1' to finish pairing:").arg(deviceName) + "\n\n" + code
+    }
+
+    // Shown when BlueZ needs a code
+    NavigableDialog {
+        id: codeEntryDialog
+        property string deviceName : ""
+        property int requestType : BluetoothManager.EnterPinCode
+
+        closePolicy: Popup.NoAutoClose
+        standardButtons: Dialog.Ok | Dialog.Cancel
+
+        onOpened: {
+            // Force focus for keyboard navigation
+            codeEntryText.forceActiveFocus()
+        }
+
+        onClosed: {
+            codeEntryText.clear()
+        }
+
+        onAccepted: BluetoothManager.respondToAgentRequest(true, codeEntryText.text)
+        onRejected: BluetoothManager.respondToAgentRequest(false, "")
+
+        ColumnLayout {
+            Label {
+                text: (codeEntryDialog.requestType === BluetoothManager.EnterPasskey)
+                          ? qsTr("Enter the passkey shown on '%1':").arg(codeEntryDialog.deviceName)
+                          : qsTr("Enter the PIN code for '%1':").arg(codeEntryDialog.deviceName)
+                font.bold: true
+                wrapMode: Text.Wrap
+                Layout.maximumWidth: 400
+            }
+
+            TextField {
+                id: codeEntryText
+                Layout.fillWidth: true
+                focus: true
+
+                // Passkeys numeric, PIN codes alphanumeric
+                inputMethodHints: (codeEntryDialog.requestType === BluetoothManager.EnterPasskey)
+                                      ? Qt.ImhDigitsOnly : Qt.ImhNone
+
+                Keys.onReturnPressed: codeEntryDialog.accept()
+                Keys.onEnterPressed: codeEntryDialog.accept()
+            }
+        }
+    }
+}

--- a/app/gui/BluetoothView.qml
+++ b/app/gui/BluetoothView.qml
@@ -14,15 +14,22 @@ Item {
 
     property BluetoothDeviceModel deviceModel : createModel()
 
+    // We hold no keys ourselves, so hand focus to a control
+    onActiveFocusChanged: {
+        if (activeFocus) {
+            focusDefaultControl()
+        }
+    }
+
     StackView.onActivated: {
         BluetoothManager.operationFailed.connect(handleOperationFailed)
         BluetoothManager.agentRequest.connect(handleAgentRequest)
         BluetoothManager.agentRequestCancelled.connect(handleAgentRequestCancelled)
 
-        // Highlight first device for gamepad users
-        if (deviceList.currentIndex === -1 && SdlGamepadKeyNavigation.getConnectedGamepads() > 0) {
-            deviceList.currentIndex = 0
-        }
+        // Arrow keys, like the other list views
+        SdlGamepadKeyNavigation.setUiNavMode(false)
+
+        focusDefaultControl()
     }
 
     StackView.onDeactivating: {
@@ -69,6 +76,35 @@ Item {
     }
 
     // Helper functions
+
+    // Focus whichever control the user can act on
+    function focusDefaultControl()
+    {
+        if (deviceList.count > 0) {
+            deviceList.forceActiveFocus(Qt.TabFocus)
+        }
+        else {
+            focusHeaderRow()
+        }
+    }
+
+    // Falls back when scanning is unavailable
+    function focusHeaderRow()
+    {
+        if (scanButton.enabled) {
+            scanButton.forceActiveFocus(Qt.TabFocus)
+        }
+        else {
+            powerSwitch.forceActiveFocus(Qt.TabFocus)
+        }
+    }
+
+    // Moves focus up into the window toolbar
+    function focusToolbar(item)
+    {
+        item.nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+    }
+
     // The action the user likely wants
     function activateDevice(device)
     {
@@ -109,6 +145,7 @@ Item {
             }
 
             Switch {
+                id: powerSwitch
                 text: qsTr("Bluetooth on")
                 enabled: BluetoothManager.available
                 checked: BluetoothManager.powered
@@ -124,7 +161,18 @@ Item {
 
                 Keys.onReturnPressed: requestPowerChange(!BluetoothManager.powered)
                 Keys.onEnterPressed: requestPowerChange(!BluetoothManager.powered)
-                Keys.onDownPressed: deviceList.forceActiveFocus(Qt.TabFocus)
+
+                Keys.onUpPressed: focusToolbar(powerSwitch)
+                Keys.onRightPressed: {
+                    if (scanButton.enabled) {
+                        scanButton.forceActiveFocus(Qt.TabFocus)
+                    }
+                }
+                Keys.onDownPressed: {
+                    if (deviceList.count > 0) {
+                        deviceList.forceActiveFocus(Qt.TabFocus)
+                    }
+                }
             }
 
             BusyIndicator {
@@ -135,6 +183,7 @@ Item {
             }
 
             Button {
+                id: scanButton
                 text: BluetoothManager.discovering ? qsTr("Stop scanning") : qsTr("Scan for devices")
                 enabled: BluetoothManager.available && BluetoothManager.powered
                 activeFocusOnTab: true
@@ -150,7 +199,14 @@ Item {
 
                 Keys.onReturnPressed: clicked()
                 Keys.onEnterPressed: clicked()
-                Keys.onDownPressed: deviceList.forceActiveFocus(Qt.TabFocus)
+
+                Keys.onUpPressed: focusToolbar(scanButton)
+                Keys.onLeftPressed: powerSwitch.forceActiveFocus(Qt.TabFocus)
+                Keys.onDownPressed: {
+                    if (deviceList.count > 0) {
+                        deviceList.forceActiveFocus(Qt.TabFocus)
+                    }
+                }
             }
         }
 
@@ -179,6 +235,13 @@ Item {
             Component.onCompleted: {
                 // Don't highlight until the user interacts
                 currentIndex = -1
+            }
+
+            // Key focus needs a visible highlight to land on
+            onActiveFocusChanged: {
+                if (activeFocus && currentIndex === -1 && count > 0) {
+                    currentIndex = 0
+                }
             }
 
             Label {
@@ -333,8 +396,8 @@ Item {
 
                 Keys.onUpPressed: {
                     if (deviceList.currentIndex === 0) {
-                        // Move focus to the toolbar
-                        deviceList.nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+                        // Leave the list for the controls above
+                        focusHeaderRow()
                     }
                     else {
                         deviceList.decrementCurrentIndex()

--- a/app/gui/bluetoothdevicemodel.cpp
+++ b/app/gui/bluetoothdevicemodel.cpp
@@ -1,0 +1,143 @@
+#include "bluetoothdevicemodel.h"
+
+BluetoothDeviceModel::BluetoothDeviceModel(QObject* parent)
+    : QAbstractListModel(parent),
+      m_Manager(nullptr)
+{
+}
+
+void BluetoothDeviceModel::initialize(BluetoothManager* manager)
+{
+    Q_ASSERT(manager != nullptr);
+
+    // Notify views attached before initialize()
+    beginResetModel();
+    m_Manager = manager;
+    m_Devices = m_Manager->devices();
+    endResetModel();
+
+    connect(m_Manager, &BluetoothManager::deviceAdded,
+            this, &BluetoothDeviceModel::handleDeviceAdded);
+    connect(m_Manager, &BluetoothManager::deviceRemoved,
+            this, &BluetoothDeviceModel::handleDeviceRemoved);
+    connect(m_Manager, &BluetoothManager::deviceChanged,
+            this, &BluetoothDeviceModel::handleDeviceChanged);
+    connect(m_Manager, &BluetoothManager::devicesReset,
+            this, &BluetoothDeviceModel::handleDevicesReset);
+}
+
+int BluetoothDeviceModel::rowCount(const QModelIndex& parent) const
+{
+    // We have no children
+    if (parent.isValid()) {
+        return 0;
+    }
+
+    return m_Devices.count();
+}
+
+QVariant BluetoothDeviceModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_Devices.count()) {
+        return QVariant();
+    }
+
+    const BluetoothDevice& device = m_Devices.at(index.row());
+
+    switch (role) {
+    case PathRole:
+        return device.path;
+    case NameRole:
+        if (!device.name.isEmpty()) {
+            return device.name;
+        }
+        else if (!device.address.isEmpty()) {
+            return device.address;
+        }
+        else {
+            return tr("Unknown device");
+        }
+    case AddressRole:
+        return device.address;
+    case PairedRole:
+        return device.paired;
+    case TrustedRole:
+        return device.trusted;
+    case ConnectedRole:
+        return device.connected;
+    case BusyRole:
+        return device.busy;
+    case StatusTextRole:
+        return statusTextForDevice(device);
+    default:
+        return QVariant();
+    }
+}
+
+QHash<int, QByteArray> BluetoothDeviceModel::roleNames() const
+{
+    QHash<int, QByteArray> names;
+
+    names[PathRole] = "path";
+    names[NameRole] = "name";
+    names[AddressRole] = "address";
+    names[PairedRole] = "paired";
+    names[TrustedRole] = "trusted";
+    names[ConnectedRole] = "connected";
+    names[BusyRole] = "busy";
+    names[StatusTextRole] = "statusText";
+
+    return names;
+}
+
+void BluetoothDeviceModel::handleDeviceAdded(int index)
+{
+    Q_ASSERT(index >= 0 && index <= m_Devices.count());
+
+    beginInsertRows(QModelIndex(), index, index);
+    m_Devices = m_Manager->devices();
+    endInsertRows();
+}
+
+void BluetoothDeviceModel::handleDeviceRemoved(int index)
+{
+    Q_ASSERT(index >= 0 && index < m_Devices.count());
+
+    beginRemoveRows(QModelIndex(), index, index);
+    m_Devices = m_Manager->devices();
+    endRemoveRows();
+}
+
+void BluetoothDeviceModel::handleDeviceChanged(int index)
+{
+    Q_ASSERT(index >= 0 && index < m_Devices.count());
+
+    m_Devices = m_Manager->devices();
+    emit dataChanged(createIndex(index, 0), createIndex(index, 0));
+}
+
+void BluetoothDeviceModel::handleDevicesReset()
+{
+    beginResetModel();
+    m_Devices = m_Manager->devices();
+    endResetModel();
+}
+
+QString BluetoothDeviceModel::statusTextForDevice(const BluetoothDevice& device) const
+{
+    if (device.busy) {
+        return tr("Working…");
+    }
+    else if (device.blocked) {
+        return tr("Blocked");
+    }
+    else if (device.connected) {
+        return device.trusted ? tr("Connected") : tr("Connected (not trusted)");
+    }
+    else if (device.paired) {
+        return device.trusted ? tr("Paired") : tr("Paired (not trusted)");
+    }
+    else {
+        return tr("Available to pair");
+    }
+}

--- a/app/gui/bluetoothdevicemodel.h
+++ b/app/gui/bluetoothdevicemodel.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "backend/bluetoothmanager.h"
+
+#include <QAbstractListModel>
+
+class BluetoothDeviceModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    enum Roles
+    {
+        PathRole = Qt::UserRole,
+        NameRole,
+        AddressRole,
+        PairedRole,
+        TrustedRole,
+        ConnectedRole,
+        BusyRole,
+        StatusTextRole
+    };
+
+public:
+    explicit BluetoothDeviceModel(QObject* parent = nullptr);
+
+    // Must be called before other functions
+    Q_INVOKABLE void initialize(BluetoothManager* manager);
+
+    QVariant data(const QModelIndex& index, int role) const override;
+
+    int rowCount(const QModelIndex& parent) const override;
+
+    QHash<int, QByteArray> roleNames() const override;
+
+private slots:
+    void handleDeviceAdded(int index);
+    void handleDeviceRemoved(int index);
+    void handleDeviceChanged(int index);
+    void handleDevicesReset();
+
+private:
+    QString statusTextForDevice(const BluetoothDevice& device) const;
+
+    QVector<BluetoothDevice> m_Devices;
+    BluetoothManager* m_Manager;
+};

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Window 2.2
 import QtQuick.Controls.Material 2.2
 
+import BluetoothManager 1.0
 import ComputerManager 1.0
 import AutoUpdateChecker 1.0
 import StreamingPreferences 1.0
@@ -419,6 +420,26 @@ ApplicationWindow {
                 Keys.onDownPressed: {
                     stackView.currentItem.forceActiveFocus(Qt.TabFocus)
                 }
+            }
+
+            NavigableToolButton {
+                id: bluetoothButton
+
+                // Hidden when BlueZ is unreachable
+                visible: BluetoothManager.available
+
+                iconSource: "qrc:/res/bluetooth.svg"
+
+                onClicked: navigateTo("qrc:/gui/BluetoothView.qml", BluetoothView)
+
+                Keys.onDownPressed: {
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                }
+
+                ToolTip.delay: 1000
+                ToolTip.timeout: 3000
+                ToolTip.visible: hovered
+                ToolTip.text: qsTr("Bluetooth devices")
             }
 
             NavigableToolButton {

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -425,7 +425,7 @@ ApplicationWindow {
             NavigableToolButton {
                 id: bluetoothButton
 
-                // Hidden when BlueZ is unreachable
+                // Embedded builds with reachable BlueZ
                 visible: BluetoothManager.available
 
                 iconSource: "qrc:/res/bluetooth.svg"

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -48,7 +48,9 @@
 #include "utils.h"
 #include "gui/computermodel.h"
 #include "gui/appmodel.h"
+#include "gui/bluetoothdevicemodel.h"
 #include "backend/autoupdatechecker.h"
+#include "backend/bluetoothmanager.h"
 #include "backend/computermanager.h"
 #include "backend/systemproperties.h"
 #include "streaming/session.h"
@@ -933,12 +935,18 @@ int main(int argc, char *argv[])
     // Register our C++ types for QML
     qmlRegisterType<ComputerModel>("ComputerModel", 1, 0, "ComputerModel");
     qmlRegisterType<AppModel>("AppModel", 1, 0, "AppModel");
+    qmlRegisterType<BluetoothDeviceModel>("BluetoothDeviceModel", 1, 0, "BluetoothDeviceModel");
     qmlRegisterUncreatableType<Session>("Session", 1, 0, "Session", "Session cannot be created from QML");
     qmlRegisterSingletonType<ComputerManager>("ComputerManager", 1, 0,
                                               "ComputerManager",
                                               [](QQmlEngine* qmlEngine, QJSEngine*) -> QObject* {
                                                   return new ComputerManager(StreamingPreferences::get(qmlEngine));
                                               });
+    qmlRegisterSingletonType<BluetoothManager>("BluetoothManager", 1, 0,
+                                               "BluetoothManager",
+                                               [](QQmlEngine*, QJSEngine*) -> QObject* {
+                                                   return new BluetoothManager();
+                                               });
     qmlRegisterSingletonType<AutoUpdateChecker>("AutoUpdateChecker", 1, 0,
                                                 "AutoUpdateChecker",
                                                 [](QQmlEngine*, QJSEngine*) -> QObject* {

--- a/app/qml.qrc
+++ b/app/qml.qrc
@@ -4,6 +4,7 @@
         <file>gui/PcView.qml</file>
         <file>gui/AppView.qml</file>
         <file>gui/SettingsView.qml</file>
+        <file>gui/BluetoothView.qml</file>
         <file>gui/StreamSegue.qml</file>
         <file>gui/GamepadMapper.qml</file>
         <file>gui/QuitSegue.qml</file>

--- a/app/res/bluetooth.svg
+++ b/app/res/bluetooth.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="white">
+    <path fill="none" d="M0 0h24v24H0V0z"/>
+    <path d="M17.71 7.71L12 2h-1v7.59L6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 11 14.41V22h1l5.71-5.71-4.3-4.29 4.3-4.29zM13 5.83l1.88 1.88L13 9.59V5.83zm1.88 10.46L13 18.17v-3.76l1.88 1.88z"/>
+</svg>

--- a/app/resources.qrc
+++ b/app/resources.qrc
@@ -18,6 +18,7 @@
         <file>res/baseline-error_outline-24px.svg</file>
         <file>res/baseline-check_circle_outline-24px.svg</file>
         <file>res/discord.svg</file>
+        <file>res/bluetooth.svg</file>
         <file>languages/qml_de.ts</file>
         <file>languages/qml_de.qm</file>
         <file>languages/qml_fr.ts</file>


### PR DESCRIPTION
- Introduced this for Devices directly running Moonlight on Startup
- Streaming Devices without Mouse & Keyboard input might need to scan for new Bluetooth devices

- Code written manually
- QML Files written with AI (since I have no clue how to do that)
- Refactored, sorted and debugged with AI
- Builds succeed
- Tested on Raspberry Pi Bookworm and Arch linux