### PR TITLE
Add Git Hash/Build Date to nightly and manual

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -9,11 +9,16 @@ on:
       ci_version:
         required: true
         type: string
+      ci_build_date:
+        required: true
+        type: string
 
 jobs:
   build:
     env:
       CI_VERSION: ${{ inputs.ci_version }}
+      GIT_HASH: ${{ inputs.ci_version }}
+      BUILD_DATE: ${{ inputs.ci_build_date }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/build-steamlink.yml
+++ b/.github/workflows/build-steamlink.yml
@@ -9,11 +9,16 @@ on:
       ci_version:
         required: true
         type: string
+      ci_build_date:
+        required: true
+        type: string
 
 jobs:
   build:
     env:
       CI_VERSION: ${{ inputs.ci_version }}
+      GIT_HASH: ${{ inputs.ci_version }}
+      BUILD_DATE: ${{ inputs.ci_build_date }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/build-win-mac.yml
+++ b/.github/workflows/build-win-mac.yml
@@ -9,11 +9,16 @@ on:
       ci_version:
         required: true
         type: string
+      ci_build_date:
+        required: true
+        type: string
 
 jobs:
   build:
     env:
       CI_VERSION: ${{ inputs.ci_version }}
+      GIT_HASH: ${{ inputs.ci_version }}
+      BUILD_DATE: ${{ inputs.ci_build_date }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 concurrency:
   group: build-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,21 +25,26 @@ jobs:
         run: |
           CI_VERSION=`echo ${GITHUB_SHA} | cut -c1-6`
           echo "ci_version=${CI_VERSION}" >> "${GITHUB_OUTPUT}"
+          CI_BUILD_DATE=`date -u +%Y-%m-%d`
+          echo "ci_build_date=${CI_BUILD_DATE}" >> "${GITHUB_OUTPUT}"
 
   build-appimage:
     needs: setup
     uses: ./.github/workflows/build-appimage.yml
     with:
       ci_version: ${{ needs.setup.outputs.ci_version }}
+      ci_build_date: ${{ needs.setup.outputs.ci_build_date }}
 
   build-steamlink:
     needs: setup
     uses: ./.github/workflows/build-steamlink.yml
     with:
       ci_version: ${{ needs.setup.outputs.ci_version }}
+      ci_build_date: ${{ needs.setup.outputs.ci_build_date }}
 
   build-windows-macos:
     needs: setup
     uses: ./.github/workflows/build-win-mac.yml
     with:
       ci_version: ${{ needs.setup.outputs.ci_version }}
+      ci_build_date: ${{ needs.setup.outputs.ci_build_date }}

--- a/app/app.pro
+++ b/app/app.pro
@@ -580,3 +580,34 @@ macx {
 
 VERSION = "$$cat(version.txt)"
 DEFINES += VERSION_STR=\\\"$$cat(version.txt)\\\"
+
+GIT_HASH = $$(GIT_HASH)
+win32 {
+    isEmpty(GIT_HASH): GIT_HASH = $$system(git rev-parse --short=6 HEAD 2> NUL)
+} else {
+    isEmpty(GIT_HASH): GIT_HASH = $$system(git rev-parse --short=6 HEAD 2> /dev/null)
+}
+isEmpty(GIT_HASH) {
+    GIT_HASH = unknown
+}
+
+BUILD_DATE = $$(BUILD_DATE)
+win32 {
+    isEmpty(BUILD_DATE): BUILD_DATE = $$system(git log -1 --format=%cd --date=format:%Y-%m-%d 2> NUL)
+} else {
+    isEmpty(BUILD_DATE): BUILD_DATE = $$system(git log -1 --format=%cd --date=format:%Y-%m-%d 2> /dev/null)
+}
+isEmpty(BUILD_DATE) {
+    BUILD_DATE = unknown
+}
+
+DEFINES += GIT_HASH_STR=\\\"$$GIT_HASH\\\"
+DEFINES += BUILD_DATE_STR=\\\"$$BUILD_DATE\\\"
+
+!isEmpty(GIT_HASH):!equals(GIT_HASH, unknown) {
+    win32 {
+        !system(git diff-index --quiet HEAD -- 2> NUL): GIT_HASH = $${GIT_HASH}-dirty
+    } else {
+        !system(git diff-index --quiet HEAD -- 2> /dev/null): GIT_HASH = $${GIT_HASH}-dirty
+    }
+}

--- a/app/backend/systemproperties.cpp
+++ b/app/backend/systemproperties.cpp
@@ -47,6 +47,12 @@ private:
 SystemProperties::SystemProperties()
 {
     versionString = QString(VERSION_STR);
+    QString gitHash(GIT_HASH_STR);
+    QString buildDate(BUILD_DATE_STR);
+    if (gitHash != "unknown" || buildDate != "unknown") {
+        buildInfoString = QString("%1, %2").arg(gitHash, buildDate);
+    }
+    
     hasDesktopEnvironment = WMUtils::isRunningDesktopEnvironment();
     isRunningWayland = WMUtils::isRunningWayland();
     isRunningXWayland = isRunningWayland && QGuiApplication::platformName() == "xcb";

--- a/app/backend/systemproperties.h
+++ b/app/backend/systemproperties.h
@@ -26,6 +26,7 @@ public:
     Q_PROPERTY(bool hasDiscordIntegration MEMBER hasDiscordIntegration CONSTANT)
     Q_PROPERTY(bool usesMaterial3Theme MEMBER usesMaterial3Theme CONSTANT)
     Q_PROPERTY(QString versionString MEMBER versionString CONSTANT)
+    Q_PROPERTY(QString buildInfoString MEMBER buildInfoString CONSTANT)
 
     // Properties queried asynchronously (startAsyncLoad() must be called!)
     Q_PROPERTY(bool hasHardwareAcceleration MEMBER hasHardwareAcceleration NOTIFY hasHardwareAccelerationChanged)
@@ -66,6 +67,7 @@ private:
     bool hasBrowser;
     bool hasDiscordIntegration;
     QString versionString;
+    QString buildInfoString;
     bool usesMaterial3Theme;
     bool isDarwin;
 

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -288,7 +288,9 @@ ApplicationWindow {
             Label {
                 id: versionLabel
                 visible: stackView.currentItem instanceof SettingsView
-                text: qsTr("Version %1").arg(SystemProperties.versionString)
+                text: SystemProperties.buildInfoString.length > 0 ?
+                        qsTr("Version %1 (%2)").arg(SystemProperties.versionString).arg(SystemProperties.buildInfoString) :
+                        qsTr("Version %1").arg(SystemProperties.versionString)
                 font.pointSize: 12
                 horizontalAlignment: Qt.AlignRight
                 verticalAlignment: Qt.AlignVCenter


### PR DESCRIPTION
Fixes #1985

Adds Git Hash and Build Data to non-main builds, in GHA builds and manual builds.