### PR TITLE
[Quickfix] Report Valve (Steam) controllers as Xbox type to the host

### DIFF
--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -701,7 +701,14 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
             type = LI_CTYPE_NINTENDO;
             break;
         default:
-            type = LI_CTYPE_UNKNOWN;
+            // SDL has no gamepad type for Valve's Steam Controllers so tell the host it's an
+            // Xbox pad and let it emulate an X360/XInput device instead.
+            if (vendorId == 0x28de) {
+                type = LI_CTYPE_XBOX;
+            }
+            else {
+                type = LI_CTYPE_UNKNOWN;
+            }
             break;
         }
 


### PR DESCRIPTION
SDL has no gamepad type for Steam Controllers, so they arrived as LI_CTYPE_UNKNOWN with gyro/accel/touchpad capabilities and Sunshine's auto mode emulated a DualShock. Report LI_CTYPE_XBOX for vendor 0x28de so the host emulates an X360 pad matching the controller's layout.

Issue: #1980

The proper fix would be a dedicated Steam Controller type in moonlight-common-c so the host can emulate a Steam Controller